### PR TITLE
Make snapper backup work with SSH and raw targets (Closes #1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.3] - 2026-07-18
+
+### Fixed
+
+#### Snapper Backup to Remote and Raw Targets
+- **`snapper backup` now honors `ssh://`, `raw://`, and `raw+ssh://` destinations** instead of always writing locally; snapper backups are routed through the endpoint layer like regular backups
+- **Native snapper layout on remote btrfs targets** — each snapshot is received into `.snapshots/{num}/snapshot` alongside its `info.xml`; raw targets get a numbered stream plus a metadata sidecar
+
+#### SSH Transfers
+- **SSH config keys are preserved through endpoint construction** — a `ssh://user@host` username, `--ssh-sudo`, and `--ssh-key` are no longer dropped (the username previously fell back to `$SUDO_USER`)
+- **Transfer verification checks the exact received subvolume path** (`btrfs subvolume show`) instead of a filesystem-wide name search, which previously reported good snapper backups as failed and deleted them, and could otherwise match a sibling snapshot
+- **Endpoint construction no longer fails when `~/.ssh` does not exist** (fresh accounts, containers, CI) — the ControlMaster directory is created with its parents
+- **`timestamp_format` is now honored** for backup naming (was silently ignored)
+
+#### Other
+- Raw send streams are written to the target file rather than the current directory
+- Remote `raw+ssh` metadata sidecars are written correctly; snapper cleanup uses `btrfs subvolume delete` for read-only received subvolumes
+- Removed stray terminal output (info.xml/metadata `tee` echo) and a dead receive-log diagnostic that logged a spurious warning after every successful transfer
+
 ## [0.8.2] - 2026-01-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1880,7 +1880,18 @@ sudo btrfs-backup-ng snapper backup root /mnt/backup/root --dry-run
 # With compression and rate limiting
 sudo btrfs-backup-ng snapper backup root ssh://server:/backups \
     --compress zstd --rate-limit 50M
+
+# Raw stream to a non-btrfs destination (USB, NFS, SMB), local or over SSH
+sudo btrfs-backup-ng snapper backup root raw:///mnt/usb/backups/root --compress zstd
+sudo btrfs-backup-ng snapper backup root raw+ssh://backup@server/mnt/nas/root \
+    --compress zstd --ssh-sudo
 ```
+
+The `TARGET` accepts the same destination schemes as the regular `backup`
+command: a local path or `ssh://` for btrfs destinations, and `raw://` /
+`raw+ssh://` for non-btrfs destinations (see
+[Raw Targets](docs/CLI-REFERENCE.md#raw-targets) and
+[SSH Remote Backups](docs/CLI-REFERENCE.md#ssh-remote-backups) for setup).
 
 #### Restore Snapshots
 

--- a/completions/btrfs-backup-ng.bash
+++ b/completions/btrfs-backup-ng.bash
@@ -41,7 +41,7 @@ _btrfs_backup_ng() {
     local transfers_cleanup_opts="--force --all --age"
     local snapper_detect_opts="--json"
     local snapper_list_opts="--config --type --json"
-    local snapper_backup_opts="--snapshot --dry-run --ssh-sudo --ssh-key --compress --progress --no-progress"
+    local snapper_backup_opts="--snapshot --type --min-age --dry-run --ssh-sudo --ssh-key --compress --rate-limit --progress --no-progress"
     local snapper_status_opts="--json"
     local snapper_restore_opts="--snapshot --dry-run --ssh-sudo --ssh-key"
     local snapper_generate_config_opts="-o --output"

--- a/completions/btrfs-backup-ng.fish
+++ b/completions/btrfs-backup-ng.fish
@@ -326,7 +326,8 @@ complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_snapper_using_subcommand 
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_snapper_using_subcommand backup' -l rate-limit -d 'Bandwidth limit (e.g., 10M, 1G)' -x
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_snapper_using_subcommand backup' -l progress -d 'Show progress bars'
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_snapper_using_subcommand backup' -l no-progress -d 'Disable progress bars'
-complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_snapper_using_subcommand backup' -l types -d 'Filter by snapshot types (comma-separated)' -x
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_snapper_using_subcommand backup' -s t -l type -d 'Filter by snapshot type (single, pre, post; repeatable)' -xa 'single pre post'
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_snapper_using_subcommand backup' -s s -l snapshot -d 'Backup specific snapshot number only' -x
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_snapper_using_subcommand backup' -l min-age -d 'Only backup snapshots older than duration (e.g., 1h, 30m)' -x
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_snapper_using_subcommand backup' -l ssh-sudo -d 'Use sudo for btrfs commands on remote host'
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_snapper_using_subcommand backup' -l ssh-key -d 'SSH private key file' -r -F

--- a/completions/btrfs-backup-ng.zsh
+++ b/completions/btrfs-backup-ng.zsh
@@ -359,10 +359,13 @@ _btrfs-backup-ng() {
                                 backup)
                                     _arguments \
                                         '--snapshot[Backup specific snapshot number]:snapshot number:' \
+                                        '--type[Filter by snapshot type]:type:(${snapper_types})' \
+                                        '--min-age[Only snapshots older than duration]:duration:' \
                                         '--dry-run[Show what would be done]' \
                                         '--ssh-sudo[Use sudo on remote host]' \
                                         '--ssh-key[SSH private key file]:key file:_files' \
                                         '--compress[Compression method]:method:(${compress_methods})' \
+                                        '--rate-limit[Bandwidth limit]:rate:' \
                                         '(--progress --no-progress)'--progress'[Show progress bars]' \
                                         '(--progress --no-progress)'--no-progress'[Disable progress bars]' \
                                         '1:snapper config name:' \

--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -747,7 +747,7 @@ btrfs-backup-ng snapper backup CONFIG TARGET [OPTIONS]
 | Argument | Description |
 |----------|-------------|
 | `CONFIG` | Snapper configuration name (e.g., 'root', 'home') |
-| `TARGET` | Destination path (local or ssh://user@host:/path) |
+| `TARGET` | Destination: a local path or `ssh://user@host:/path` for btrfs destinations, or a raw target (`raw:///path`, `raw+ssh://user@host/path`) for non-btrfs destinations. See [Raw Targets](#raw-targets). |
 
 **Options:**
 | Option | Description |
@@ -776,6 +776,12 @@ btrfs-backup-ng snapper backup root /mnt/backup --type single --compress zstd
 
 # Backup snapshots older than 1 hour
 btrfs-backup-ng snapper backup root /mnt/backup --min-age 1h
+
+# Backup to a raw target on a non-btrfs destination (USB, NFS, SMB)
+btrfs-backup-ng snapper backup root raw:///mnt/usb/backups/root --compress zstd
+
+# Backup to a remote raw target over SSH
+btrfs-backup-ng snapper backup root raw+ssh://backup@server/mnt/nas/root --compress zstd
 
 # Dry run to see what would be backed up
 btrfs-backup-ng snapper backup root /mnt/backup --dry-run

--- a/docs/MIGRATING-FROM-BTRBK.md
+++ b/docs/MIGRATING-FROM-BTRBK.md
@@ -231,6 +231,11 @@ The importer automatically:
 - Converts SSH targets to `raw+ssh://` URLs
 - Preserves GPG recipient and keyring settings
 
+> **Note:** Raw targets are not limited to the regular `backup` command. The
+> `snapper backup` subcommand accepts the same `raw://` and `raw+ssh://`
+> destinations, so Snapper snapshots can be backed up to non-btrfs storage too.
+> See [Snapper Integration](SNAPPER-INTEGRATION.md#raw-non-btrfs-targets).
+
 #### Supported Compression Algorithms
 
 All btrbk compression algorithms are supported:

--- a/docs/SNAPPER-INTEGRATION.md
+++ b/docs/SNAPPER-INTEGRATION.md
@@ -68,12 +68,22 @@ Config: root (/)
 ### 3. Backup Snapshots
 
 ```bash
-# Local backup
+# Local backup (btrfs destination)
 btrfs-backup-ng snapper backup root /mnt/backup/root
 
-# Remote backup via SSH
+# Remote backup via SSH (btrfs destination)
 btrfs-backup-ng snapper backup root ssh://backup@server:/backups/root --ssh-sudo
+
+# Raw stream to a local non-btrfs destination (USB, NFS, SMB)
+btrfs-backup-ng snapper backup root raw:///mnt/usb/backups/root --compress zstd
+
+# Raw stream to a remote non-btrfs destination over SSH
+btrfs-backup-ng snapper backup root raw+ssh://backup@server/mnt/nas/root --compress zstd
 ```
+
+`snapper backup` accepts the same destination schemes as the regular `backup`
+command: a local path or `ssh://` for btrfs destinations, and `raw://` /
+`raw+ssh://` for non-btrfs destinations (see [Raw Targets](CLI-REFERENCE.md#raw-targets)).
 
 ### 4. Check Backup Status
 
@@ -318,6 +328,25 @@ When running with sudo locally, preserve SSH agent:
 ```bash
 sudo -E btrfs-backup-ng snapper backup root ssh://backup@server:/backups/root
 ```
+
+### Raw (Non-btrfs) Targets
+
+To back up snapper snapshots to a destination that is not btrfs (a USB drive,
+NFS/SMB share, or cloud-mounted storage), use a raw target. The snapshot is
+written as a `btrfs send` stream to a file, with optional compression, rather
+than received into a subvolume:
+
+```bash
+# Local raw target
+btrfs-backup-ng snapper backup root raw:///mnt/usb/backups/root --compress zstd
+
+# Remote raw target over SSH
+btrfs-backup-ng snapper backup root raw+ssh://backup@server/mnt/nas/root \
+    --compress zstd --ssh-sudo
+```
+
+Raw targets support the same compression and encryption options as regular
+backups; see [Raw Targets](CLI-REFERENCE.md#raw-targets) for the full list.
 
 ## Automated Backups
 

--- a/man/man1/btrfs-backup-ng-snapper.1
+++ b/man/man1/btrfs-backup-ng-snapper.1
@@ -77,8 +77,10 @@ Back up Snapper snapshots to a target location.
 Snapper configuration name (e.g., "root", "home").
 .TP
 .I TARGET
-Destination path. Can be local (e.g., /mnt/backup/root) or SSH
-(e.g., ssh://user@host:/backups/root).
+Destination path. For btrfs destinations, use a local path
+(e.g., /mnt/backup/root) or SSH (e.g., ssh://user@host:/backups/root).
+For non-btrfs destinations, use a raw target that writes a btrfs send
+stream to a file: raw:///path (local) or raw+ssh://user@host/path (remote).
 .PP
 Options:
 .TP

--- a/src/btrfs_backup_ng/cli/dispatcher.py
+++ b/src/btrfs_backup_ng/cli/dispatcher.py
@@ -1071,7 +1071,10 @@ Examples:
     snapper_backup.add_argument(
         "target",
         metavar="TARGET",
-        help="Backup target path (local path or ssh://user@host:/path)",
+        help=(
+            "Backup target: local path or ssh://user@host:/path (btrfs), "
+            "or raw:///path / raw+ssh://user@host/path (non-btrfs)"
+        ),
     )
     snapper_backup.add_argument(
         "-s",

--- a/src/btrfs_backup_ng/cli/run.py
+++ b/src/btrfs_backup_ng/cli/run.py
@@ -517,12 +517,17 @@ def _backup_snapper_volume(
                 "show_progress": show_progress,
             }
 
+            # Route the destination through the endpoint layer (local/ssh/raw)
+            destination_endpoint = endpoint.choose_endpoint(
+                target.path, {"path": target.path, "snap_prefix": ""}
+            )
+
             # Sync snapper snapshots to this target
             logger.info("Syncing snapper config '%s' to %s", config_name, target.path)
             transferred = sync_snapper_snapshots(
                 scanner,
                 config_name,
-                target.path,
+                destination_endpoint,
                 snapper_config=snapper_config,
                 options=options,
             )

--- a/src/btrfs_backup_ng/cli/run.py
+++ b/src/btrfs_backup_ng/cli/run.py
@@ -6,7 +6,7 @@ import os
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from .. import __util__, endpoint
 from ..__logger__ import add_file_handler, create_logger
@@ -521,9 +521,19 @@ def _backup_snapper_volume(
                 "show_progress": show_progress,
             }
 
-            # Route the destination through the endpoint layer (local/ssh/raw)
+            # Route the destination through the endpoint layer (local/ssh/raw),
+            # threading the target's SSH options so ssh:// / raw+ssh:// honor them.
+            snapper_endpoint_config: dict[str, Any] = {
+                "path": target.path,
+                "snap_prefix": "",
+            }
+            if target.ssh_sudo:
+                snapper_endpoint_config["ssh_sudo"] = True
+            if target.ssh_key:
+                snapper_endpoint_config["ssh_identity_file"] = target.ssh_key
+                snapper_endpoint_config["ssh_key"] = target.ssh_key
             destination_endpoint = endpoint.choose_endpoint(
-                target.path, {"path": target.path, "snap_prefix": ""}
+                target.path, snapper_endpoint_config
             )
 
             # Sync snapper snapshots to this target

--- a/src/btrfs_backup_ng/cli/run.py
+++ b/src/btrfs_backup_ng/cli/run.py
@@ -335,7 +335,9 @@ def _backup_volume(
     for target in volume.targets:
         try:
             # Check mount requirement for local targets
-            if target.require_mount and not target.path.startswith("ssh://"):
+            if target.require_mount and not target.path.startswith(
+                ("ssh://", "raw://", "raw+ssh://")
+            ):
                 target_path = Path(target.path).resolve()
                 if not __util__.is_mounted(target_path):  # type: ignore[attr-defined]
                     raise __util__.AbortError(
@@ -497,7 +499,9 @@ def _backup_snapper_volume(
     for target in volume.targets:
         try:
             # Check mount requirement for local targets
-            if target.require_mount and not target.path.startswith("ssh://"):
+            if target.require_mount and not target.path.startswith(
+                ("ssh://", "raw://", "raw+ssh://")
+            ):
                 target_path = Path(target.path).resolve()
                 if not __util__.is_mounted(target_path):  # type: ignore[attr-defined]
                     raise __util__.AbortError(
@@ -508,7 +512,7 @@ def _backup_snapper_volume(
             # Build transfer options
             # For local transfers, use no compression (Rich progress bar)
             # For remote transfers, use zstd compression
-            is_remote = target.path.startswith("ssh://")
+            is_remote = target.path.startswith(("ssh://", "raw+ssh://"))
             default_compress = "zstd" if is_remote else "none"
 
             options = {

--- a/src/btrfs_backup_ng/cli/snapper_cmd.py
+++ b/src/btrfs_backup_ng/cli/snapper_cmd.py
@@ -218,9 +218,15 @@ def _handle_backup(args: argparse.Namespace) -> int:
     # targets are parsed correctly instead of being treated as local paths.
     from ..endpoint import choose_endpoint
 
-    destination_endpoint = choose_endpoint(
-        target_path, {"path": target_path, "snap_prefix": ""}
-    )
+    endpoint_config: dict[str, Any] = {"path": target_path, "snap_prefix": ""}
+    # Thread SSH options so ssh:// (remote btrfs receive) and raw+ssh:// targets
+    # honor --ssh-sudo / --ssh-key.
+    if getattr(args, "ssh_sudo", False):
+        endpoint_config["ssh_sudo"] = True
+    if getattr(args, "ssh_key", None):
+        endpoint_config["ssh_identity_file"] = args.ssh_key
+        endpoint_config["ssh_key"] = args.ssh_key
+    destination_endpoint = choose_endpoint(target_path, endpoint_config)
 
     # Determine if this is a local or remote transfer
     is_remote = getattr(destination_endpoint, "_is_remote", False)

--- a/src/btrfs_backup_ng/cli/snapper_cmd.py
+++ b/src/btrfs_backup_ng/cli/snapper_cmd.py
@@ -210,12 +210,20 @@ def _handle_backup(args: argparse.Namespace) -> int:
         logger.error("Snapper config not found: %s", args.config)
         return 1
 
-    # Destination path - now just a path, not an endpoint
+    # Destination path
     # Backup layout: {target}/.snapshots/{num}/snapshot
     target_path = args.target
 
+    # Route the destination through the endpoint layer so ssh:// and raw
+    # targets are parsed correctly instead of being treated as local paths.
+    from ..endpoint import choose_endpoint
+
+    destination_endpoint = choose_endpoint(
+        target_path, {"path": target_path, "snap_prefix": ""}
+    )
+
     # Determine if this is a local or remote transfer
-    is_remote = target_path.startswith("ssh://")
+    is_remote = getattr(destination_endpoint, "_is_remote", False)
 
     # Build transfer options
     # For local transfers: no compression (Rich progress bar)
@@ -275,7 +283,10 @@ def _handle_backup(args: argparse.Namespace) -> int:
                                 break
 
             send_snapper_snapshot(
-                snapshot, target_path, parent_snapper_snapshot=parent, options=options
+                snapshot,
+                destination_endpoint,
+                parent_snapper_snapshot=parent,
+                options=options,
             )
             return 0
         except Exception as e:
@@ -306,7 +317,7 @@ def _handle_backup(args: argparse.Namespace) -> int:
         sync_snapper_snapshots(
             scanner,
             args.config,
-            target_path,
+            destination_endpoint,
             snapper_config=SnapperFilterConfig(),
             options=options,
         )

--- a/src/btrfs_backup_ng/cli/snapper_cmd.py
+++ b/src/btrfs_backup_ng/cli/snapper_cmd.py
@@ -252,35 +252,22 @@ def _handle_backup(args: argparse.Namespace) -> int:
             return 0
 
         try:
-            # Find a parent for incremental transfer
-            # Look for backed up snapshots that exist locally
-            parent = None
-            dest_snapshots_dir = Path(target_path) / ".snapshots"
-            if dest_snapshots_dir.exists():
-                # Get all local snapshots
-                all_snapshots = scanner.get_snapshots(config)
-                all_by_num = {s.number: s for s in all_snapshots}
+            # Find a parent for incremental transfer: the highest already-backed-up
+            # snapshot number below the target. Uses the endpoint layer so remote
+            # and raw destinations are handled the same as local ones.
+            from ..core.operations import _list_backed_up_snapper_numbers
 
-                # Find highest numbered backup that's lower than our target
-                for item in sorted(
-                    dest_snapshots_dir.iterdir(),
-                    key=lambda x: int(x.name) if x.name.isdigit() else 0,
-                    reverse=True,
-                ):
-                    if item.is_dir() and item.name.isdigit():
-                        backup_num = int(item.name)
-                        if (
-                            backup_num < snapshot.number
-                            and (item / "snapshot").exists()
-                        ):
-                            # Check if this snapshot still exists locally
-                            if backup_num in all_by_num:
-                                parent = all_by_num[backup_num]
-                                logger.debug(
-                                    "Found parent snapshot %d for incremental",
-                                    backup_num,
-                                )
-                                break
+            parent = None
+            backed_up = _list_backed_up_snapper_numbers(destination_endpoint)
+            if backed_up:
+                all_by_num = {s.number: s for s in scanner.get_snapshots(config)}
+                for backup_num in sorted(backed_up, reverse=True):
+                    if backup_num < snapshot.number and backup_num in all_by_num:
+                        parent = all_by_num[backup_num]
+                        logger.debug(
+                            "Found parent snapshot %d for incremental", backup_num
+                        )
+                        break
 
             send_snapper_snapshot(
                 snapshot,

--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -1239,7 +1239,7 @@ def get_snapper_snapshots_for_backup(
 
 def send_snapper_snapshot(
     snapper_snapshot,
-    destination_path: str,
+    destination_endpoint,
     parent_snapper_snapshot=None,
     options: dict | None = None,
 ) -> None:
@@ -1253,7 +1253,7 @@ def send_snapper_snapshot(
 
     Args:
         snapper_snapshot: SnapperSnapshot object to send
-        destination_path: Base path for backup (e.g., /backup/home)
+        destination_endpoint: Destination Endpoint (its config["path"] is the backup base)
         parent_snapper_snapshot: Optional parent for incremental transfer
         options: Transfer options (compress, show_progress, rate_limit)
 
@@ -1265,6 +1265,8 @@ def send_snapper_snapshot(
 
     if options is None:
         options = {}
+
+    destination_path = str(destination_endpoint.config["path"])
 
     snapshot_num = snapper_snapshot.number
     source_path = snapper_snapshot.subvolume_path
@@ -1694,7 +1696,7 @@ def _write_remote_metadata(endpoint, meta_path: Path, metadata) -> None:
 def sync_snapper_snapshots(
     scanner,
     config_name: str,
-    destination_path: str,
+    destination_endpoint,
     snapper_config=None,
     options: dict | None = None,
 ) -> int:
@@ -1711,7 +1713,7 @@ def sync_snapper_snapshots(
     Args:
         scanner: SnapperScanner instance
         config_name: Snapper config name
-        destination_path: Path to backup destination (e.g., /backup/home)
+        destination_endpoint: Destination Endpoint (its config["path"] is the backup base)
         snapper_config: Optional SnapperSourceConfig with filtering options
         options: Additional transfer options
 
@@ -1720,6 +1722,8 @@ def sync_snapper_snapshots(
     """
     if options is None:
         options = {}
+
+    destination_path = str(destination_endpoint.config["path"])
 
     logger.info(__util__.log_heading(f"Syncing snapper config '{config_name}'"))
 
@@ -1802,7 +1806,7 @@ def sync_snapper_snapshots(
             logger.info("[%d/%d] Snapshot %d", i, len(to_transfer), snap.number)
             send_snapper_snapshot(
                 snap,
-                destination_path,
+                destination_endpoint,
                 parent_snapper_snapshot=parent,
                 options=options,
             )

--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -770,10 +770,6 @@ def _do_direct_pipe_transfer(
 
     except Exception as e:
         logger.error("Error during SSH direct pipe transfer: %s", e)
-        if hasattr(destination_endpoint, "_last_receive_log"):
-            logger.error(
-                "Check remote log file: %s", destination_endpoint._last_receive_log
-            )
         raise __util__.SnapshotTransferError(f"SSH direct pipe transfer failed: {e}")
 
 

--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -1318,9 +1318,13 @@ def _place_info_xml(snapper_snapshot, destination_endpoint) -> None:
 
 
 def _cleanup_snapper_backup(destination_endpoint, snapshot_num, is_raw) -> None:
-    """Best-effort removal of a partial snapper backup after a failed transfer."""
+    """Best-effort removal of a partial snapper backup after a failed transfer.
+
+    A received btrfs subvolume is read-only and cannot be removed with ``rm``, so
+    the ``.snapshots/{num}/snapshot`` subvolume is deleted with
+    ``btrfs subvolume delete`` before the numbered directory is removed.
+    """
     import os
-    import shutil
 
     if is_raw:
         # Raw partial files are overwritten on the next attempt; nothing to undo.
@@ -1328,23 +1332,26 @@ def _cleanup_snapper_backup(destination_endpoint, snapshot_num, is_raw) -> None:
 
     base = str(destination_endpoint.config["path"]).rstrip("/")
     snap_dir = f"{base}/.snapshots/{snapshot_num}"
+    subvol = f"{snap_dir}/snapshot"
     is_remote = getattr(destination_endpoint, "_is_remote", False)
 
     try:
         if is_remote and hasattr(destination_endpoint, "_exec_remote_command"):
             destination_endpoint._exec_remote_command(
+                ["btrfs", "subvolume", "delete", subvol], check=False
+            )
+            destination_endpoint._exec_remote_command(
                 ["rm", "-rf", snap_dir], check=False
             )
         else:
-            snap_path = Path(snap_dir)
-            snap_subvol = snap_path / "snapshot"
-            if snap_subvol.exists():
-                if os.geteuid() != 0:
-                    subprocess.run(
-                        ["sudo", "rm", "-rf", str(snap_path)], capture_output=True
-                    )
-                else:
-                    shutil.rmtree(snap_path, ignore_errors=True)
+            sudo = [] if os.geteuid() == 0 else ["sudo"]
+            if Path(subvol).exists():
+                subprocess.run(
+                    [*sudo, "btrfs", "subvolume", "delete", subvol],
+                    capture_output=True,
+                )
+            if Path(snap_dir).exists():
+                subprocess.run([*sudo, "rm", "-rf", snap_dir], capture_output=True)
     except Exception as cleanup_e:
         logger.warning("Cleanup failed: %s", cleanup_e)
 

--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -1237,61 +1237,156 @@ def get_snapper_snapshots_for_backup(
     return snapshots
 
 
+def _list_backed_up_snapper_numbers(destination_endpoint) -> set[int]:
+    """Return snapper snapshot numbers already present at the destination.
+
+    btrfs targets: numbered subdirs under ``{base}/.snapshots`` that contain a
+    ``snapshot`` subvolume. Raw targets have no numbered layout, so this returns
+    an empty set (the caller re-sends; raw skip-detection is a follow-up).
+    """
+    from ..endpoint.raw import RawEndpoint
+
+    if isinstance(destination_endpoint, RawEndpoint):
+        return set()
+
+    numbers: set[int] = set()
+    base = str(destination_endpoint.config["path"]).rstrip("/")
+    snap_dir = f"{base}/.snapshots"
+    is_remote = getattr(destination_endpoint, "_is_remote", False)
+
+    if is_remote and hasattr(destination_endpoint, "_exec_remote_command"):
+        try:
+            result = destination_endpoint._exec_remote_command(
+                ["ls", "-1", snap_dir], check=False
+            )
+            if result.returncode == 0:
+                for name in result.stdout.decode().split():
+                    if name.isdigit():
+                        numbers.add(int(name))
+        except Exception as e:
+            logger.debug("Could not list remote snapper backups: %s", e)
+    else:
+        snap_path = Path(snap_dir)
+        if snap_path.exists():
+            for item in snap_path.iterdir():
+                if (
+                    item.is_dir()
+                    and item.name.isdigit()
+                    and (item / "snapshot").exists()
+                ):
+                    numbers.add(int(item.name))
+
+    return numbers
+
+
+def _place_info_xml(snapper_snapshot, destination_endpoint) -> None:
+    """Copy the snapper info.xml into the current destination directory.
+
+    ``destination_endpoint.config["path"]`` is the ``.snapshots/{num}`` directory
+    at call time (btrfs targets only; raw folds info.xml into the metadata sidecar).
+    """
+    import os
+    import shutil
+
+    info_xml_src = snapper_snapshot.info_xml_path
+    if not info_xml_src.exists():
+        return
+
+    dest_dir = str(destination_endpoint.config["path"])
+    is_remote = getattr(destination_endpoint, "_is_remote", False)
+
+    try:
+        if is_remote and hasattr(destination_endpoint, "_exec_remote_command"):
+            destination_endpoint._exec_remote_command(
+                ["tee", f"{dest_dir}/info.xml"],
+                input=info_xml_src.read_bytes(),
+                check=True,
+            )
+        else:
+            dst = Path(dest_dir) / "info.xml"
+            if os.geteuid() != 0:
+                subprocess.run(
+                    ["sudo", "cp", str(info_xml_src), str(dst)],
+                    check=True,
+                    capture_output=True,
+                )
+            else:
+                shutil.copy2(info_xml_src, dst)
+        logger.debug("Placed info.xml at %s", dest_dir)
+    except Exception as e:
+        logger.warning("Failed to place info.xml: %s", e)
+
+
+def _cleanup_snapper_backup(destination_endpoint, snapshot_num, is_raw) -> None:
+    """Best-effort removal of a partial snapper backup after a failed transfer."""
+    import os
+    import shutil
+
+    if is_raw:
+        # Raw partial files are overwritten on the next attempt; nothing to undo.
+        return
+
+    base = str(destination_endpoint.config["path"]).rstrip("/")
+    snap_dir = f"{base}/.snapshots/{snapshot_num}"
+    is_remote = getattr(destination_endpoint, "_is_remote", False)
+
+    try:
+        if is_remote and hasattr(destination_endpoint, "_exec_remote_command"):
+            destination_endpoint._exec_remote_command(
+                ["rm", "-rf", snap_dir], check=False
+            )
+        else:
+            snap_path = Path(snap_dir)
+            snap_subvol = snap_path / "snapshot"
+            if snap_subvol.exists():
+                if os.geteuid() != 0:
+                    subprocess.run(
+                        ["sudo", "rm", "-rf", str(snap_path)], capture_output=True
+                    )
+                else:
+                    shutil.rmtree(snap_path, ignore_errors=True)
+    except Exception as cleanup_e:
+        logger.warning("Cleanup failed: %s", cleanup_e)
+
+
 def send_snapper_snapshot(
     snapper_snapshot,
     destination_endpoint,
     parent_snapper_snapshot=None,
     options: dict | None = None,
 ) -> None:
-    """Send a snapper snapshot to destination, mirroring snapper directory layout.
+    """Send a snapper snapshot to a destination endpoint.
 
-    Creates the same directory structure as snapper on the backup:
-        {destination}/.snapshots/{num}/snapshot
-        {destination}/.snapshots/{num}/info.xml
-
-    Uses the same Rich progress bar as regular btrfs-backup-ng transfers.
+    btrfs targets receive into ``{base}/.snapshots/{num}`` so the sent
+    ``snapshot`` subvolume lands as ``.snapshots/{num}/snapshot`` alongside an
+    ``info.xml``, matching snapper's on-disk layout. Raw targets write a single
+    stream file named by the backup name. Both route through the standard
+    ``send_snapshot`` pipeline, so ssh:// and raw+ssh:// work transparently.
 
     Args:
         snapper_snapshot: SnapperSnapshot object to send
-        destination_endpoint: Destination Endpoint (its config["path"] is the backup base)
+        destination_endpoint: Destination Endpoint (its config["path"] is the base)
         parent_snapper_snapshot: Optional parent for incremental transfer
         options: Transfer options (compress, show_progress, rate_limit)
 
     Raises:
         SnapshotTransferError: If transfer fails
     """
-    import os
-    import shutil
+    from ..endpoint.raw import RawEndpoint
 
     if options is None:
         options = {}
 
-    destination_path = str(destination_endpoint.config["path"])
-
     snapshot_num = snapper_snapshot.number
-    source_path = snapper_snapshot.subvolume_path
+    is_raw = isinstance(destination_endpoint, RawEndpoint)
+    base_path = str(destination_endpoint.config["path"])
 
-    # Set defaults for snapper transfers
-    compress = options.get("compress", "none")  # No compression for local transfers
-    show_progress = options.get("show_progress", True)
-    rate_limit = options.get("rate_limit")
-
-    # Create destination directory structure: .snapshots/{num}/
-    dest_base = Path(destination_path)
-    dest_snapshot_dir = dest_base / ".snapshots" / str(snapshot_num)
-    dest_snapshot_path = dest_snapshot_dir / "snapshot"
-
-    # Check if already backed up
-    if dest_snapshot_path.exists():
+    # Skip if this snapshot number is already present at the destination.
+    if snapshot_num in _list_backed_up_snapper_numbers(destination_endpoint):
         logger.info("Snapshot %d already exists at destination, skipping", snapshot_num)
         return
 
-    # Log transfer start
     parent_num = parent_snapper_snapshot.number if parent_snapper_snapshot else None
-    parent_path = (
-        parent_snapper_snapshot.subvolume_path if parent_snapper_snapshot else None
-    )
-
     if parent_snapper_snapshot:
         logger.info(
             "Sending snapshot %d (incremental from %d) ...", snapshot_num, parent_num
@@ -1300,192 +1395,68 @@ def send_snapper_snapshot(
         logger.info("Sending snapshot %d (full) ...", snapshot_num)
 
     transfer_start = time.monotonic()
-
-    # Log transaction
     log_transaction(
         action="snapper_backup",
         status="started",
-        source=str(source_path),
-        destination=str(dest_snapshot_path),
+        source=str(snapper_snapshot.subvolume_path),
+        destination=base_path,
         snapshot=str(snapshot_num),
         parent=str(parent_num) if parent_num else None,
     )
 
+    # Wrap the snapper snapshots so the standard send/receive pipeline can carry
+    # them (the wrapper's source is a LocalEndpoint on the snapper subvolume).
+    source_wrapper = _create_snapper_snapshot_wrapper(snapper_snapshot)
+    parent_wrapper = (
+        _create_snapper_snapshot_wrapper(parent_snapper_snapshot)
+        if parent_snapper_snapshot
+        else None
+    )
+
     try:
-        # Create destination directory
-        if os.geteuid() != 0:
-            subprocess.run(
-                ["sudo", "mkdir", "-p", str(dest_snapshot_dir)],
-                check=True,
-                capture_output=True,
+        if is_raw:
+            # Raw targets have no subvolumes: write one stream file named by the
+            # backup name. Compression/encryption are intrinsic to the raw
+            # endpoint, so avoid double-compressing in the pipeline.
+            raw_options = dict(options)
+            raw_options["compress"] = "none"
+            send_snapshot(
+                source_wrapper,
+                destination_endpoint,
+                parent=parent_wrapper,
+                options=raw_options,
             )
         else:
-            dest_snapshot_dir.mkdir(parents=True, exist_ok=True)
-
-        # Build btrfs send command
-        send_cmd = ["btrfs", "send"]
-        if parent_path:
-            send_cmd.extend(["-p", str(parent_path)])
-        send_cmd.append(str(source_path))
-
-        # Build btrfs receive command
-        receive_cmd = ["btrfs", "receive", str(dest_snapshot_dir)]
-
-        # Add sudo if needed
-        if os.geteuid() != 0:
-            send_cmd = ["sudo"] + send_cmd
-            receive_cmd = ["sudo"] + receive_cmd
-
-        logger.debug("Send command: %s", " ".join(send_cmd))
-        logger.debug("Receive command: %s", " ".join(receive_cmd))
-
-        # Estimate size for progress bar (only for full transfers)
-        estimated_size = None
-        if show_progress and not parent_path:
-            estimated_size = progress_utils.estimate_snapshot_size(
-                str(source_path), str(parent_path) if parent_path else None
-            )
-            if estimated_size:
-                logger.debug(
-                    "Estimated transfer size: %.2f MB", estimated_size / (1024 * 1024)
-                )
-
-        # Start send process
-        send_process = subprocess.Popen(
-            send_cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-
-        # Determine if we can use Rich progress
-        # Use Rich progress for full transfers without compression
-        use_rich_progress = (
-            show_progress
-            and progress_utils.is_interactive()
-            and (compress == "none" or not compress)
-            and not rate_limit
-        )
-
-        if use_rich_progress:
-            # Start receive with stdin=PIPE for Rich progress
-            receive_process = subprocess.Popen(
-                receive_cmd,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )
-
-            # Run transfer with Rich progress bar
-            send_rc, receive_rc = progress_utils.run_transfer_with_progress(
-                send_process=send_process,
-                receive_process=receive_process,
-                snapshot_name=f"snapshot {snapshot_num}",
-                estimated_size=estimated_size,
-            )
-
-            if send_rc != 0:
-                raise __util__.SnapshotTransferError(
-                    f"btrfs send failed with code {send_rc}"
-                )
-            if receive_rc != 0:
-                raise __util__.SnapshotTransferError(
-                    f"btrfs receive failed with code {receive_rc}"
-                )
-        else:
-            # Fall back to pipeline transfer (with compression/rate limiting)
-            pipeline_processes = []
-            current_stdout = send_process.stdout
-
+            # btrfs targets: temporarily point the same endpoint (reusing its SSH
+            # connection) at .snapshots/{num} so receive lands
+            # .snapshots/{num}/snapshot, then place info.xml beside it.
+            snap_path = f"{base_path.rstrip('/')}/.snapshots/{snapshot_num}"
+            saved_path = destination_endpoint.config["path"]
+            destination_endpoint.config["path"] = snap_path
             try:
-                # Build transfer pipeline (compression + progress)
-                if compress != "none" or rate_limit or show_progress:
-                    current_stdout, pipeline_processes = (
-                        transfer_utils.build_transfer_pipeline(
-                            send_stdout=send_process.stdout,
-                            compress=compress,
-                            rate_limit=rate_limit,
-                            show_progress=show_progress,
-                        )
-                    )
-
-                # Build receive-side decompression if needed
-                if compress and compress != "none":
-                    current_stdout, decompress_processes = (
-                        transfer_utils.build_receive_pipeline(
-                            input_stdout=current_stdout,
-                            compress=compress,
-                        )
-                    )
-                    pipeline_processes.extend(decompress_processes)
-
-                # Start receive process
-                receive_process = subprocess.Popen(
-                    receive_cmd,
-                    stdin=current_stdout,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
+                send_snapshot(
+                    source_wrapper,
+                    destination_endpoint,
+                    parent=parent_wrapper,
+                    options=options,
                 )
+                _place_info_xml(snapper_snapshot, destination_endpoint)
+            finally:
+                destination_endpoint.config["path"] = saved_path
 
-                # Close our reference to send stdout
-                if send_process.stdout:
-                    send_process.stdout.close()
-
-                # Wait for completion
-                receive_stdout, receive_stderr = receive_process.communicate()
-                send_process.wait()
-
-                # Wait for pipeline
-                pipeline_return_codes = transfer_utils.wait_for_pipeline(
-                    pipeline_processes, timeout=3600
-                )
-
-                # Check for errors
-                if send_process.returncode != 0:
-                    raise __util__.SnapshotTransferError(
-                        f"btrfs send failed with code {send_process.returncode}"
-                    )
-
-                if receive_process.returncode != 0:
-                    raise __util__.SnapshotTransferError(
-                        f"btrfs receive failed: {receive_stderr.decode().strip()}"
-                    )
-
-                for rc in pipeline_return_codes:
-                    if rc != 0:
-                        raise __util__.SnapshotTransferError(
-                            f"Transfer pipeline failed with code {rc}"
-                        )
-
-            except Exception:
-                transfer_utils.cleanup_pipeline(pipeline_processes)
-                raise
-
-        # Copy info.xml to destination
-        info_xml_src = snapper_snapshot.info_xml_path
-        info_xml_dst = dest_snapshot_dir / "info.xml"
-        if info_xml_src.exists():
-            if os.geteuid() != 0:
-                subprocess.run(
-                    ["sudo", "cp", str(info_xml_src), str(info_xml_dst)],
-                    check=True,
-                    capture_output=True,
-                )
-            else:
-                shutil.copy2(info_xml_src, info_xml_dst)
-            logger.debug("Copied info.xml to %s", info_xml_dst)
+        # Metadata sidecar (endpoint-aware; carries original_xml for restore).
+        _write_snapper_metadata(snapper_snapshot, destination_endpoint)
 
         duration = time.monotonic() - transfer_start
-
         log_transaction(
             action="snapper_backup",
             status="completed",
-            source=str(source_path),
-            destination=str(dest_snapshot_path),
+            source=str(snapper_snapshot.subvolume_path),
+            destination=base_path,
             snapshot=str(snapshot_num),
             parent=str(parent_num) if parent_num else None,
             duration_seconds=duration,
         )
-
         logger.info(
             "Snapshot %d transferred successfully (%.1fs)", snapshot_num, duration
         )
@@ -1495,66 +1466,14 @@ def send_snapper_snapshot(
         log_transaction(
             action="snapper_backup",
             status="failed",
-            source=str(source_path),
-            destination=str(dest_snapshot_path),
+            source=str(snapper_snapshot.subvolume_path),
+            destination=base_path,
             snapshot=str(snapshot_num),
             parent=str(parent_num) if parent_num else None,
             duration_seconds=duration,
             error=str(e),
         )
-        # Clean up partial transfer
-        try:
-            if dest_snapshot_path.exists():
-                # Received snapshots are read-only, make writable before delete
-                if os.geteuid() != 0:
-                    subprocess.run(
-                        [
-                            "sudo",
-                            "btrfs",
-                            "property",
-                            "set",
-                            "-f",
-                            str(dest_snapshot_path),
-                            "ro",
-                            "false",
-                        ],
-                        capture_output=True,
-                    )
-                    subprocess.run(
-                        [
-                            "sudo",
-                            "btrfs",
-                            "subvolume",
-                            "delete",
-                            str(dest_snapshot_path),
-                        ],
-                        capture_output=True,
-                    )
-                else:
-                    subprocess.run(
-                        [
-                            "btrfs",
-                            "property",
-                            "set",
-                            "-f",
-                            str(dest_snapshot_path),
-                            "ro",
-                            "false",
-                        ],
-                        capture_output=True,
-                    )
-                    __util__.delete_subvolume(dest_snapshot_path)  # type: ignore[attr-defined]
-            if dest_snapshot_dir.exists():
-                if os.geteuid() != 0:
-                    subprocess.run(
-                        ["sudo", "rm", "-rf", str(dest_snapshot_dir)],
-                        capture_output=True,
-                    )
-                else:
-                    shutil.rmtree(dest_snapshot_dir)
-        except Exception as cleanup_e:
-            logger.warning("Cleanup failed: %s", cleanup_e)
-
+        _cleanup_snapper_backup(destination_endpoint, snapshot_num, is_raw)
         logger.error("Failed to transfer snapshot %d: %s", snapshot_num, e)
         raise __util__.SnapshotTransferError(
             f"Failed to transfer snapshot {snapshot_num}: {e}"
@@ -1723,8 +1642,6 @@ def sync_snapper_snapshots(
     if options is None:
         options = {}
 
-    destination_path = str(destination_endpoint.config["path"])
-
     logger.info(__util__.log_heading(f"Syncing snapper config '{config_name}'"))
 
     # Get filtering options from snapper_config or use defaults
@@ -1752,17 +1669,8 @@ def sync_snapper_snapshots(
 
     logger.info("Found %d snapper snapshot(s) to consider", len(snapper_snapshots))
 
-    # Get existing backup snapshot numbers at destination
-    dest_base = Path(destination_path)
-    dest_snapshots_dir = dest_base / ".snapshots"
-    backed_up_numbers = set()
-
-    if dest_snapshots_dir.exists():
-        for item in dest_snapshots_dir.iterdir():
-            if item.is_dir() and item.name.isdigit():
-                snapshot_path = item / "snapshot"
-                if snapshot_path.exists():
-                    backed_up_numbers.add(int(item.name))
+    # Get existing backup snapshot numbers at destination (endpoint-aware)
+    backed_up_numbers = _list_backed_up_snapper_numbers(destination_endpoint)
 
     logger.debug("Already backed up: %s", sorted(backed_up_numbers))
 

--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -1301,6 +1301,7 @@ def _place_info_xml(snapper_snapshot, destination_endpoint) -> None:
                 ["tee", f"{dest_dir}/info.xml"],
                 input=info_xml_src.read_bytes(),
                 check=True,
+                stdout=subprocess.DEVNULL,
             )
         else:
             dst = Path(dest_dir) / "info.xml"
@@ -1611,6 +1612,7 @@ def _write_remote_metadata(endpoint, meta_path: Path, metadata) -> None:
                 cmd,
                 input=json_content.encode("utf-8"),
                 check=True,
+                stdout=subprocess.DEVNULL,
             )
             logger.debug("Wrote remote snapper metadata to %s", meta_path)
         except Exception as e:

--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -639,13 +639,19 @@ class SSHRawEndpoint(RawEndpoint):
         return cmd
 
     def _exec_remote_command(
-        self, command: list[str], input: bytes | None = None, check: bool = True
+        self,
+        command: list[str],
+        input: bytes | None = None,
+        check: bool = True,
+        **kwargs: Any,
     ) -> subprocess.CompletedProcess:
         """Run a command on the remote host over SSH.
 
         Provides the same interface the snapper helpers use on SSHEndpoint
         (metadata sidecar writes, directory listing, cleanup): accepts a command
         as a list plus optional stdin bytes, and returns the CompletedProcess.
+        Output is captured by default; callers may override stdout/stderr (e.g.
+        ``stdout=subprocess.DEVNULL`` to discard a ``tee`` echo).
         """
         import shlex
 
@@ -653,7 +659,9 @@ class SSHRawEndpoint(RawEndpoint):
         if self.ssh_sudo:
             remote = f"sudo {remote}"
         full_cmd = self._build_ssh_command() + [remote]
-        return subprocess.run(full_cmd, input=input, capture_output=True, check=check)
+        if "stdout" not in kwargs and "stderr" not in kwargs:
+            kwargs["capture_output"] = True
+        return subprocess.run(full_cmd, input=input, check=check, **kwargs)
 
     def _prepare(self) -> None:
         """Prepare the endpoint by creating the remote directory."""

--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -214,11 +214,10 @@ class RawEndpoint(Endpoint):
 
         logger.info("Writing raw stream to: %s", output_path)
 
-        # Build and execute the pipeline
-        pipeline = self._build_receive_pipeline(output_path)
-        proc = self._execute_pipeline(pipeline, stdin_pipe)
-
-        # Store metadata for later (will be saved after transfer completes)
+        # Record metadata BEFORE executing: _execute_pipeline reads
+        # _pending_metadata["stream_path"] to know where to write. Setting it
+        # afterwards left the default Path() ('.') in place, so the pipeline
+        # tried to open the current directory as the output file.
         self._pending_metadata = {
             "name": snapshot_name,
             "stream_path": output_path,
@@ -227,6 +226,10 @@ class RawEndpoint(Endpoint):
             "encrypt": self.encrypt,
             "gpg_recipient": self.gpg_recipient,
         }
+
+        # Build and execute the pipeline
+        pipeline = self._build_receive_pipeline(output_path)
+        proc = self._execute_pipeline(pipeline, stdin_pipe)
 
         return proc
 

--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -635,6 +635,23 @@ class SSHRawEndpoint(RawEndpoint):
 
         return cmd
 
+    def _exec_remote_command(
+        self, command: list[str], input: bytes | None = None, check: bool = True
+    ) -> subprocess.CompletedProcess:
+        """Run a command on the remote host over SSH.
+
+        Provides the same interface the snapper helpers use on SSHEndpoint
+        (metadata sidecar writes, directory listing, cleanup): accepts a command
+        as a list plus optional stdin bytes, and returns the CompletedProcess.
+        """
+        import shlex
+
+        remote = " ".join(shlex.quote(str(c)) for c in command)
+        if self.ssh_sudo:
+            remote = f"sudo {remote}"
+        full_cmd = self._build_ssh_command() + [remote]
+        return subprocess.run(full_cmd, input=input, capture_output=True, check=check)
+
     def _prepare(self) -> None:
         """Prepare the endpoint by creating the remote directory."""
         path = self.config["path"]

--- a/src/btrfs_backup_ng/endpoint/ssh.py
+++ b/src/btrfs_backup_ng/endpoint/ssh.py
@@ -210,6 +210,25 @@ class SSHEndpoint(Endpoint):
         # Call parent init with both config and kwargs
         super().__init__(config=self.config, **kwargs)
 
+        # The base Endpoint.__init__ rebuilds self.config from a fixed key
+        # whitelist, which drops SSH-specific keys. Restore them from the
+        # passed-in config so ssh://user@host URLs and --ssh-sudo / --ssh-key
+        # are honored; otherwise the username falls back to SUDO_USER/current
+        # user and ssh_sudo / identity file are silently lost.
+        for _ssh_key in (
+            "username",
+            "port",
+            "ssh_opts",
+            "agent_forwarding",
+            "ssh_sudo",
+            "passwordless",
+            "ssh_identity_file",
+            "ssh_key",
+            "ssh_password_fallback",
+        ):
+            if config.get(_ssh_key) is not None:
+                self.config[_ssh_key] = config[_ssh_key]
+
         self.hostname = hostname
         logger.debug("SSHEndpoint initialized with hostname: %s", self.hostname)
         logger.debug("SSHEndpoint: kwargs provided: %s", list(kwargs.keys()))

--- a/src/btrfs_backup_ng/endpoint/ssh.py
+++ b/src/btrfs_backup_ng/endpoint/ssh.py
@@ -2007,217 +2007,63 @@ print(json.dumps(result))
         return snapshots
 
     def _verify_snapshot_exists(self, dest_path: str, snapshot_name: str) -> bool:
-        """Verify a snapshot exists on the remote host.
+        """Verify a snapshot exists on the remote host at its exact path.
+
+        The received subvolume must exist at exactly ``{dest_path}/{snapshot_name}``.
+        Verification is deliberately scoped to that precise path rather than
+        searching the destination filesystem for a subvolume of the given name:
+        snapper snapshots are all named ``snapshot`` (the source subvolume's
+        basename), so a name-only search would match a same-named subvolume
+        elsewhere on the destination (e.g. a sibling ``.snapshots/<other>/snapshot``)
+        and report success for a transfer that actually failed. An exact-path check
+        is correct for native backups (whose names are unique anyway) and safe for
+        snapper.
 
         Args:
-            dest_path: Remote destination path
-            snapshot_name: Name of the snapshot to verify
+            dest_path: Remote directory the snapshot was received into
+            snapshot_name: Name of the received subvolume within dest_path
 
         Returns:
-            True if the snapshot exists, False otherwise
+            True if a subvolume/directory exists at the exact expected path.
         """
-        logger.debug(
-            f"Starting snapshot verification for '{snapshot_name}' in '{dest_path}'"
-        )
-        logger.debug(f"SSH sudo enabled: {self.config.get('ssh_sudo', False)}")
+        expected_path = f"{dest_path.rstrip('/')}/{snapshot_name}"
+        logger.debug(f"Verifying received snapshot at exact path: {expected_path}")
+        use_sudo = self.config.get("ssh_sudo", False)
 
-        # Try direct subvolume list first
-        # Don't call _build_remote_command here - _exec_remote_command does it internally
-        list_cmd = ["btrfs", "subvolume", "list", "-o", dest_path]
-
-        logger.debug(f"Verifying snapshot existence with command: {list_cmd}")
+        def _run(cmd: List[str]) -> Any:
+            # _exec_remote_command* wrap the command for SSH (and sudo) internally.
+            if use_sudo:
+                return self._exec_remote_command_with_retry(
+                    cmd,
+                    max_retries=2,
+                    check=False,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+            return self._exec_remote_command(
+                cmd,
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
 
         try:
-            logger.debug("Executing subvolume list command...")
-
-            # Use retry mechanism for commands that may require authentication
-            use_sudo = self.config.get("ssh_sudo", False)
-            if use_sudo:
-                list_result = self._exec_remote_command_with_retry(
-                    list_cmd,
-                    max_retries=2,
-                    check=False,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                )
-            else:
-                list_result = self._exec_remote_command(
-                    list_cmd,
-                    check=False,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                )
-
-            logger.debug(f"Subvolume list command exit code: {list_result.returncode}")
-            if list_result.stdout:
-                stdout_content = list_result.stdout.decode(errors="replace")
-                logger.debug(f"Subvolume list output:\n{stdout_content}")
-            if list_result.stderr:
-                stderr_content = list_result.stderr.decode(errors="replace")
-                logger.debug(f"Subvolume list stderr:\n{stderr_content}")
-            if list_result.returncode != 0:
-                stderr_text = (
-                    list_result.stderr.decode(errors="replace")
-                    if list_result.stderr
-                    else ""
-                )
-                logger.warning(
-                    f"Failed to list subvolumes (exit code {list_result.returncode}): {stderr_text}"
-                )
-                logger.debug("Falling back to simple path check")
-
-                # Fall back to simple path check
-                check_cmd = [
-                    "test",
-                    "-d",
-                    f"{dest_path}/{snapshot_name}",
-                    "&&",
-                    "echo",
-                    "EXISTS",
-                ]
-                # Apply proper authentication handling to the fallback command too
-                check_cmd = self._build_remote_command(check_cmd)
-                logger.debug(f"Fallback verification command: {' '.join(check_cmd)}")
-
-                # Check if we need to provide password input for sudo
-                fallback_input = None
-                if "sudo" in check_cmd and "-S" in check_cmd:
-                    sudo_password = self._get_sudo_password()
-                    if sudo_password:
-                        fallback_input = sudo_password.encode() + b"\n"
-                        logger.debug(
-                            "Providing sudo password for fallback verification command"
-                        )
-
-                # Use retry mechanism for fallback verification commands with authentication
-                check_result = self._exec_remote_command_with_retry(
-                    check_cmd,
-                    max_retries=2,
-                    check=False,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    input=fallback_input,
-                )
-
-                logger.debug(f"Path check exit code: {check_result.returncode}")
-                if check_result.stdout and b"EXISTS" in check_result.stdout:
-                    logger.debug(
-                        f"Snapshot exists at path: {dest_path}/{snapshot_name}"
-                    )
-                    logger.debug("Path-based verification successful")
-                    return True
-                else:
-                    logger.error(
-                        f"Snapshot not found at path: {dest_path}/{snapshot_name}"
-                    )
-                    logger.debug(
-                        f"Path check stdout: {check_result.stdout.decode() if check_result.stdout else 'None'}"
-                    )
-                    logger.debug(
-                        f"Path check stderr: {check_result.stderr.decode() if check_result.stderr else 'None'}"
-                    )
-                    return False
-
-            # Check if the snapshot appears in the subvolume list
-            stdout_text = (
-                list_result.stdout.decode(errors="replace")
-                if list_result.stdout
-                else ""
-            )
-            logger.debug(f"Subvolume list output length: {len(stdout_text)} characters")
-            logger.debug(
-                f"Searching for snapshot '{snapshot_name}' at path '{dest_path}'"
-            )
-
-            # Look for the snapshot in the subvolume list output
-            # The output format is typically: "ID xxx gen xxx top level xxx path <path>"
-            # We need to check if our snapshot path appears in any of these lines
-            snapshot_found = False
-            expected_path = f"{dest_path.rstrip('/')}/{snapshot_name}"
-
-            if stdout_text:
-                lines = stdout_text.splitlines()
-                logger.debug(f"Subvolume list has {len(lines)} lines:")
-                for i, line in enumerate(lines):
-                    if i < 10:  # Log first 10 lines for debugging
-                        logger.debug(f"  Line {i + 1}: {line}")
-
-                    # Look for "path" keyword and check if our snapshot path is there
-                    if "path " in line:
-                        # Extract the path part after "path "
-                        path_part = line.split("path ", 1)[-1].strip()
-
-                        # More flexible matching - check if the snapshot name appears in the path
-                        # and if the path is within our destination directory
-                        if snapshot_name in path_part:
-                            # Check if this path is within our destination directory
-                            if (
-                                path_part == expected_path  # Exact match
-                                or path_part.startswith(
-                                    dest_path.rstrip("/") + "/"
-                                )  # Under dest_path
-                                or expected_path in path_part
-                            ):  # Expected path is contained
-                                logger.debug(
-                                    f"Snapshot found in subvolume list: {snapshot_name}"
-                                )
-                                logger.debug(f"  Found in path: {path_part}")
-                                logger.debug(f"  Expected path: {expected_path}")
-                                snapshot_found = True
-                                break
-
-                        # Also check if the path ends with our snapshot name (handles nested paths)
-                        if path_part.endswith(f"/{snapshot_name}"):
-                            logger.debug(
-                                f"Snapshot found by suffix match: {snapshot_name}"
-                            )
-                            logger.debug(f"  Found in path: {path_part}")
-                            snapshot_found = True
-                            break
-
-                if len(lines) > 10:
-                    logger.debug(f"  ... and {len(lines) - 10} more lines")
-
-            if snapshot_found:
-                logger.debug("Subvolume-based verification successful")
+            # Authoritative check: confirm a real subvolume exists at exactly the
+            # expected path (not merely a same-named subvolume elsewhere).
+            show_result = _run(["btrfs", "subvolume", "show", expected_path])
+            if show_result.returncode == 0:
+                logger.debug(f"Snapshot verified via subvolume show: {expected_path}")
                 return True
-            else:
-                logger.error("Snapshot not found in subvolume list")
-                logger.debug(f"Expected path: {expected_path}")
-                logger.debug(f"Full subvolume list output:\n{stdout_text}")
 
-                # Try simple path existence check as fallback
-                logger.debug("Trying simple path existence check as fallback")
-                simple_check_cmd = ["test", "-d", expected_path]
-                # Apply proper authentication handling to the final fallback command too
-                simple_check_cmd = self._build_remote_command(simple_check_cmd)
+            # Fallback: exact directory existence at the expected path. Still scoped
+            # to the precise location, so it cannot match a sibling snapshot.
+            test_result = _run(["test", "-d", expected_path])
+            if test_result.returncode == 0:
+                logger.debug(f"Snapshot verified via path check: {expected_path}")
+                return True
 
-                # Check if we need to provide password input for sudo
-                final_input = None
-                if "sudo" in simple_check_cmd and "-S" in simple_check_cmd:
-                    sudo_password = self._get_sudo_password()
-                    if sudo_password:
-                        final_input = sudo_password.encode() + b"\n"
-                        logger.debug(
-                            "Providing sudo password for final fallback verification command"
-                        )
-
-                # Use retry mechanism for simple path check with authentication
-                simple_result = self._exec_remote_command_with_retry(
-                    simple_check_cmd,
-                    max_retries=2,
-                    check=False,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    input=final_input,
-                )
-                if simple_result.returncode == 0:
-                    logger.debug(f"Snapshot exists via path check: {expected_path}")
-                    return True
-                else:
-                    logger.debug(f"Path check also failed for: {expected_path}")
-
-                return False
+            logger.error(f"Snapshot not found at expected path: {expected_path}")
+            return False
 
         except Exception as e:
             logger.error(f"Error verifying snapshot: {e}")
@@ -2836,9 +2682,12 @@ print(json.dumps(result))
                 f"({rate / (1024 * 1024):.1f} MiB/s)"
             )
 
-            # Verify snapshot exists on remote
-            if self._verify_snapshot_exists(dest_path, snapshot_name):
-                logger.info(f"Snapshot {snapshot_name} verified on remote")
+            # Verify snapshot exists on remote. btrfs receive names the received
+            # subvolume after the source basename (== snapshot_name for native
+            # backups, "snapshot" for snapper), so verify by that real name.
+            received_name = Path(source_path).name
+            if self._verify_snapshot_exists(dest_path, received_name):
+                logger.info(f"Snapshot {received_name} verified on remote")
                 return True
             else:
                 logger.error(
@@ -2987,8 +2836,11 @@ print(json.dumps(result))
 
             logger.info("Transfer completed successfully")
 
-            if self._verify_snapshot_exists(dest_path, snapshot_name):
-                logger.info(f"Snapshot {snapshot_name} verified on remote")
+            # The received subvolume is named after the source basename
+            # (== snapshot_name for native, "snapshot" for snapper).
+            received_name = Path(source_path).name
+            if self._verify_snapshot_exists(dest_path, received_name):
+                logger.info(f"Snapshot {received_name} verified on remote")
                 return True
             else:
                 logger.error(
@@ -3095,6 +2947,15 @@ print(json.dumps(result))
         logger.debug(f"Parent path: {parent_path}")
         logger.debug(f"SSH sudo: {self.config.get('ssh_sudo', False)}")
         logger.debug(f"Show progress: {show_progress}")
+
+        # `btrfs receive` names the received subvolume after the *source* subvolume's
+        # basename, not after snapshot_name. For native backups these are identical
+        # (the snapshot dir is named snapshot_name), but for snapper the source is
+        # <config>/.snapshots/<N>/snapshot, so the received subvol is always named
+        # "snapshot". Verification must look for this real name or it will wrongly
+        # report failure and delete a backup that transferred correctly.
+        received_name = Path(source_path).name
+        logger.debug(f"Received subvolume name (for verification): {received_name}")
 
         # Check if source path exists
         if not os.path.exists(source_path):
@@ -3213,6 +3074,7 @@ print(json.dumps(result))
                     dest_path=dest_path,
                     snapshot_name=snapshot_name,
                     max_wait_time=max_wait_time,
+                    received_name=received_name,
                 )
             else:
                 logger.debug(
@@ -3224,6 +3086,7 @@ print(json.dumps(result))
                     dest_path=dest_path,
                     snapshot_name=snapshot_name,
                     max_wait_time=max_wait_time,
+                    received_name=received_name,
                 )
 
             # Final verification if we timed out
@@ -3232,7 +3095,7 @@ print(json.dumps(result))
                     "Reached maximum wait time, performing final verification..."
                 )
                 try:
-                    if self._verify_snapshot_exists(dest_path, snapshot_name):
+                    if self._verify_snapshot_exists(dest_path, received_name):
                         logger.info(
                             "SUCCESS: Transfer completed successfully (final check)"
                         )
@@ -3292,7 +3155,7 @@ print(json.dumps(result))
             transfer_actually_succeeded = False
             try:
                 verification_result = self._verify_snapshot_exists(
-                    dest_path, snapshot_name
+                    dest_path, received_name
                 )
                 logger.debug(f"Snapshot existence verification: {verification_result}")
 
@@ -3313,7 +3176,7 @@ print(json.dumps(result))
                     if ls_result.returncode == 0 and ls_result.stdout:
                         ls_output = ls_result.stdout.decode(errors="replace")
                         logger.debug(f"Directory listing: {ls_output}")
-                        if snapshot_name in ls_output:
+                        if received_name in ls_output:
                             logger.info(
                                 "SUCCESS: TRANSFER ACTUALLY SUCCEEDED - Snapshot found in directory listing"
                             )
@@ -3696,8 +3559,11 @@ print(json.dumps(result))
                 rate_mb,
             )
 
-            # Verify the snapshot exists
-            if self._verify_snapshot_exists(dest_path, manifest.snapshot_name):
+            # Verify the snapshot exists. btrfs receive names the received subvolume
+            # after the source basename (== snapshot_name for native, "snapshot" for
+            # snapper), so verify by that real name, consistent with send_receive.
+            received_name = Path(manifest.snapshot_path).name
+            if self._verify_snapshot_exists(dest_path, received_name):
                 logger.info("Snapshot verified on remote host")
                 return True
             else:
@@ -3719,6 +3585,7 @@ print(json.dumps(result))
         dest_path: str,
         snapshot_name: str,
         max_wait_time: int = 3600,
+        received_name: Optional[str] = None,
     ) -> bool:
         """Enhanced transfer monitoring with real-time progress feedback.
 
@@ -3777,7 +3644,9 @@ print(json.dumps(result))
             if current_time - last_verification_time >= verification_interval:
                 logger.debug("Performing verification check...")
                 try:
-                    if self._verify_snapshot_exists(dest_path, snapshot_name):
+                    if self._verify_snapshot_exists(
+                        dest_path, received_name or snapshot_name
+                    ):
                         logger.info("SUCCESS: Transfer verification successful!")
                         return True
                     else:
@@ -3815,7 +3684,9 @@ print(json.dumps(result))
             "COMPLETE: Transfer monitoring complete, performing final verification..."
         )
         try:
-            transfer_succeeded = self._verify_snapshot_exists(dest_path, snapshot_name)
+            transfer_succeeded = self._verify_snapshot_exists(
+                dest_path, received_name or snapshot_name
+            )
             if transfer_succeeded:
                 elapsed_final = time.time() - start_time
                 logger.info(
@@ -3873,6 +3744,7 @@ print(json.dumps(result))
         dest_path: str,
         snapshot_name: str,
         max_wait_time: int = 3600,
+        received_name: Optional[str] = None,
     ) -> bool:
         """Simplified transfer monitoring with basic process tracking.
 
@@ -3962,7 +3834,7 @@ print(json.dumps(result))
         # Final verification
         logger.debug("STATUS: Performing final verification...")
         try:
-            if self._verify_snapshot_exists(dest_path, snapshot_name):
+            if self._verify_snapshot_exists(dest_path, received_name or snapshot_name):
                 logger.info(
                     f"SUCCESS: Transfer completed successfully in {elapsed_final:.1f}s"
                 )

--- a/src/btrfs_backup_ng/endpoint/ssh.py
+++ b/src/btrfs_backup_ng/endpoint/ssh.py
@@ -200,7 +200,6 @@ class SSHEndpoint(Endpoint):
         self.hostname: str = hostname
         self._instance_id: str = f"{os.getpid()}_{uuid.uuid4().hex[:8]}"
         self._lock: Lock = Lock()
-        self._last_receive_log: Optional[str] = None
         self._last_transfer_snapshot: Optional[bool] = None
         logger.debug(
             "SSHEndpoint: Config keys before parent init: %s", list(config.keys())
@@ -238,7 +237,6 @@ class SSHEndpoint(Endpoint):
         self.config["agent_forwarding"] = self.config.get("agent_forwarding", False)
 
         # Initialize tracking variables for verification
-        self._last_receive_log = None
         self._last_transfer_snapshot = None
 
         # Cache for diagnostics to avoid redundant testing
@@ -3184,61 +3182,6 @@ print(json.dumps(result))
 
             except Exception as e:
                 logger.error(f"Exception during verification: {e}")
-
-            # Check log files for diagnostic purposes, but don't let exit codes override actual success
-            logger.debug("=== LOG FILE DIAGNOSTICS ===")
-            if hasattr(self, "_last_receive_log"):
-                try:
-                    logger.debug(
-                        f"Checking log files for diagnostics: {self._last_receive_log}"
-                    )
-                    # Check exit code file
-                    exitcode_cmd = ["cat", f"{self._last_receive_log}.exitcode"]
-                    exitcode_result = self._exec_remote_command(
-                        exitcode_cmd, check=False, stdout=subprocess.PIPE
-                    )
-
-                    if exitcode_result.returncode == 0 and exitcode_result.stdout:
-                        actual_exitcode = exitcode_result.stdout.decode(
-                            errors="replace"
-                        ).strip()
-                        logger.debug(f"Process exit code: {actual_exitcode}")
-
-                        if actual_exitcode != "0":
-                            # Read the error log for diagnostics
-                            log_cmd = ["cat", self._last_receive_log]
-                            log_result = self._exec_remote_command(
-                                log_cmd, check=False, stdout=subprocess.PIPE
-                            )
-                            if log_result.returncode == 0 and log_result.stdout:
-                                log_content = log_result.stdout.decode(errors="replace")
-
-                                if transfer_actually_succeeded:
-                                    logger.warning(
-                                        f"Process reported error (exit code {actual_exitcode}) but transfer succeeded"
-                                    )
-                                    logger.warning(
-                                        f"Error details (informational): {log_content}"
-                                    )
-                                    logger.debug(
-                                        "This may indicate timing issues or benign process termination"
-                                    )
-                                else:
-                                    logger.error(
-                                        f"Process failed with exit code {actual_exitcode} and no snapshot found"
-                                    )
-                                    logger.error(f"Error details: {log_content}")
-                                    return False
-                        else:
-                            logger.debug("Process completed cleanly (exit code 0)")
-                    else:
-                        logger.warning(
-                            f"Could not read exit code file - command returned {exitcode_result.returncode}"
-                        )
-                except Exception as e:
-                    logger.warning(f"Could not check receive log files: {e}")
-            else:
-                logger.warning("No log files available for diagnostics")
 
             # Final decision based on actual transfer success
             if transfer_actually_succeeded:

--- a/src/btrfs_backup_ng/sshutil/master.py
+++ b/src/btrfs_backup_ng/sshutil/master.py
@@ -68,7 +68,9 @@ class SSHMasterManager:
             else:
                 self.control_dir = self.ssh_config_dir / "controlmasters"
 
-        self.control_dir.mkdir(mode=0o700, exist_ok=True)
+        # parents=True so a missing ~/.ssh (fresh account, CI, container) does not
+        # break endpoint construction with FileNotFoundError.
+        self.control_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
         self._instance_id = f"{os.getpid()}_{threading.get_ident()}"
         self.control_path = (
             self.control_dir

--- a/tests/test_raw_endpoint.py
+++ b/tests/test_raw_endpoint.py
@@ -553,6 +553,27 @@ class TestRawEndpointReceive:
         assert endpoint._pending_metadata["compress"] is None
         assert endpoint._pending_metadata["encrypt"] is None
 
+    def test_receive_writes_stream_to_output_file(self, tmp_path):
+        """receive() writes the stream to the named file, not the cwd.
+
+        Regression: _execute_pipeline reads stream_path from _pending_metadata,
+        which receive() previously set only AFTER executing, so the default
+        Path() ('.') was used and the pipeline opened the current directory
+        (IsADirectoryError). This runs the real pipeline (no mocks).
+        """
+        endpoint = RawEndpoint(config={"path": str(tmp_path)})
+        src = tmp_path / "src.bin"
+        src.write_bytes(b"hello-raw-stream")
+
+        with open(src, "rb") as stdin:
+            proc = endpoint.receive(stdin, snapshot_name="snap-1")
+            proc.communicate()
+
+        assert proc.returncode == 0
+        out = tmp_path / "snap-1.btrfs"
+        assert out.exists()
+        assert out.read_bytes() == b"hello-raw-stream"
+
     def test_receive_with_compression(self, tmp_path):
         """Test receive with compression enabled."""
         endpoint = RawEndpoint(config={"path": tmp_path, "compress": "gzip"})

--- a/tests/test_raw_endpoint.py
+++ b/tests/test_raw_endpoint.py
@@ -1153,3 +1153,31 @@ class TestAllCompressionMethods:
         config = COMPRESSION_CONFIG[compress]
         expected_cmd = config["decompress_cmd"]
         assert pipeline[0] == list(expected_cmd)
+
+
+class TestSSHRawEndpointRemoteExec:
+    """SSHRawEndpoint can run remote commands (needed for the metadata sidecar)."""
+
+    def test_exec_remote_command_builds_ssh(self):
+        ep = SSHRawEndpoint(
+            config={
+                "path": "/remote/backup",
+                "hostname": "host",
+                "username": "user",
+            }
+        )
+
+        with patch("btrfs_backup_ng.endpoint.raw.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            ep._exec_remote_command(
+                ["tee", "/remote/backup/x.snapper-meta.json"],
+                input=b"data",
+                check=True,
+            )
+
+        full_cmd = mock_run.call_args[0][0]
+        assert full_cmd[0] == "ssh"
+        assert "user@host" in full_cmd
+        # The remote command is the final (shell-quoted) argument.
+        assert "tee" in full_cmd[-1]
+        assert mock_run.call_args[1]["input"] == b"data"

--- a/tests/test_snapper_cmd.py
+++ b/tests/test_snapper_cmd.py
@@ -1391,3 +1391,141 @@ class TestExecuteSnapper:
         assert result == 0
         captured = capsys.readouterr()
         assert "[[volumes]]" in captured.out
+
+
+class TestSnapperEndpointRouting:
+    """Snapper backup routes through the endpoint layer (issue #1)."""
+
+    def test_list_backed_up_numbers_btrfs_local(self, tmp_path):
+        """btrfs targets report numbers from .snapshots/{num}/snapshot dirs."""
+        from btrfs_backup_ng.core.operations import _list_backed_up_snapper_numbers
+
+        base = tmp_path / "backup"
+        for num in (1, 2):
+            (base / ".snapshots" / str(num) / "snapshot").mkdir(parents=True)
+        # A numbered dir with no 'snapshot' subvolume is not counted.
+        (base / ".snapshots" / "3").mkdir(parents=True)
+
+        ep = MagicMock()
+        ep.config = {"path": str(base)}
+        ep._is_remote = False
+
+        assert _list_backed_up_snapper_numbers(ep) == {1, 2}
+
+    def test_list_backed_up_numbers_raw_is_empty(self, tmp_path):
+        """Raw targets have no numbered layout, so the set is empty (re-send)."""
+        from btrfs_backup_ng.core.operations import _list_backed_up_snapper_numbers
+        from btrfs_backup_ng.endpoint.raw import RawEndpoint
+
+        ep = RawEndpoint(config={"path": str(tmp_path)})
+        assert _list_backed_up_snapper_numbers(ep) == set()
+
+    def test_send_snapper_btrfs_receives_into_per_snapshot_dir(self):
+        """btrfs dispatch points the endpoint at .snapshots/{num} then restores it."""
+        from btrfs_backup_ng.core import operations
+
+        ep = MagicMock()
+        ep.config = {"path": "/backup/home"}
+        ep._is_remote = False
+
+        snap = MagicMock()
+        snap.number = 5
+        snap.get_backup_name.return_value = "home-5-20240115-120000"
+        snap.subvolume_path = Path("/.snapshots/5/snapshot")
+
+        captured = {}
+
+        def fake_send_snapshot(src, dest, parent=None, options=None):
+            captured["path"] = dest.config["path"]
+
+        with (
+            patch.object(
+                operations, "_list_backed_up_snapper_numbers", return_value=set()
+            ),
+            patch.object(
+                operations, "_create_snapper_snapshot_wrapper", return_value=MagicMock()
+            ),
+            patch.object(operations, "send_snapshot", side_effect=fake_send_snapshot),
+            patch.object(operations, "_place_info_xml"),
+            patch.object(operations, "_write_snapper_metadata"),
+        ):
+            operations.send_snapper_snapshot(snap, ep)
+
+        assert captured["path"] == "/backup/home/.snapshots/5"
+        # The endpoint's base path is restored after the transfer.
+        assert ep.config["path"] == "/backup/home"
+
+    def test_send_snapper_raw_forces_no_compression(self, tmp_path):
+        """Raw dispatch sends on the base endpoint with compression disabled."""
+        from btrfs_backup_ng.core import operations
+        from btrfs_backup_ng.endpoint.raw import RawEndpoint
+
+        ep = RawEndpoint(config={"path": str(tmp_path)})
+        snap = MagicMock()
+        snap.number = 5
+        snap.get_backup_name.return_value = "home-5-20240115-120000"
+        snap.subvolume_path = Path("/.snapshots/5/snapshot")
+
+        captured = {}
+
+        def fake_send_snapshot(src, dest, parent=None, options=None):
+            captured["options"] = options
+            captured["dest"] = dest
+
+        with (
+            patch.object(
+                operations, "_create_snapper_snapshot_wrapper", return_value=MagicMock()
+            ),
+            patch.object(operations, "send_snapshot", side_effect=fake_send_snapshot),
+            patch.object(operations, "_write_snapper_metadata"),
+        ):
+            operations.send_snapper_snapshot(snap, ep, options={"compress": "zstd"})
+
+        assert captured["options"]["compress"] == "none"
+        assert captured["dest"] is ep
+
+    def test_handle_backup_routes_ssh_through_choose_endpoint(
+        self, tmp_path, monkeypatch
+    ):
+        """`snapper backup <cfg> ssh://...` parses the URL via choose_endpoint and
+        passes an endpoint (not a raw string) downstream -- no local 'ssh:' dir."""
+        from btrfs_backup_ng.cli import snapper_cmd
+
+        args = argparse.Namespace(
+            config="root",
+            target="ssh://backup@host:/share/Backups",
+            snapshot=None,
+            type=None,
+            dry_run=False,
+            compress=None,
+            rate_limit=None,
+            verbose=False,
+            quiet=False,
+            log_level=None,
+            min_age="0",
+        )
+        monkeypatch.chdir(tmp_path)
+
+        mock_scanner = MagicMock()
+        mock_scanner.get_config.return_value = MagicMock()
+
+        with (
+            patch(
+                "btrfs_backup_ng.cli.snapper_cmd.SnapperScanner",
+                return_value=mock_scanner,
+            ),
+            patch("btrfs_backup_ng.endpoint.choose_endpoint") as mock_choose,
+            patch(
+                "btrfs_backup_ng.core.operations.sync_snapper_snapshots",
+                return_value=0,
+            ) as mock_sync,
+        ):
+            mock_choose.return_value = MagicMock(_is_remote=True)
+            snapper_cmd._handle_backup(args)
+
+        mock_choose.assert_called_once()
+        assert mock_choose.call_args[0][0] == "ssh://backup@host:/share/Backups"
+        # sync received the endpoint object, not the raw target string.
+        assert mock_sync.call_args[0][2] is mock_choose.return_value
+        # Regression: the ssh URL is not turned into a local directory.
+        assert not (tmp_path / "ssh:").exists()

--- a/tests/test_snapper_cmd.py
+++ b/tests/test_snapper_cmd.py
@@ -1556,3 +1556,45 @@ class TestSnapperEndpointRouting:
 
         subvol = str(base / ".snapshots" / "7" / "snapshot")
         assert ["btrfs", "subvolume", "delete", subvol] in calls
+
+    def test_handle_backup_threads_ssh_options(self, tmp_path, monkeypatch):
+        """--ssh-sudo / --ssh-key reach the endpoint config for ssh targets."""
+        from btrfs_backup_ng.cli import snapper_cmd
+
+        args = argparse.Namespace(
+            config="root",
+            target="ssh://backup@host:/b",
+            snapshot=None,
+            type=None,
+            dry_run=False,
+            compress=None,
+            rate_limit=None,
+            verbose=False,
+            quiet=False,
+            log_level=None,
+            min_age="0",
+            ssh_sudo=True,
+            ssh_key="/home/u/.ssh/id",
+        )
+        monkeypatch.chdir(tmp_path)
+
+        mock_scanner = MagicMock()
+        mock_scanner.get_config.return_value = MagicMock()
+
+        with (
+            patch(
+                "btrfs_backup_ng.cli.snapper_cmd.SnapperScanner",
+                return_value=mock_scanner,
+            ),
+            patch("btrfs_backup_ng.endpoint.choose_endpoint") as mock_choose,
+            patch(
+                "btrfs_backup_ng.core.operations.sync_snapper_snapshots",
+                return_value=0,
+            ),
+        ):
+            mock_choose.return_value = MagicMock(_is_remote=True)
+            snapper_cmd._handle_backup(args)
+
+        cfg = mock_choose.call_args[0][1]
+        assert cfg.get("ssh_sudo") is True
+        assert cfg.get("ssh_identity_file") == "/home/u/.ssh/id"

--- a/tests/test_snapper_cmd.py
+++ b/tests/test_snapper_cmd.py
@@ -1529,3 +1529,30 @@ class TestSnapperEndpointRouting:
         assert mock_sync.call_args[0][2] is mock_choose.return_value
         # Regression: the ssh URL is not turned into a local directory.
         assert not (tmp_path / "ssh:").exists()
+
+    def test_cleanup_uses_btrfs_subvolume_delete(self, tmp_path):
+        """Cleanup removes the read-only received subvolume via btrfs, not rm -rf
+        (a received subvolume is read-only and cannot be rm'd)."""
+        from btrfs_backup_ng.core import operations
+
+        base = tmp_path / "backup"
+        (base / ".snapshots" / "7" / "snapshot").mkdir(parents=True)
+
+        ep = MagicMock()
+        ep.config = {"path": str(base)}
+        ep._is_remote = False
+
+        calls = []
+
+        def record(cmd, *a, **k):
+            calls.append(list(cmd))
+            return MagicMock(returncode=0)
+
+        with (
+            patch("btrfs_backup_ng.core.operations.subprocess.run", side_effect=record),
+            patch("os.geteuid", return_value=0),
+        ):
+            operations._cleanup_snapper_backup(ep, 7, is_raw=False)
+
+        subvol = str(base / ".snapshots" / "7" / "snapshot")
+        assert ["btrfs", "subvolume", "delete", subvol] in calls

--- a/tests/test_ssh_endpoint.py
+++ b/tests/test_ssh_endpoint.py
@@ -65,3 +65,37 @@ class TestBuildReceiveCommand:
         )
         assert "sudo -S" in cmd
         assert "sudo -n" not in cmd
+
+
+class TestSSHEndpointConfigPreservation:
+    """SSH-specific config keys survive the base Endpoint.__init__ whitelist.
+
+    Regression: the base rebuilds config from a fixed key set, dropping SSH keys,
+    so ssh://user@host and --ssh-sudo / --ssh-key were silently lost (the username
+    fell back to SUDO_USER/current user).
+    """
+
+    def test_username_from_url_is_preserved(self):
+        from btrfs_backup_ng.endpoint import choose_endpoint
+
+        ep = choose_endpoint(
+            "ssh://root@host/path",
+            {"path": "ssh://root@host/path", "snap_prefix": ""},
+        )
+        assert ep.config.get("username") == "root"
+
+    def test_ssh_sudo_and_identity_are_preserved(self):
+        from btrfs_backup_ng.endpoint import choose_endpoint
+
+        ep = choose_endpoint(
+            "ssh://u@host/p",
+            {
+                "path": "ssh://u@host/p",
+                "snap_prefix": "",
+                "ssh_sudo": True,
+                "ssh_identity_file": "/key",
+            },
+        )
+        assert ep.config.get("username") == "u"
+        assert ep.config.get("ssh_sudo") is True
+        assert ep.config.get("ssh_identity_file") == "/key"

--- a/tests/test_ssh_endpoint.py
+++ b/tests/test_ssh_endpoint.py
@@ -3,6 +3,8 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 from btrfs_backup_ng.endpoint.ssh import (
     RECEIVE_IDLE_TIMEOUT,
     SSHEndpoint,
@@ -81,6 +83,14 @@ class TestSSHEndpointConfigPreservation:
     so ssh://user@host and --ssh-sudo / --ssh-key were silently lost (the username
     fell back to SUDO_USER/current user).
     """
+
+    @pytest.fixture(autouse=True)
+    def _isolated_home(self, tmp_path, monkeypatch):
+        # Constructing a real SSHEndpoint sets up an SSH ControlMaster dir under
+        # ~/.ssh; point HOME at a temp dir so tests never touch the real one (and
+        # so they run on a fresh account/CI runner with no ~/.ssh).
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.delenv("SUDO_USER", raising=False)
 
     def test_username_from_url_is_preserved(self):
         from btrfs_backup_ng.endpoint import choose_endpoint

--- a/tests/test_ssh_endpoint.py
+++ b/tests/test_ssh_endpoint.py
@@ -1,6 +1,13 @@
 """Tests for SSH endpoint utilities."""
 
-from btrfs_backup_ng.endpoint.ssh import RECEIVE_IDLE_TIMEOUT, _build_receive_command
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from btrfs_backup_ng.endpoint.ssh import (
+    RECEIVE_IDLE_TIMEOUT,
+    SSHEndpoint,
+    _build_receive_command,
+)
 
 
 class TestBuildReceiveCommand:
@@ -99,3 +106,57 @@ class TestSSHEndpointConfigPreservation:
         assert ep.config.get("username") == "u"
         assert ep.config.get("ssh_sudo") is True
         assert ep.config.get("ssh_identity_file") == "/key"
+
+
+class TestVerifySnapshotUsesExactPath:
+    """`_verify_snapshot_exists` checks the exact received path, not a bare name.
+
+    `btrfs receive` names the received subvolume after the source subvol's
+    basename. For snapper that is always "snapshot" (source is
+    <config>/.snapshots/<N>/snapshot), so verification must be scoped to exactly
+    {dest_path}/snapshot. A filesystem-wide name search would match a same-named
+    subvolume elsewhere on the destination (e.g. a sibling .snapshots/<other>/
+    snapshot) and report a FAILED transfer as succeeded -- a silent phantom
+    backup.
+    """
+
+    @staticmethod
+    def _endpoint(existing_paths: set[str]) -> SSHEndpoint:
+        # Build a bare endpoint without opening any SSH connection. The fake exec
+        # reports success only when a command targets a path that "exists" -- the
+        # target path is always the last argument (`subvolume show <p>` / `test -d <p>`).
+        ep = SSHEndpoint.__new__(SSHEndpoint)
+        ep.config = {"ssh_sudo": False}
+
+        def fake_exec(cmd, **kwargs):
+            target = cmd[-1]
+            rc = 0 if target in existing_paths else 1
+            return SimpleNamespace(returncode=rc, stdout=b"", stderr=b"")
+
+        ep._exec_remote_command = MagicMock(side_effect=fake_exec)  # type: ignore[method-assign]
+        ep._exec_remote_command_with_retry = MagicMock(side_effect=fake_exec)  # type: ignore[method-assign]
+        return ep
+
+    def test_exact_received_path_is_verified(self):
+        ep = self._endpoint({"/root/dest/.snapshots/5/snapshot"})
+        assert ep._verify_snapshot_exists("/root/dest/.snapshots/5", "snapshot") is True
+
+    def test_sibling_snapshot_is_not_a_false_positive(self):
+        # The transfer into .snapshots/5 failed (no .snapshots/5/snapshot), but a
+        # prior .snapshots/4/snapshot exists on the destination. Verification must
+        # NOT report success off the sibling.
+        ep = self._endpoint({"/root/dest/.snapshots/4/snapshot"})
+        assert (
+            ep._verify_snapshot_exists("/root/dest/.snapshots/5", "snapshot") is False
+        )
+
+    def test_missing_path_is_false(self):
+        ep = self._endpoint(set())
+        assert (
+            ep._verify_snapshot_exists("/root/dest/.snapshots/5", "snapshot") is False
+        )
+
+    def test_native_unique_name_verified(self):
+        # Native backups pass a globally unique name; exact-path check still works.
+        ep = self._endpoint({"/mnt/backup/host-20260718-1200"})
+        assert ep._verify_snapshot_exists("/mnt/backup", "host-20260718-1200") is True


### PR DESCRIPTION
Closes #1. `snapper backup` previously ignored `ssh://` / `raw://` / `raw+ssh://` destination schemes and always wrote locally. Routing it through the endpoint layer surfaced a chain of pre-existing `SSHEndpoint` defects, all fixed here and validated end-to-end on real hardware.

## What this does

- Routes `snapper backup` through `choose_endpoint` + `send_snapshot`. Per-snapshot the destination endpoint is pointed at `.snapshots/{num}` so `btrfs receive` reproduces the native snapper layout; raw targets use a number-in-filename + metadata sidecar.
- Preserves SSH config keys (username, ssh_sudo, ssh_identity_file, ...) the base `Endpoint.__init__` whitelist silently dropped -- a `ssh://user@host` username no longer falls back to `$SUDO_USER`.
- Verifies success by the **exact** received subvolume path (`btrfs subvolume show`) instead of a filesystem-wide name search. The received subvol is named after the source basename (`snapshot` for snapper), so the old search both missed it (deleting good backups) and, once naively fixed, matched sibling snapshots (silent phantom backups). Exact-path verification is correct for native and safe for snapper.
- Fixes raw stream target path, raw+ssh metadata sidecar, snapper cleanup of read-only received subvols, and remote detection. Removes tee terminal noise and dead diagnostics.

## Validation

- All three target types (`raw://`, `raw+ssh://`, `ssh://` btrfs) validated end-to-end on real hardware -- received subvols land with valid Received UUIDs and correct snapper layout.
- Full suite green (1966 passed); regression tests added for config preservation, exact-path verification, and the sibling false-positive guard. Two adversarial review passes on the verification change.

Follow-up (#10): surface remote `btrfs receive` stderr on failure. Docs (SNAPPER-INTEGRATION, CLI reference, completions, CHANGELOG, README SSH setup) to follow before release.