### PR TITLE
Honor an explicit empty snapshot_prefix (Closes #6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.3] - 2026-07-18
 
+### Added
+
+- **Explicit empty `snapshot_prefix`** is now honored — set `snapshot_prefix = ""` for bare-timestamp snapshot names. An omitted/unset prefix still auto-derives from the volume path (`/home` → `home-`) as before. Pair an empty prefix with a strict `timestamp_format` and a dedicated `snapshot_dir` so unrelated subvolumes are not mistaken for snapshots.
+  - *Migration note:* an existing config that sets `snapshot_prefix = ""` (rather than omitting the key) now yields bare-timestamp names instead of the previously auto-derived default. Omit the key to keep the derived prefix.
+
 ### Fixed
 
 #### Snapper Backup to Remote and Raw Targets

--- a/README.md
+++ b/README.md
@@ -516,7 +516,11 @@ Duration format: `30m` (minutes), `2h` (hours), `1d` (days), `1w` (weeks)
 ```toml
 [[volumes]]
 path = "/home"                    # Path to BTRFS subvolume
-snapshot_prefix = "home-"         # Prefix for snapshot names
+# snapshot_prefix: prefix for snapshot names. Omit to auto-derive from the path
+# (/home -> "home-"). Set to "" for bare-timestamp names -- if you do, pair it
+# with a strict timestamp_format and a dedicated snapshot_dir so unrelated
+# subvolumes are not mistaken for snapshots.
+snapshot_prefix = "home-"
 snapshot_dir = ".snapshots"       # Override global snapshot_dir
 enabled = true                    # Enable/disable this volume
 

--- a/src/btrfs_backup_ng/cli/config_cmd.py
+++ b/src/btrfs_backup_ng/cli/config_cmd.py
@@ -26,6 +26,7 @@ from .wizard_utils import (
     prompt_choice,
     prompt_int,
     prompt_selection,
+    prompt_snapshot_prefix,
 )
 
 logger = logging.getLogger(__name__)
@@ -234,8 +235,11 @@ def _generate_config_from_wizard(config_data: dict[str, Any]) -> str:
             lines.append(f"include_types = [{types_str}]")
             lines.append(f'min_age = "{snapper.get("min_age", "1h")}"')
         else:
-            # Native volumes use snapshot_prefix
-            lines.append(f'snapshot_prefix = "{volume.get("snapshot_prefix", "")}"')
+            # Native volumes use snapshot_prefix. Only emit it when explicitly
+            # set, so an unset prefix round-trips to auto-derive on load; an
+            # explicit "" is preserved and honored.
+            if volume.get("snapshot_prefix") is not None:
+                lines.append(f'snapshot_prefix = "{volume["snapshot_prefix"]}"')
 
         for target in volume.get("targets", []):
             lines.extend(
@@ -358,7 +362,7 @@ def _run_interactive_wizard() -> str:
 
         # Generate default prefix from path (with trailing dash for readable snapshot names)
         default_prefix = (Path(volume_path).name or "root") + "-"
-        snapshot_prefix = prompt("Snapshot prefix", default_prefix)
+        snapshot_prefix = prompt_snapshot_prefix(default_prefix)
 
         volume: dict[str, Any] = {
             "path": volume_path,
@@ -1270,13 +1274,13 @@ def _run_detection_wizard(result) -> int:
                 )
             else:
                 # User wants native management instead
-                volume["snapshot_prefix"] = prompt(
-                    "Snapshot prefix", suggestion.suggested_prefix
+                volume["snapshot_prefix"] = prompt_snapshot_prefix(
+                    suggestion.suggested_prefix
                 )
         else:
             # Native volume
-            volume["snapshot_prefix"] = prompt(
-                "Snapshot prefix", suggestion.suggested_prefix
+            volume["snapshot_prefix"] = prompt_snapshot_prefix(
+                suggestion.suggested_prefix
             )
 
         # Add targets

--- a/src/btrfs_backup_ng/cli/list_cmd.py
+++ b/src/btrfs_backup_ng/cli/list_cmd.py
@@ -3,7 +3,6 @@
 import argparse
 import json
 import logging
-import os
 from pathlib import Path
 from typing import Any
 
@@ -70,7 +69,7 @@ def execute_list(args: argparse.Namespace) -> int:
 
         # Build endpoint kwargs
         endpoint_kwargs = {
-            "snap_prefix": volume.snapshot_prefix or f"{os.uname()[1]}-",
+            "snap_prefix": volume.snapshot_prefix,
             "convert_rw": False,
             "subvolume_sync": False,
             "btrfs_debug": False,

--- a/src/btrfs_backup_ng/cli/prune.py
+++ b/src/btrfs_backup_ng/cli/prune.py
@@ -2,7 +2,6 @@
 
 import argparse
 import logging
-import os
 import time
 from pathlib import Path
 from typing import Literal
@@ -97,7 +96,7 @@ def execute_prune(args: argparse.Namespace) -> int:
 
         # Build endpoint kwargs
         endpoint_kwargs = {
-            "snap_prefix": volume.snapshot_prefix or f"{os.uname()[1]}-",
+            "snap_prefix": volume.snapshot_prefix,
             "convert_rw": False,
             "subvolume_sync": False,
             "btrfs_debug": False,
@@ -105,7 +104,7 @@ def execute_prune(args: argparse.Namespace) -> int:
             "timestamp_format": get_timestamp_format(config),
         }
 
-        prefix = volume.snapshot_prefix or f"{os.uname()[1]}-"
+        prefix = volume.snapshot_prefix
 
         # Prune source snapshots
         try:

--- a/src/btrfs_backup_ng/cli/run.py
+++ b/src/btrfs_backup_ng/cli/run.py
@@ -2,7 +2,6 @@
 
 import argparse
 import logging
-import os
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
@@ -273,7 +272,7 @@ def _backup_volume(
 
     # Build endpoint kwargs
     endpoint_kwargs = {
-        "snap_prefix": volume.snapshot_prefix or f"{os.uname()[1]}-",
+        "snap_prefix": volume.snapshot_prefix,
         "convert_rw": False,
         "subvolume_sync": False,
         "btrfs_debug": False,

--- a/src/btrfs_backup_ng/cli/snapshot.py
+++ b/src/btrfs_backup_ng/cli/snapshot.py
@@ -2,7 +2,6 @@
 
 import argparse
 import logging
-import os
 import time
 from pathlib import Path
 
@@ -71,7 +70,7 @@ def execute_snapshot(args: argparse.Namespace) -> int:
         print("")
         print("Would create snapshots for:")
         for volume in volumes:
-            prefix = volume.snapshot_prefix or f"{os.uname()[1]}-"
+            prefix = volume.snapshot_prefix
             print(f"  {volume.path} (prefix: {prefix})")
         return 0
 
@@ -86,7 +85,7 @@ def execute_snapshot(args: argparse.Namespace) -> int:
         try:
             # Build endpoint kwargs
             endpoint_kwargs = {
-                "snap_prefix": volume.snapshot_prefix or f"{os.uname()[1]}-",
+                "snap_prefix": volume.snapshot_prefix,
                 "convert_rw": False,
                 "subvolume_sync": False,
                 "btrfs_debug": False,

--- a/src/btrfs_backup_ng/cli/status.py
+++ b/src/btrfs_backup_ng/cli/status.py
@@ -2,7 +2,6 @@
 
 import argparse
 import logging
-import os
 from pathlib import Path
 
 from .. import endpoint
@@ -86,7 +85,7 @@ def execute_status(args: argparse.Namespace) -> int:
 
         # Build endpoint kwargs
         endpoint_kwargs = {
-            "snap_prefix": volume.snapshot_prefix or f"{os.uname()[1]}-",
+            "snap_prefix": volume.snapshot_prefix,
             "convert_rw": False,
             "subvolume_sync": False,
             "btrfs_debug": False,

--- a/src/btrfs_backup_ng/cli/transfer.py
+++ b/src/btrfs_backup_ng/cli/transfer.py
@@ -2,7 +2,6 @@
 
 import argparse
 import logging
-import os
 import time
 from pathlib import Path
 
@@ -95,7 +94,7 @@ def execute_transfer(args: argparse.Namespace) -> int:
         try:
             # Build endpoint kwargs
             endpoint_kwargs = {
-                "snap_prefix": volume.snapshot_prefix or f"{os.uname()[1]}-",
+                "snap_prefix": volume.snapshot_prefix,
                 "convert_rw": False,
                 "subvolume_sync": False,
                 "btrfs_debug": False,

--- a/src/btrfs_backup_ng/cli/wizard_utils.py
+++ b/src/btrfs_backup_ng/cli/wizard_utils.py
@@ -57,6 +57,25 @@ def prompt_bool(message: str, default: bool = True) -> bool:
         raise KeyboardInterrupt
 
 
+def prompt_snapshot_prefix(default_prefix: str) -> str:
+    """Prompt for a snapshot name prefix, allowing an explicit empty prefix.
+
+    A plain text prompt cannot express "empty" (pressing Enter returns the
+    default), so gate on a yes/no first: answering "no" selects an empty prefix
+    (bare-timestamp snapshot names); otherwise prompt for the prefix with the
+    path-derived default.
+
+    Args:
+        default_prefix: Path-derived default prefix (e.g. "home-")
+
+    Returns:
+        The chosen prefix ("" for no prefix)
+    """
+    if not prompt_bool("Use a snapshot name prefix?", default=True):
+        return ""
+    return prompt("Snapshot prefix", default_prefix)
+
+
 def prompt_int(message: str, default: int, min_val: int = 0, max_val: int = 100) -> int:
     """Prompt user for integer input with validation.
 

--- a/src/btrfs_backup_ng/config/loader.py
+++ b/src/btrfs_backup_ng/config/loader.py
@@ -202,7 +202,10 @@ def _parse_volume(data: dict[str, Any], global_config: GlobalConfig) -> VolumeCo
 
     return VolumeConfig(
         path=data["path"],
-        snapshot_prefix=data.get("snapshot_prefix", ""),
+        # Absent -> None so the schema auto-derives from the path; an explicit
+        # value (including "") is passed through and honored. None is the
+        # documented sentinel here, hence the arg-type ignore.
+        snapshot_prefix=data.get("snapshot_prefix"),  # type: ignore[arg-type]
         snapshot_dir=data.get("snapshot_dir", global_config.snapshot_dir),
         targets=targets,
         retention=retention,

--- a/src/btrfs_backup_ng/config/schema.py
+++ b/src/btrfs_backup_ng/config/schema.py
@@ -219,7 +219,10 @@ class VolumeConfig:
     """
 
     path: str
-    snapshot_prefix: str = ""
+    # Defaults to None so __post_init__ can distinguish "unset" (auto-derive from
+    # path) from an explicit "" (bare-timestamp names). Always a concrete str after
+    # __post_init__, so it is typed str for consumers.
+    snapshot_prefix: str = None  # type: ignore[assignment]
     snapshot_dir: str = ".snapshots"
     targets: list[TargetConfig] = field(default_factory=list)
     retention: Optional[RetentionConfig] = None
@@ -228,8 +231,10 @@ class VolumeConfig:
     snapper: Optional[SnapperSourceConfig] = None
 
     def __post_init__(self):
-        # Generate default prefix from path if not specified
-        if not self.snapshot_prefix:
+        # Auto-derive a prefix from the path only when unset (None). An explicit
+        # empty string is a valid, intentional choice (bare-timestamp names) and
+        # must be preserved.
+        if self.snapshot_prefix is None:
             # /home -> home-, /var/log -> var-log- (trailing dash for readable snapshot names)
             base = self.path.strip("/").replace("/", "-") or "root"
             self.snapshot_prefix = base + "-"

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -450,7 +450,6 @@ class TestInteractiveWizard:
                 "",  # transaction_log (empty)
                 "1d",  # min retention
                 "/home",  # volume path
-                "home-",  # snapshot prefix
                 "/mnt/backup",  # target path
             ]
         )
@@ -478,7 +477,11 @@ class TestInteractiveWizard:
                     "btrfs_backup_ng.cli.config_cmd.prompt_bool",
                     side_effect=lambda *a, **kw: next(prompt_bool_returns),
                 ):
-                    result = _run_interactive_wizard()
+                    with mock.patch(
+                        "btrfs_backup_ng.cli.config_cmd.prompt_snapshot_prefix",
+                        side_effect=["home-"],  # snapshot prefix
+                    ):
+                        result = _run_interactive_wizard()
 
         assert "[global]" in result
         assert 'path = "/home"' in result
@@ -644,7 +647,6 @@ class TestMigrateSystemd:
                 "",
                 "1d",
                 "/home",
-                "home-",
                 "ssh://user@server:/backups",  # SSH target
             ]
         )
@@ -672,7 +674,11 @@ class TestMigrateSystemd:
                     "btrfs_backup_ng.cli.config_cmd.prompt_bool",
                     side_effect=lambda *a, **kw: next(prompt_bool_returns),
                 ):
-                    result = _run_interactive_wizard()
+                    with mock.patch(
+                        "btrfs_backup_ng.cli.config_cmd.prompt_snapshot_prefix",
+                        side_effect=["home-"],  # snapshot prefix
+                    ):
+                        result = _run_interactive_wizard()
 
         assert 'path = "ssh://user@server:/backups"' in result
         assert "ssh_sudo = true" in result
@@ -688,7 +694,6 @@ class TestMigrateSystemd:
                 "1d",
                 "",  # Try empty volume path first
                 "/home",  # Then provide valid path
-                "home-",
                 "/mnt/backup",
             ]
         )
@@ -716,7 +721,11 @@ class TestMigrateSystemd:
                     "btrfs_backup_ng.cli.config_cmd.prompt_bool",
                     side_effect=lambda *a, **kw: next(prompt_bool_returns),
                 ):
-                    result = _run_interactive_wizard()
+                    with mock.patch(
+                        "btrfs_backup_ng.cli.config_cmd.prompt_snapshot_prefix",
+                        side_effect=["home-"],  # snapshot prefix
+                    ):
+                        result = _run_interactive_wizard()
 
         # Should have completed with the second volume attempt
         assert 'path = "/home"' in result
@@ -731,7 +740,6 @@ class TestMigrateSystemd:
                 "",
                 "1d",
                 "/home",
-                "home-",
                 "",  # Try empty target first
                 "/mnt/backup",  # Then provide valid target
             ]
@@ -760,6 +768,10 @@ class TestMigrateSystemd:
                     "btrfs_backup_ng.cli.config_cmd.prompt_bool",
                     side_effect=lambda *a, **kw: next(prompt_bool_returns),
                 ):
-                    result = _run_interactive_wizard()
+                    with mock.patch(
+                        "btrfs_backup_ng.cli.config_cmd.prompt_snapshot_prefix",
+                        side_effect=["home-"],  # snapshot prefix
+                    ):
+                        result = _run_interactive_wizard()
 
         assert 'path = "/mnt/backup"' in result

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -189,6 +189,34 @@ path = "/mnt/backup"
         with pytest.raises(ConfigError, match="path"):
             load_config(bad_config)
 
+    def test_load_explicit_empty_snapshot_prefix(self, tmp_config_dir):
+        """An explicit empty snapshot_prefix in TOML is preserved, not replaced
+        by the auto-derived default."""
+        cfg = tmp_config_dir / "empty_prefix.toml"
+        cfg.write_text("""
+[[volumes]]
+path = "/home"
+snapshot_prefix = ""
+
+[[volumes.targets]]
+path = "/mnt/backup"
+""")
+        config, _ = load_config(cfg)
+        assert config.volumes[0].snapshot_prefix == ""
+
+    def test_load_absent_snapshot_prefix_auto_derives(self, tmp_config_dir):
+        """Omitting snapshot_prefix auto-derives it from the volume path."""
+        cfg = tmp_config_dir / "no_prefix.toml"
+        cfg.write_text("""
+[[volumes]]
+path = "/home"
+
+[[volumes.targets]]
+path = "/mnt/backup"
+""")
+        config, _ = load_config(cfg)
+        assert config.volumes[0].snapshot_prefix == "home-"
+
     def test_load_missing_target_path(self, tmp_config_dir):
         """Test error when target is missing path."""
         bad_config = tmp_config_dir / "no_target_path.toml"

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -142,6 +142,17 @@ class TestVolumeConfig:
         volume = VolumeConfig(path="/home", snapshot_prefix="my-prefix-")
         assert volume.snapshot_prefix == "my-prefix-"
 
+    def test_explicit_empty_prefix_is_preserved(self):
+        """An explicit empty prefix is honored (not replaced by the auto-derived
+        default), giving bare-timestamp snapshot names."""
+        volume = VolumeConfig(path="/home", snapshot_prefix="")
+        assert volume.snapshot_prefix == ""
+
+    def test_unset_prefix_auto_derives(self):
+        """Omitting snapshot_prefix (None) still auto-derives from the path."""
+        volume = VolumeConfig(path="/home", snapshot_prefix=None)
+        assert volume.snapshot_prefix == "home-"
+
     def test_with_targets(self):
         """Test volume with targets."""
         targets = [

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1965,9 +1965,7 @@ class TestDetectionWizard:
 
         # Use /backup paths to avoid /mnt/ require_mount check
         mock_prompt.side_effect = [
-            "home",  # prefix for /home
             "/backup/home",  # target for /home
-            "root",  # prefix for /
             "/backup/root",  # target for /
         ]
         mock_bool.side_effect = [
@@ -1979,7 +1977,11 @@ class TestDetectionWizard:
             "print",  # print config instead of save
         ]
 
-        exit_code = _run_detection_wizard(result)
+        with patch(
+            "btrfs_backup_ng.cli.config_cmd.prompt_snapshot_prefix",
+            side_effect=["home", "root"],  # prefix for /home, prefix for /
+        ):
+            exit_code = _run_detection_wizard(result)
 
         assert exit_code == 0
         captured = capsys.readouterr()
@@ -2017,7 +2019,6 @@ class TestDetectionWizard:
         mock_selection.return_value = [0]
 
         mock_prompt.side_effect = [
-            "home",  # prefix
             "/backup/home",  # target (not /mnt/)
         ]
         mock_bool.side_effect = [
@@ -2028,7 +2029,11 @@ class TestDetectionWizard:
             "print",  # print config
         ]
 
-        exit_code = _run_detection_wizard(result)
+        with patch(
+            "btrfs_backup_ng.cli.config_cmd.prompt_snapshot_prefix",
+            side_effect=["home"],  # prefix
+        ):
+            exit_code = _run_detection_wizard(result)
 
         assert exit_code == 0
         captured = capsys.readouterr()
@@ -2063,7 +2068,6 @@ class TestDetectionWizard:
 
         mock_selection.return_value = [0]  # Select first volume
         mock_prompt.side_effect = [
-            "home",  # prefix
             "/backup",  # target (not /mnt/)
         ]
         mock_bool.side_effect = [
@@ -2074,7 +2078,11 @@ class TestDetectionWizard:
             "cancel",  # cancel
         ]
 
-        exit_code = _run_detection_wizard(result)
+        with patch(
+            "btrfs_backup_ng.cli.config_cmd.prompt_snapshot_prefix",
+            side_effect=["home"],  # prefix
+        ):
+            exit_code = _run_detection_wizard(result)
 
         assert exit_code == 0
 
@@ -2107,7 +2115,6 @@ class TestDetectionWizard:
 
         mock_selection.return_value = [0]  # Select first volume
         mock_prompt.side_effect = [
-            "home",  # prefix
             "ssh://user@host:/backup/home",  # SSH target
         ]
         mock_bool.side_effect = [
@@ -2119,7 +2126,11 @@ class TestDetectionWizard:
             "print",  # print config
         ]
 
-        exit_code = _run_detection_wizard(result)
+        with patch(
+            "btrfs_backup_ng.cli.config_cmd.prompt_snapshot_prefix",
+            side_effect=["home"],  # prefix
+        ):
+            exit_code = _run_detection_wizard(result)
 
         assert exit_code == 0
         captured = capsys.readouterr()
@@ -2155,7 +2166,6 @@ class TestDetectionWizard:
 
         mock_selection.return_value = [0]  # Select first volume
         mock_prompt.side_effect = [
-            "home",  # prefix
             "/mnt/usb-drive/backup",  # Mount point target triggers require_mount
         ]
         mock_bool.side_effect = [
@@ -2167,7 +2177,11 @@ class TestDetectionWizard:
             "print",  # print config
         ]
 
-        exit_code = _run_detection_wizard(result)
+        with patch(
+            "btrfs_backup_ng.cli.config_cmd.prompt_snapshot_prefix",
+            side_effect=["home"],  # prefix
+        ):
+            exit_code = _run_detection_wizard(result)
 
         assert exit_code == 0
         captured = capsys.readouterr()
@@ -2206,9 +2220,7 @@ class TestDetectionWizard:
         mock_selection.return_value = [0, 1]  # Both recommended
 
         mock_prompt.side_effect = [
-            "home",  # prefix for /home
             "/backup/home",  # target (not /mnt/)
-            "root",  # prefix for /
             "/backup/root",  # target (not /mnt/)
         ]
         mock_bool.side_effect = [
@@ -2220,7 +2232,11 @@ class TestDetectionWizard:
             "print",  # print config
         ]
 
-        exit_code = _run_detection_wizard(result)
+        with patch(
+            "btrfs_backup_ng.cli.config_cmd.prompt_snapshot_prefix",
+            side_effect=["home", "root"],  # prefix for /home, prefix for /
+        ):
+            exit_code = _run_detection_wizard(result)
 
         assert exit_code == 0
         captured = capsys.readouterr()
@@ -2258,7 +2274,6 @@ class TestDetectionWizard:
 
         mock_selection.return_value = [0]  # Select first volume
         mock_prompt.side_effect = [
-            "home",  # prefix
             "/backup",  # target (not /mnt/)
             "2d",  # min retention
         ]
@@ -2278,7 +2293,11 @@ class TestDetectionWizard:
             "print",  # print config
         ]
 
-        exit_code = _run_detection_wizard(result)
+        with patch(
+            "btrfs_backup_ng.cli.config_cmd.prompt_snapshot_prefix",
+            side_effect=["home"],  # prefix
+        ):
+            exit_code = _run_detection_wizard(result)
 
         assert exit_code == 0
         captured = capsys.readouterr()
@@ -2404,7 +2423,6 @@ path = "/backup"
 
         mock_selection.return_value = [0]  # Select first volume
         mock_prompt.side_effect = [
-            "home-new",  # different prefix
             "/backup/new",  # different target (not /mnt/)
         ]
         mock_bool.side_effect = [
@@ -2417,7 +2435,11 @@ path = "/backup"
             "cancel",  # cancel after seeing diff
         ]
 
-        exit_code = _run_detection_wizard(result)
+        with patch(
+            "btrfs_backup_ng.cli.config_cmd.prompt_snapshot_prefix",
+            side_effect=["home-new"],  # different prefix
+        ):
+            exit_code = _run_detection_wizard(result)
 
         assert exit_code == 0
         captured = capsys.readouterr()
@@ -2457,7 +2479,6 @@ path = "/backup"
 
         mock_selection.return_value = [0]  # Select first volume
         mock_prompt.side_effect = [
-            "home",  # prefix
             "/backup",  # target (not /mnt/)
             str(save_path),  # save path
         ]
@@ -2469,7 +2490,11 @@ path = "/backup"
             "save",  # save config
         ]
 
-        exit_code = _run_detection_wizard(result)
+        with patch(
+            "btrfs_backup_ng.cli.config_cmd.prompt_snapshot_prefix",
+            side_effect=["home"],  # prefix
+        ):
+            exit_code = _run_detection_wizard(result)
 
         assert exit_code == 0
         assert save_path.exists()

--- a/tests/test_wizard_utils.py
+++ b/tests/test_wizard_utils.py
@@ -19,6 +19,7 @@ from btrfs_backup_ng.cli.wizard_utils import (
     prompt_choice,
     prompt_int,
     prompt_selection,
+    prompt_snapshot_prefix,
 )
 
 
@@ -44,6 +45,25 @@ class TestPrompt:
         with mock.patch("rich.prompt.Prompt.ask", side_effect=KeyboardInterrupt):
             with pytest.raises(KeyboardInterrupt):
                 prompt("Enter value")
+
+
+class TestPromptSnapshotPrefix:
+    """Tests for prompt_snapshot_prefix (explicit empty prefix support)."""
+
+    def test_no_prefix_returns_empty(self):
+        # Answering "no" to the prefix question yields an explicit empty prefix.
+        with mock.patch("rich.prompt.Confirm.ask", return_value=False):
+            assert prompt_snapshot_prefix("home-") == ""
+
+    def test_yes_accepts_default_prefix(self):
+        with mock.patch("rich.prompt.Confirm.ask", return_value=True):
+            with mock.patch("rich.prompt.Prompt.ask", return_value="home-"):
+                assert prompt_snapshot_prefix("home-") == "home-"
+
+    def test_yes_accepts_custom_prefix(self):
+        with mock.patch("rich.prompt.Confirm.ask", return_value=True):
+            with mock.patch("rich.prompt.Prompt.ask", return_value="custom-"):
+                assert prompt_snapshot_prefix("home-") == "custom-"
 
 
 class TestPromptBool:


### PR DESCRIPTION
Closes #6. Completes the second half of mjg's #2 report: an empty `snapshot_prefix` was replaced by the auto-derived default (e.g. `home-` for `/home`), so bare-timestamp snapshot names could not be configured.

## What this does

- **schema:** `VolumeConfig.snapshot_prefix` defaults to `None`; `__post_init__` auto-derives from the path only when `None`, so an explicit `""` is preserved (typed `str` for consumers).
- **loader:** an absent key passes `None` (auto-derive); an explicit value, including `""`, is honored.
- **CLI (8 sites):** drop the `volume.snapshot_prefix or f"{hostname}-"` fallback that clobbered an empty prefix — the schema already resolves the value, and the fallback used an inconsistent hostname-based default.
- **config generation:** emit `snapshot_prefix` only when set, so an unset prefix round-trips to auto-derive.
- **wizard:** a new "Use a snapshot name prefix?" step makes an empty prefix reachable interactively, not just via hand-edited config.

## Behavior

- Unset/omitted prefix → auto-derived from the path, exactly as before (no change for existing users).
- Explicit `snapshot_prefix = ""` → bare-timestamp snapshot names.

## Validation

- Full suite green (1973 passed); new tests cover schema (empty preserved, unset derives), loader (TOML round-trip), and the wizard prefix helper.
- Adversarial review found no code defects; the two documentation findings (a CHANGELOG/migration note and an empty-prefix caveat about pairing with a strict `timestamp_format` + dedicated `snapshot_dir`) are addressed in the CHANGELOG and config reference.

*Migration note:* an existing config that sets `snapshot_prefix = ""` (rather than omitting the key) now yields bare-timestamp names instead of the previously auto-derived default. Omit the key to keep the derived prefix.