### PR TITLE
Fixed error: missing snapshot_name in raw+ssh transfer

### DIFF
--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -852,7 +852,8 @@ def _do_process_transfer(
             )
 
         # Start receive process with potentially modified input stream
-        receive_process = destination_endpoint.receive(current_stdout)
+        receive_process = destination_endpoint.receive(
+            current_stdout, snapshot_name)
         if receive_process is None:
             logger.error("Failed to start receive process")
             if is_ssh_endpoint and not destination_endpoint.config.get(


### PR DESCRIPTION
When transferring to a `raw+ssh` target, the `snapshot_name` is not set. For a `RawEndpoint` it then defaults to an empty string, triggering an exception in the `RawEndpoint.receive()` method.

Not sure how this got in there. Not sure if this is a "correct" fix. It certainly eliminates the problem for me. Take it or leave it.