### PR TITLE
chore: Bump version to 0.8.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ where = ["src"]
 
 [project]
 name = "btrfs-backup-ng"
-version = "0.8.2"
+version = "0.8.3"
 description = "Complete btrfs backup solution with automated snapshots, incremental transfers, restore functionality, snapper integration, and systemd scheduling"
 authors = [{ name = "Michael Berry", email = "trismegustis@gmail.com" }]
 license = { file = "LICENSE" }

--- a/src/btrfs_backup_ng/__init__.py
+++ b/src/btrfs_backup_ng/__init__.py
@@ -1,8 +1,12 @@
 """btrfs-backup-ng: btrfs-backup_ng/__init__.py."""
 
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
-__version__ = "0.8.1"
+try:
+    __version__ = version("btrfs-backup-ng")
+except PackageNotFoundError:  # running from a source tree without an installed dist
+    __version__ = "0.0.0+unknown"
 
 
 def encode_path_for_dir(path: Path) -> str:


### PR DESCRIPTION
Release prep for 0.8.3.

- `pyproject.toml`: `0.8.2` → `0.8.3`.
- `__init__.py`: derive `__version__` from installed package metadata (`importlib.metadata.version`) instead of a hardcoded string. It was stale at `0.8.1` while pyproject was `0.8.2`; deriving from metadata means it can no longer drift and the version is bumped in one place.

Verified locally: the editable install rebuilds and `btrfs_backup_ng.__version__` resolves to `0.8.3`; full suite green (1973 passed).

0.8.3 closes #1, #2, and #6. After merge, a GitHub Release for `v0.8.3` triggers the PyPI publish workflow.