### PR TITLE
Honor timestamp_format across all commands (Closes #7, #8, #14, #15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.4] - 2026-07-19
+
+### Fixed
+
+#### timestamp_format honored across all commands
+- The configured `timestamp_format` is now applied consistently everywhere a snapshot name is generated or parsed, completing the work started in 0.8.3:
+  - **snapper backup** names (raw stream filenames and metadata sidecars) use the configured format on both entry paths (config-driven `run` and standalone `snapper backup`).
+  - **verify** and **restore** direct mode parse custom-named snapshots instead of silently skipping them (`verify` could otherwise report "all verified" while skipping); restore threads the same resolved format into both the source and destination endpoints, so skip-existing and incremental-base detection work on re-restore.
+  - **retention/prune** parse custom-format snapshot times, so custom-named snapshots are pruned instead of kept forever.
+  - **estimate** direct mode, **snapper status** (backed-up/pending counts), and **snapper list** (previewed name) honor the format.
+- New `--timestamp-format` flag on `snapper backup`/`list`/`status`, `verify`, `restore`, and `estimate`; otherwise the `[global] timestamp_format` is used.
+
+### Added
+- Mutation-verified enforcement tests that assert every command threads the configured `timestamp_format`, so a regression fails CI.
+
 ## [0.8.3] - 2026-07-18
 
 ### Added

--- a/src/btrfs_backup_ng/cli/common.py
+++ b/src/btrfs_backup_ng/cli/common.py
@@ -161,3 +161,26 @@ def get_timestamp_format(config=None) -> str:
     global_config = getattr(config, "global_config", None)
     fmt = getattr(global_config, "timestamp_format", None)
     return fmt or __util__.DATE_FORMAT
+
+
+def resolve_timestamp_format(explicit: str | None = None) -> str:
+    """Resolve the snapshot timestamp_format for direct-mode commands.
+
+    ``verify`` and ``restore`` operate on a location argument and may have no
+    config object, so without this they parse snapshot names with only the
+    default format and silently skip custom-named snapshots. An explicit
+    ``--timestamp-format`` wins; otherwise honor ``[global] timestamp_format``
+    from a discoverable config; else the built-in default.
+    """
+    if explicit:
+        return explicit
+    try:
+        from ..config import find_config_file, load_config
+
+        path = find_config_file(None)
+        if path is not None:
+            config, _ = load_config(path)
+            return get_timestamp_format(config)
+    except Exception:
+        pass
+    return __util__.DATE_FORMAT

--- a/src/btrfs_backup_ng/cli/dispatcher.py
+++ b/src/btrfs_backup_ng/cli/dispatcher.py
@@ -487,6 +487,12 @@ Config-driven restore:
         help="Snapshot prefix filter",
     )
     restore_parser.add_argument(
+        "--timestamp-format",
+        metavar="FMT",
+        help="strftime format for parsing snapshot timestamps in direct mode "
+        "(defaults to the config's [global] timestamp_format, else the built-in)",
+    )
+    restore_parser.add_argument(
         "--ssh-sudo",
         action="store_true",
         help="Use sudo for btrfs commands on remote host",
@@ -626,6 +632,12 @@ Examples:
         "--prefix",
         metavar="PREFIX",
         help="Snapshot prefix filter",
+    )
+    verify_parser.add_argument(
+        "--timestamp-format",
+        metavar="FMT",
+        help="strftime format for parsing snapshot timestamps in direct mode "
+        "(defaults to the config's [global] timestamp_format, else the built-in)",
     )
     verify_parser.add_argument(
         "--ssh-sudo",
@@ -777,6 +789,12 @@ Examples:
         "--ssh-key",
         metavar="FILE",
         help="SSH private key file",
+    )
+    estimate_parser.add_argument(
+        "--timestamp-format",
+        metavar="FMT",
+        help="strftime format for parsing snapshot timestamps in direct mode "
+        "(defaults to the config's [global] timestamp_format, else the built-in)",
     )
     add_fs_checks_args(estimate_parser)
     estimate_parser.add_argument(
@@ -1057,6 +1075,12 @@ Examples:
         action="store_true",
         help="Output in JSON format",
     )
+    snapper_list.add_argument(
+        "--timestamp-format",
+        metavar="FMT",
+        help="strftime format for the previewed backup_name "
+        "(defaults to the config's [global] timestamp_format)",
+    )
 
     # snapper backup
     snapper_backup = snapper_subs.add_parser(
@@ -1123,6 +1147,12 @@ Examples:
         metavar="RATE",
         help="Bandwidth limit (e.g., '10M', '1G')",
     )
+    snapper_backup.add_argument(
+        "--timestamp-format",
+        metavar="FMT",
+        help="strftime format for the timestamp in backup names "
+        "(default: %%Y%%m%%d-%%H%%M%%S)",
+    )
     add_progress_args(snapper_backup)
 
     # snapper status
@@ -1146,6 +1176,12 @@ Examples:
         "--json",
         action="store_true",
         help="Output in JSON format",
+    )
+    snapper_status.add_argument(
+        "--timestamp-format",
+        metavar="FMT",
+        help="strftime format used when the backups were written, so status "
+        "counts match (defaults to the config's [global] timestamp_format)",
     )
 
     # snapper restore

--- a/src/btrfs_backup_ng/cli/estimate.py
+++ b/src/btrfs_backup_ng/cli/estimate.py
@@ -27,7 +27,12 @@ from ..core.space import (
     check_space_availability,
     format_space_check,
 )
-from .common import get_fs_checks_mode, get_log_level, get_timestamp_format
+from .common import (
+    get_fs_checks_mode,
+    get_log_level,
+    get_timestamp_format,
+    resolve_timestamp_format,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -195,11 +200,15 @@ def _estimate_direct(args: argparse.Namespace, source: str, destination: str) ->
 
     # Prepare source endpoint
     fs_checks_mode = get_fs_checks_mode(args)
+    # Thread timestamp_format so custom-named snapshots are counted, not skipped
+    # (which would undercount and hide an existing incremental parent).
+    ts_fmt = resolve_timestamp_format(getattr(args, "timestamp_format", None))
 
     try:
         source_kwargs = {
             "snap_prefix": prefix,
             "fs_checks": fs_checks_mode,
+            "timestamp_format": ts_fmt,
         }
         if not source.startswith("ssh://"):
             source_kwargs["path"] = Path(source).resolve()
@@ -219,6 +228,7 @@ def _estimate_direct(args: argparse.Namespace, source: str, destination: str) ->
         dest_kwargs = {
             "snap_prefix": prefix,
             "fs_checks": fs_checks_mode,
+            "timestamp_format": ts_fmt,
         }
         if ssh_sudo:
             dest_kwargs["ssh_sudo"] = True

--- a/src/btrfs_backup_ng/cli/prune.py
+++ b/src/btrfs_backup_ng/cli/prune.py
@@ -143,6 +143,7 @@ def execute_prune(args: argparse.Namespace) -> int:
                     retention,
                     get_name=lambda s: s.get_name(),
                     prefix=prefix,
+                    timestamp_format=get_timestamp_format(config),
                 )
 
                 logger.info("  Keeping %d, deleting %d", len(to_keep), len(to_delete))
@@ -196,6 +197,7 @@ def execute_prune(args: argparse.Namespace) -> int:
                         retention,
                         get_name=lambda s: s.get_name(),
                         prefix=prefix,
+                        timestamp_format=get_timestamp_format(config),
                     )
 
                     logger.info(

--- a/src/btrfs_backup_ng/cli/restore.py
+++ b/src/btrfs_backup_ng/cli/restore.py
@@ -20,7 +20,12 @@ from ..core.restore import (
     restore_snapshots,
     validate_restore_destination,
 )
-from .common import get_fs_checks_mode, get_log_level, should_show_progress
+from .common import (
+    get_fs_checks_mode,
+    get_log_level,
+    resolve_timestamp_format,
+    should_show_progress,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -291,9 +296,14 @@ def _execute_main_restore(args: argparse.Namespace) -> int:
         logger.error("Failed to prepare backup endpoint: %s", e)
         return 1
 
-    # Prepare local endpoint (destination)
+    # Prepare local endpoint (destination). Resolve the SAME timestamp_format the
+    # backup (source) endpoint uses so already-restored custom-named snapshots are
+    # recognized (skip-existing + incremental-base detection).
     try:
-        local_endpoint = _prepare_local_endpoint(dest_path)
+        local_endpoint = _prepare_local_endpoint(
+            dest_path,
+            resolve_timestamp_format(getattr(args, "timestamp_format", None)),
+        )
     except Exception as e:
         logger.error("Failed to prepare local endpoint: %s", e)
         return 1
@@ -421,13 +431,17 @@ def _prepare_backup_endpoint(args: argparse.Namespace, source: str):
     Returns:
         Configured endpoint
     """
-    # Build endpoint kwargs
+    # Build endpoint kwargs. Thread timestamp_format so custom-named snapshots
+    # are parsed rather than silently skipped when listing/matching backups.
     endpoint_kwargs = {
         "snap_prefix": getattr(args, "prefix", "") or "",
         "convert_rw": False,
         "subvolume_sync": False,
         "btrfs_debug": False,
         "fs_checks": get_fs_checks_mode(args),
+        "timestamp_format": resolve_timestamp_format(
+            getattr(args, "timestamp_format", None)
+        ),
     }
 
     # SSH options
@@ -457,11 +471,15 @@ def _prepare_backup_endpoint(args: argparse.Namespace, source: str):
     return backup_ep
 
 
-def _prepare_local_endpoint(dest_path: Path):
+def _prepare_local_endpoint(dest_path: Path, timestamp_format: str | None = None):
     """Prepare the local endpoint for receiving restored snapshots.
 
     Args:
         dest_path: Local destination path
+        timestamp_format: Format for parsing names of snapshots already at the
+            destination, so skip-existing and incremental-base detection see
+            custom-named snapshots instead of silently dropping them. Must match
+            the format the backup (source) endpoint uses.
 
     Returns:
         Configured local endpoint
@@ -479,6 +497,7 @@ def _prepare_local_endpoint(dest_path: Path):
         "subvolume_sync": False,
         "btrfs_debug": False,
         "fs_checks": "auto",
+        "timestamp_format": timestamp_format,
     }
 
     local_ep = LocalEndpoint(config=endpoint_kwargs)

--- a/src/btrfs_backup_ng/cli/run.py
+++ b/src/btrfs_backup_ng/cli/run.py
@@ -525,6 +525,7 @@ def _backup_snapper_volume(
             snapper_endpoint_config: dict[str, Any] = {
                 "path": target.path,
                 "snap_prefix": "",
+                "timestamp_format": get_timestamp_format(config),
             }
             if target.ssh_sudo:
                 snapper_endpoint_config["ssh_sudo"] = True

--- a/src/btrfs_backup_ng/cli/snapper_cmd.py
+++ b/src/btrfs_backup_ng/cli/snapper_cmd.py
@@ -13,7 +13,7 @@ from typing import Any, cast
 from ..__logger__ import create_logger
 from ..snapper import SnapperScanner
 from ..snapper.scanner import SnapperNotFoundError
-from .common import get_log_level
+from .common import get_log_level, resolve_timestamp_format
 
 logger = logging.getLogger(__name__)
 
@@ -130,6 +130,10 @@ def _handle_list(args: argparse.Namespace) -> int:
     # Get type filter
     include_types = args.type if args.type else None
 
+    # Backup names honor --timestamp-format (else [global] config) so the
+    # displayed name matches what a backup would write on disk.
+    backup_fmt = resolve_timestamp_format(getattr(args, "timestamp_format", None))
+
     all_data: list[dict[str, Any]] = []
 
     for config in configs:
@@ -150,7 +154,7 @@ def _handle_list(args: argparse.Namespace) -> int:
                     "description": s.description,
                     "cleanup": s.cleanup,
                     "pre_num": s.pre_num,
-                    "backup_name": s.get_backup_name(),
+                    "backup_name": s.get_backup_name(backup_fmt),
                 }
                 for s in snapshots
             ],
@@ -218,7 +222,14 @@ def _handle_backup(args: argparse.Namespace) -> int:
     # targets are parsed correctly instead of being treated as local paths.
     from ..endpoint import choose_endpoint
 
-    endpoint_config: dict[str, Any] = {"path": target_path, "snap_prefix": ""}
+    endpoint_config: dict[str, Any] = {
+        "path": target_path,
+        "snap_prefix": "",
+        # Honor --timestamp-format, else [global] config, else the default.
+        "timestamp_format": resolve_timestamp_format(
+            getattr(args, "timestamp_format", None)
+        ),
+    }
     # Thread SSH options so ssh:// (remote btrfs receive) and raw+ssh:// targets
     # honor --ssh-sudo / --ssh-key.
     if getattr(args, "ssh_sudo", False):
@@ -360,8 +371,16 @@ def _handle_status(args: argparse.Namespace) -> int:
 
     # If target specified, check backup status there
     if args.target:
+        # Resolve the format the same way `snapper backup` does, so the local
+        # names we recompute match the on-disk backup filenames (else the
+        # backed-up/pending counts are wrong under a custom timestamp_format).
+        status_fmt = resolve_timestamp_format(getattr(args, "timestamp_format", None))
         try:
-            endpoint_config = {"path": args.target, "snap_prefix": ""}
+            endpoint_config = {
+                "path": args.target,
+                "snap_prefix": "",
+                "timestamp_format": status_fmt,
+            }
             endpoint = choose_endpoint(endpoint_config["path"], endpoint_config)
             backed_up = _list_snapper_backups_at_destination(endpoint)
         except Exception as e:
@@ -379,7 +398,7 @@ def _handle_status(args: argparse.Namespace) -> int:
                 snapshots = []
 
             # Count backed up vs not backed up
-            snapshot_names = {s.get_backup_name() for s in snapshots}
+            snapshot_names = {s.get_backup_name(status_fmt) for s in snapshots}
             backed_up_count = len(snapshot_names & backed_up)
             not_backed_up = len(snapshot_names) - backed_up_count
 

--- a/src/btrfs_backup_ng/cli/verify.py
+++ b/src/btrfs_backup_ng/cli/verify.py
@@ -15,7 +15,7 @@ from ..core.verify import (
     verify_metadata,
     verify_stream,
 )
-from .common import get_fs_checks_mode
+from .common import get_fs_checks_mode, resolve_timestamp_format
 
 logger = logging.getLogger(__name__)
 console = Console()
@@ -33,13 +33,17 @@ def execute(args: argparse.Namespace) -> int:
     # Determine verification level
     level = VerifyLevel(args.level)
 
-    # Build endpoint kwargs
+    # Build endpoint kwargs. Thread timestamp_format so custom-named snapshots
+    # are parsed (otherwise verify silently skips them and can report success).
     endpoint_kwargs = {
         "snap_prefix": args.prefix or "",
         "convert_rw": False,
         "subvolume_sync": False,
         "btrfs_debug": False,
         "fs_checks": get_fs_checks_mode(args),
+        "timestamp_format": resolve_timestamp_format(
+            getattr(args, "timestamp_format", None)
+        ),
     }
 
     # SSH options

--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -1410,9 +1410,11 @@ def send_snapper_snapshot(
 
     # Wrap the snapper snapshots so the standard send/receive pipeline can carry
     # them (the wrapper's source is a LocalEndpoint on the snapper subvolume).
-    source_wrapper = _create_snapper_snapshot_wrapper(snapper_snapshot)
+    source_wrapper = _create_snapper_snapshot_wrapper(
+        snapper_snapshot, destination_endpoint
+    )
     parent_wrapper = (
-        _create_snapper_snapshot_wrapper(parent_snapper_snapshot)
+        _create_snapper_snapshot_wrapper(parent_snapper_snapshot, destination_endpoint)
         if parent_snapper_snapshot
         else None
     )
@@ -1493,15 +1495,22 @@ def _create_snapper_snapshot_wrapper(snapper_snapshot, destination_endpoint=None
 
     Args:
         snapper_snapshot: SnapperSnapshot object
-        destination_endpoint: Optional destination endpoint (not used for source)
+        destination_endpoint: Destination endpoint; its configured
+            timestamp_format is applied to the backup name (default when None)
 
     Returns:
         __util__.Snapshot wrapper object with a local source endpoint
     """
     from ..endpoint.local import LocalEndpoint
 
-    # The backup name follows the format: {config}-{number}-{date}
-    backup_name = snapper_snapshot.get_backup_name()
+    # The backup name follows the format: {config}-{number}-{date}, honoring the
+    # destination's configured timestamp_format (default when no endpoint given).
+    date_format = (
+        destination_endpoint.config.get("timestamp_format")
+        if destination_endpoint is not None
+        else None
+    )
+    backup_name = snapper_snapshot.get_backup_name(date_format)
 
     # Parse the date from snapper snapshot
     time_obj = snapper_snapshot.date.timetuple()
@@ -1567,7 +1576,9 @@ def _write_snapper_metadata(snapper_snapshot, destination_endpoint) -> None:
     )
 
     # Determine metadata file path at destination
-    backup_name = snapper_snapshot.get_backup_name()
+    backup_name = snapper_snapshot.get_backup_name(
+        destination_endpoint.config.get("timestamp_format")
+    )
     dest_path = Path(destination_endpoint.config["path"])
     meta_file = dest_path / f"{backup_name}.snapper-meta.json"
 
@@ -1776,34 +1787,3 @@ def _list_snapper_backups_at_destination(endpoint) -> set[str]:
             logger.warning("Could not list local backups: %s", e)
 
     return backup_names
-
-
-def _find_snapper_parent(
-    snapshot,
-    all_snapshots: list,
-    backed_up_names: set[str],
-):
-    """Find the best parent snapshot for incremental transfer.
-
-    Args:
-        snapshot: SnapperSnapshot to find parent for
-        all_snapshots: All available snapper snapshots
-        backed_up_names: Names of snapshots already at destination
-
-    Returns:
-        SnapperSnapshot to use as parent, or None
-    """
-    # Find snapshots that are both older than target and already backed up
-    candidates = [
-        s
-        for s in all_snapshots
-        if s.number < snapshot.number
-        and s.config_name == snapshot.config_name
-        and s.get_backup_name() in backed_up_names
-    ]
-
-    if not candidates:
-        return None
-
-    # Return the most recent candidate (highest number)
-    return max(candidates, key=lambda s: s.number)

--- a/src/btrfs_backup_ng/retention.py
+++ b/src/btrfs_backup_ng/retention.py
@@ -100,14 +100,19 @@ class SnapshotInfo:
     keep_reason: str = ""
 
 
-def extract_timestamp(snapshot_name: str, prefix: str = "") -> datetime | None:
+def extract_timestamp(
+    snapshot_name: str, prefix: str = "", preferred_fmt: str | None = None
+) -> datetime | None:
     """Extract timestamp from snapshot name.
 
-    Tries multiple common timestamp formats.
+    ``preferred_fmt`` (the configured ``timestamp_format``) is tried first when
+    given, so snapshots named with a custom format parse correctly; a list of
+    common formats is tried as a fallback.
 
     Args:
         snapshot_name: Name of the snapshot
         prefix: Optional prefix to strip
+        preferred_fmt: Configured timestamp_format to try before the fallbacks
 
     Returns:
         datetime if parsed successfully, None otherwise
@@ -116,7 +121,7 @@ def extract_timestamp(snapshot_name: str, prefix: str = "") -> datetime | None:
     if prefix and name.startswith(prefix):
         name = name[len(prefix) :]
 
-    # Common timestamp formats
+    # Common timestamp formats (fallbacks).
     formats = [
         "%Y%m%d-%H%M%S",  # 20240115-143022
         "%Y-%m-%d_%H%M%S",  # 2024-01-15_143022
@@ -124,6 +129,9 @@ def extract_timestamp(snapshot_name: str, prefix: str = "") -> datetime | None:
         "%Y%m%d%H%M%S",  # 20240115143022
         "%Y-%m-%dT%H:%M:%S",  # 2024-01-15T14:30:22
     ]
+    # Configured format takes precedence so custom-named snapshots parse.
+    if preferred_fmt and preferred_fmt not in formats:
+        formats.insert(0, preferred_fmt)
 
     for fmt in formats:
         try:
@@ -184,6 +192,7 @@ def apply_retention(
     get_name: Callable[[Any], str] | None = None,
     prefix: str = "",
     now: datetime | None = None,
+    timestamp_format: str | None = None,
 ) -> tuple[list, list]:
     """Apply retention policy to a list of snapshots.
 
@@ -193,6 +202,8 @@ def apply_retention(
         get_name: Function to get name from snapshot (default: str(snapshot))
         prefix: Snapshot name prefix to strip for timestamp parsing
         now: Current time (default: datetime.now())
+        timestamp_format: Configured timestamp_format, tried first when parsing
+            snapshot times so custom-named snapshots are bucketed (not kept forever)
 
     Returns:
         Tuple of (snapshots_to_keep, snapshots_to_delete)
@@ -219,7 +230,7 @@ def apply_retention(
     snapshot_infos: list[SnapshotInfo] = []
     for snap in snapshots:
         name = name_func(snap)
-        timestamp = extract_timestamp(name, prefix)
+        timestamp = extract_timestamp(name, prefix, timestamp_format)
 
         if timestamp is None:
             # Can't parse timestamp, keep it to be safe

--- a/src/btrfs_backup_ng/snapper/snapshot.py
+++ b/src/btrfs_backup_ng/snapper/snapshot.py
@@ -57,18 +57,19 @@ class SnapperSnapshot:
         """For 'post' snapshots, the paired 'pre' snapshot number."""
         return self.metadata.pre_num
 
-    def get_backup_name(self, date_format: str = "%Y%m%d-%H%M%S") -> str:
+    def get_backup_name(self, date_format: str | None = None) -> str:
         """Generate backup name for this snapshot.
 
         Format: {config_name}-{number}-{date}
 
         Args:
-            date_format: strftime format for the date portion
+            date_format: strftime format for the date portion; the configured
+                timestamp_format, or the built-in default when None
 
         Returns:
             Backup name string
         """
-        date_str = self.metadata.date.strftime(date_format)
+        date_str = self.metadata.date.strftime(date_format or "%Y%m%d-%H%M%S")
         return f"{self.config_name}-{self.number}-{date_str}"
 
     def exists(self) -> bool:

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -13,6 +13,7 @@ from btrfs_backup_ng.cli.common import (
     get_log_level,
     get_timestamp_format,
     is_interactive,
+    resolve_timestamp_format,
     should_show_progress,
 )
 
@@ -35,6 +36,29 @@ class TestGetTimestampFormat:
         config = MagicMock()
         config.global_config.timestamp_format = ""
         assert get_timestamp_format(config) == DATE_FORMAT
+
+
+class TestResolveTimestampFormat:
+    """Tests for resolve_timestamp_format (verify/restore direct mode)."""
+
+    def test_explicit_wins(self):
+        """An explicit format is returned as-is without touching config."""
+        assert resolve_timestamp_format("%Y/%m/%d") == "%Y/%m/%d"
+
+    def test_no_config_falls_back_to_default(self):
+        """With no discoverable config, the built-in default is used."""
+        with patch("btrfs_backup_ng.config.find_config_file", return_value=None):
+            assert resolve_timestamp_format(None) == DATE_FORMAT
+
+    def test_falls_back_to_global_config(self):
+        """With no explicit flag, the config's [global] timestamp_format is used."""
+        cfg = MagicMock()
+        cfg.global_config.timestamp_format = "%Y%m%dT%H%M%S"
+        with (
+            patch("btrfs_backup_ng.config.find_config_file", return_value="/cfg.toml"),
+            patch("btrfs_backup_ng.config.load_config", return_value=(cfg, [])),
+        ):
+            assert resolve_timestamp_format(None) == "%Y%m%dT%H%M%S"
 
 
 class TestCreateGlobalParser:

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -2429,6 +2429,18 @@ class TestPrepareLocalEndpoint:
         assert dest.exists()
 
     @patch("btrfs_backup_ng.endpoint.local.LocalEndpoint")
+    def test_threads_timestamp_format(self, mock_local_ep, tmp_path):
+        """The timestamp_format is threaded into the destination endpoint config so
+        already-restored custom-named snapshots are recognized (skip-existing and
+        incremental-base detection) instead of silently dropped."""
+        from btrfs_backup_ng.cli.restore import _prepare_local_endpoint
+
+        _prepare_local_endpoint(tmp_path / "dest", "%Y%m%dT%H%M%S")
+
+        config = mock_local_ep.call_args.kwargs["config"]
+        assert config["timestamp_format"] == "%Y%m%dT%H%M%S"
+
+    @patch("btrfs_backup_ng.endpoint.local.LocalEndpoint")
     def test_calls_prepare(self, mock_local_ep, tmp_path):
         """Test local endpoint prepare is called."""
         from btrfs_backup_ng.cli.restore import _prepare_local_endpoint

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -122,6 +122,23 @@ class TestExtractTimestamp:
         result = extract_timestamp("snapshot-without-date")
         assert result is None
 
+    def test_preferred_format_parses_custom_names(self):
+        """A custom timestamp_format not in the built-in list is honored when
+        passed as preferred_fmt, so retention buckets it instead of keeping it
+        forever."""
+        # Custom format with a 'T' separator and no seconds -> not in the fallbacks.
+        name = "home-2024-01-15T1430"
+        assert extract_timestamp(name, prefix="home-") is None
+        result = extract_timestamp(name, prefix="home-", preferred_fmt="%Y-%m-%dT%H%M")
+        assert result is not None
+        assert (result.year, result.month, result.day, result.hour, result.minute) == (
+            2024,
+            1,
+            15,
+            14,
+            30,
+        )
+
     def test_extract_invalid_timestamp(self):
         """Test extracting invalid timestamp."""
         result = extract_timestamp("home-99999999-999999")

--- a/tests/test_snapper_metadata.py
+++ b/tests/test_snapper_metadata.py
@@ -15,6 +15,78 @@ from btrfs_backup_ng.snapper.metadata import (
 )
 
 
+class TestSnapperSnapshotBackupName:
+    """SnapperSnapshot.get_backup_name honors the configured timestamp_format (#7)."""
+
+    @staticmethod
+    def _snapshot():
+        from pathlib import Path
+        from unittest.mock import MagicMock
+
+        from btrfs_backup_ng.snapper.snapshot import SnapperSnapshot
+
+        meta = MagicMock()
+        meta.date = datetime(2024, 1, 15, 14, 30, 22)
+        return SnapperSnapshot(
+            config_name="root",
+            number=7,
+            metadata=meta,
+            subvolume_path=Path("/snap"),
+            info_xml_path=Path("/snap/info.xml"),
+        )
+
+    def test_default_format(self):
+        assert self._snapshot().get_backup_name() == "root-7-20240115-143022"
+
+    def test_honors_configured_format(self):
+        assert (
+            self._snapshot().get_backup_name("%Y%m%dT%H%M%S")
+            == "root-7-20240115T143022"
+        )
+
+
+class TestCreateSnapperSnapshotWrapper:
+    """The real wrapper is null-safe and honors the endpoint's timestamp_format.
+
+    Regression guard for the #7 blocker: the wrapper dereferenced a None
+    destination_endpoint, crashing every snapper backup. The snapper_cmd tests
+    mock the wrapper out, so this exercises the REAL function.
+    """
+
+    @staticmethod
+    def _snap(tmp_path):
+        from unittest.mock import MagicMock
+
+        from btrfs_backup_ng.snapper.snapshot import SnapperSnapshot
+
+        meta = MagicMock()
+        meta.date = datetime(2024, 1, 15, 14, 30, 22)
+        sub = tmp_path / "snapshot"
+        sub.mkdir()
+        return SnapperSnapshot(
+            config_name="root",
+            number=7,
+            metadata=meta,
+            subvolume_path=sub,
+            info_xml_path=sub.parent / "info.xml",
+        )
+
+    def test_none_endpoint_does_not_crash(self, tmp_path):
+        from btrfs_backup_ng.core.operations import _create_snapper_snapshot_wrapper
+
+        wrapper = _create_snapper_snapshot_wrapper(self._snap(tmp_path))
+        assert wrapper.get_name() == "root-7-20240115-143022"
+
+    def test_honors_endpoint_timestamp_format(self, tmp_path):
+        from types import SimpleNamespace
+
+        from btrfs_backup_ng.core.operations import _create_snapper_snapshot_wrapper
+
+        ep = SimpleNamespace(config={"timestamp_format": "%Y%m%dT%H%M%S"})
+        wrapper = _create_snapper_snapshot_wrapper(self._snap(tmp_path), ep)
+        assert wrapper.get_name() == "root-7-20240115T143022"
+
+
 class TestSnapperMetadata:
     """Tests for SnapperMetadata dataclass."""
 

--- a/tests/test_timestamp_format_enforcement.py
+++ b/tests/test_timestamp_format_enforcement.py
@@ -1,0 +1,590 @@
+"""Enforcement tests: every command threads the configured timestamp_format.
+
+Each test exercises a real command code path and captures the configuration that
+reaches the endpoint (or the retention/naming call), then asserts a DISTINCTIVE
+CUSTOM format value -- ``%Y%m%dT%H%M%S`` -- is present rather than the built-in
+default ``%Y%m%d-%H%M%S``.
+
+Asserting the custom value specifically is what makes these tests ENFORCING: if a
+future change stops threading ``timestamp_format`` (dropping the line, or reverting
+a ``get_backup_name(fmt)`` call to ``get_backup_name()``), the captured value falls
+back to the default and the test fails.
+"""
+
+import argparse
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from btrfs_backup_ng.config.schema import (
+    Config,
+    GlobalConfig,
+    TargetConfig,
+    VolumeConfig,
+)
+
+# Distinctive value that is NOT the built-in default "%Y%m%d-%H%M%S".
+CUSTOM_FMT = "%Y%m%dT%H%M%S"
+DEFAULT_FMT = "%Y%m%d-%H%M%S"
+
+
+def _custom_config(volumes=None) -> Config:
+    """Build a Config whose [global] timestamp_format is the custom value."""
+    return Config(
+        global_config=GlobalConfig(timestamp_format=CUSTOM_FMT),
+        volumes=volumes or [],
+    )
+
+
+def _native_volume() -> VolumeConfig:
+    """A native (non-snapper) volume with one local target."""
+    return VolumeConfig(
+        path="/data",
+        snapshot_prefix="data-",
+        snapshot_dir=".snapshots",
+        targets=[TargetConfig(path="/mnt/backup")],
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. verify
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyThreadsTimestampFormat:
+    """cli/verify.execute() puts timestamp_format into endpoint_kwargs."""
+
+    @patch("btrfs_backup_ng.cli.verify.verify_metadata")
+    @patch("btrfs_backup_ng.cli.verify.endpoint.choose_endpoint")
+    def test_endpoint_kwargs_carry_custom_format(self, mock_choose, mock_verify):
+        from btrfs_backup_ng.core.verify import VerifyLevel, VerifyReport
+
+        mock_choose.return_value = MagicMock()
+        report = VerifyReport(level=VerifyLevel.METADATA, location="/backup")
+        report.completed_at = report.started_at
+        mock_verify.return_value = report
+
+        args = argparse.Namespace(
+            level="metadata",
+            location="/backup",
+            prefix="",
+            fs_checks="auto",
+            snapshot=None,
+            quiet=True,
+            json=False,
+            temp_dir=None,
+            no_cleanup=False,
+            timestamp_format=CUSTOM_FMT,
+        )
+
+        from btrfs_backup_ng.cli.verify import execute
+
+        execute(args)
+
+        endpoint_kwargs = mock_choose.call_args[0][1]
+        assert endpoint_kwargs["timestamp_format"] == CUSTOM_FMT
+
+
+# ---------------------------------------------------------------------------
+# 2. restore: _prepare_backup_endpoint + main restore (local + backup)
+# ---------------------------------------------------------------------------
+
+
+class TestRestoreThreadsTimestampFormat:
+    """cli/restore threads timestamp_format into backup and local endpoints."""
+
+    @patch("btrfs_backup_ng.cli.restore.endpoint.choose_endpoint")
+    def test_backup_endpoint_config_carries_custom_format(self, mock_choose, tmp_path):
+        mock_choose.return_value = MagicMock()
+
+        args = MagicMock()
+        args.prefix = ""
+        args.fs_checks = "auto"
+        args.timestamp_format = CUSTOM_FMT
+
+        from btrfs_backup_ng.cli.restore import _prepare_backup_endpoint
+
+        _prepare_backup_endpoint(args, str(tmp_path))
+
+        endpoint_kwargs = mock_choose.call_args[0][1]
+        assert endpoint_kwargs["timestamp_format"] == CUSTOM_FMT
+
+    @patch("btrfs_backup_ng.cli.restore.restore_snapshots")
+    @patch("btrfs_backup_ng.cli.restore._prepare_local_endpoint")
+    @patch("btrfs_backup_ng.cli.restore._prepare_backup_endpoint")
+    @patch("btrfs_backup_ng.cli.restore.validate_restore_destination")
+    def test_local_endpoint_receives_custom_format(
+        self, mock_validate, mock_backup, mock_local, mock_restore, tmp_path
+    ):
+        """The main restore path resolves the same custom format and passes it as
+        the second positional arg to _prepare_local_endpoint."""
+        mock_backup.return_value = MagicMock()
+        mock_local.return_value = MagicMock()
+        mock_restore.return_value = {"failed": 0}
+
+        args = MagicMock()
+        args.source = "/backup"
+        args.destination = str(tmp_path / "dest")
+        args.in_place = False
+        args.yes_i_know_what_i_am_doing = False
+        args.timestamp_format = CUSTOM_FMT
+        args.before = None
+        args.dry_run = True
+        args.snapshot = None
+        args.all = False
+        args.overwrite = False
+        args.no_incremental = False
+        args.interactive = False
+        args.compress = None
+        args.rate_limit = None
+
+        from btrfs_backup_ng.cli.restore import _execute_main_restore
+
+        _execute_main_restore(args)
+
+        # _prepare_local_endpoint(dest_path, timestamp_format)
+        assert mock_local.call_args[0][1] == CUSTOM_FMT
+
+
+# ---------------------------------------------------------------------------
+# 3. estimate: _estimate_direct (BOTH source and dest)
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateDirectThreadsTimestampFormat:
+    """cli/estimate._estimate_direct threads it into source AND dest kwargs."""
+
+    @patch("btrfs_backup_ng.cli.estimate.print_estimate")
+    @patch("btrfs_backup_ng.cli.estimate.estimate_transfer")
+    @patch("btrfs_backup_ng.cli.estimate.endpoint")
+    def test_both_endpoints_carry_custom_format(
+        self, mock_endpoint, mock_estimate, mock_print, tmp_path
+    ):
+        mock_endpoint.choose_endpoint.return_value = MagicMock()
+        mock_estimate.return_value = MagicMock()
+
+        args = MagicMock()
+        args.json = False
+        args.prefix = ""
+        args.ssh_sudo = False
+        args.ssh_key = None
+        args.no_fs_checks = False
+        args.fs_checks = "auto"
+        args.check_space = False
+        args.timestamp_format = CUSTOM_FMT
+
+        from btrfs_backup_ng.cli.estimate import _estimate_direct
+
+        _estimate_direct(args, str(tmp_path / "source"), str(tmp_path / "dest"))
+
+        calls = mock_endpoint.choose_endpoint.call_args_list
+        assert len(calls) == 2
+        source_kwargs = calls[0][0][1]
+        dest_kwargs = calls[1][0][1]
+        assert source_kwargs["timestamp_format"] == CUSTOM_FMT
+        assert dest_kwargs["timestamp_format"] == CUSTOM_FMT
+
+
+# ---------------------------------------------------------------------------
+# 4. prune: endpoint kwargs AND apply_retention(timestamp_format=...)
+# ---------------------------------------------------------------------------
+
+
+class TestPruneThreadsTimestampFormat:
+    """cli/prune threads it into endpoint kwargs and the apply_retention call."""
+
+    @patch("btrfs_backup_ng.cli.prune.apply_retention")
+    @patch("btrfs_backup_ng.cli.prune.endpoint.choose_endpoint")
+    @patch("btrfs_backup_ng.cli.prune.load_config")
+    @patch("btrfs_backup_ng.cli.prune.find_config_file")
+    def test_endpoint_and_retention_carry_custom_format(
+        self, mock_find, mock_load, mock_choose, mock_retention, tmp_path
+    ):
+        # Real snapshot dir so the source-prune branch runs.
+        snap_dir = tmp_path / ".snapshots"
+        snap_dir.mkdir()
+        volume = VolumeConfig(
+            path=str(tmp_path),
+            snapshot_prefix="data-",
+            snapshot_dir=".snapshots",
+            targets=[TargetConfig(path="/mnt/backup")],
+        )
+        config = _custom_config([volume])
+
+        mock_find.return_value = str(tmp_path / "config.toml")
+        mock_load.return_value = (config, [])
+
+        # An endpoint that reports one snapshot so apply_retention is invoked.
+        ep = MagicMock()
+        ep.list_snapshots.return_value = [MagicMock()]
+        mock_choose.return_value = ep
+        mock_retention.return_value = ([], [])
+
+        args = MagicMock()
+        args.config = None
+        args.dry_run = True
+
+        from btrfs_backup_ng.cli.prune import execute_prune
+
+        execute_prune(args)
+
+        # EVERY endpoint (source and target) carries the format.
+        assert mock_choose.call_args_list  # sanity: at least one endpoint built
+        for call in mock_choose.call_args_list:
+            assert call[0][1]["timestamp_format"] == CUSTOM_FMT
+
+        # EVERY apply_retention call (source and target) uses the configured format.
+        assert mock_retention.call_args_list  # sanity: retention actually applied
+        for call in mock_retention.call_args_list:
+            assert call.kwargs["timestamp_format"] == CUSTOM_FMT
+
+
+# ---------------------------------------------------------------------------
+# 5. run: native volume endpoint kwargs AND snapper-volume endpoint config
+# ---------------------------------------------------------------------------
+
+
+class TestRunThreadsTimestampFormat:
+    """cli/run threads it into native and snapper-volume endpoint configs."""
+
+    @patch("btrfs_backup_ng.cli.run.endpoint.choose_endpoint")
+    @patch("btrfs_backup_ng.cli.run.load_config")
+    @patch("btrfs_backup_ng.cli.run.find_config_file")
+    def test_native_volume_endpoint_carries_custom_format(
+        self, mock_find, mock_load, mock_choose, tmp_path
+    ):
+        volume = VolumeConfig(
+            path=str(tmp_path / "data"),
+            snapshot_prefix="data-",
+            snapshot_dir=".snapshots",
+            targets=[],  # No targets: snapshot created, no transfer -> success.
+        )
+        config = _custom_config([volume])
+
+        mock_find.return_value = str(tmp_path / "config.toml")
+        mock_load.return_value = (config, [])
+
+        source_ep = MagicMock()
+        source_ep.snapshot.return_value = MagicMock()
+        mock_choose.return_value = source_ep
+
+        args = MagicMock()
+        args.config = None
+        args.dry_run = False
+        args.parallel_volumes = 1
+        args.parallel_targets = 1
+        args.compress = None
+        args.rate_limit = None
+        args.progress = False
+        args.no_progress = True
+        args.quiet = True
+
+        from btrfs_backup_ng.cli.run import execute_run
+
+        execute_run(args)
+
+        source_kwargs = mock_choose.call_args_list[0][0][1]
+        assert source_kwargs["timestamp_format"] == CUSTOM_FMT
+
+    @patch("btrfs_backup_ng.core.operations.sync_snapper_snapshots")
+    @patch("btrfs_backup_ng.cli.run.endpoint.choose_endpoint")
+    def test_snapper_volume_endpoint_config_carries_custom_format(
+        self, mock_choose, mock_sync
+    ):
+        """_backup_snapper_volume builds the destination endpoint config with the
+        configured timestamp_format."""
+        from btrfs_backup_ng.snapper.scanner import SnapperConfig
+
+        volume = VolumeConfig(path="/", snapshot_prefix="root-")
+        # Make it a snapper source with one target.
+        volume.source = "snapper"  # type: ignore[attr-defined]
+        volume.snapper = MagicMock(config_name="root")  # type: ignore[attr-defined]
+        volume.targets = [TargetConfig(path="/mnt/backup")]
+        config = _custom_config([volume])
+
+        mock_choose.return_value = MagicMock(_is_remote=False)
+        mock_sync.return_value = 1
+
+        with patch("btrfs_backup_ng.snapper.SnapperScanner") as mock_scanner_cls:
+            scanner = MagicMock()
+            scanner.find_config_for_path.return_value = SnapperConfig(
+                name="root", subvolume=Path("/")
+            )
+            mock_scanner_cls.return_value = scanner
+
+            from btrfs_backup_ng.cli.run import _backup_snapper_volume
+
+            _backup_snapper_volume(volume, config)
+
+        snapper_endpoint_config = mock_choose.call_args[0][1]
+        assert snapper_endpoint_config["timestamp_format"] == CUSTOM_FMT
+
+
+# ---------------------------------------------------------------------------
+# 6. snapshot / list / status / transfer: endpoint kwargs
+# ---------------------------------------------------------------------------
+
+
+class TestConfigDrivenCommandsThreadTimestampFormat:
+    """snapshot, list, status, transfer each build endpoint_kwargs with it."""
+
+    @patch("btrfs_backup_ng.cli.snapshot.endpoint.choose_endpoint")
+    @patch("btrfs_backup_ng.cli.snapshot.load_config")
+    @patch("btrfs_backup_ng.cli.snapshot.find_config_file")
+    def test_snapshot_endpoint_carries_custom_format(
+        self, mock_find, mock_load, mock_choose, tmp_path
+    ):
+        volume = VolumeConfig(
+            path=str(tmp_path / "data"),
+            snapshot_prefix="data-",
+            snapshot_dir=".snapshots",
+        )
+        mock_find.return_value = str(tmp_path / "config.toml")
+        mock_load.return_value = (_custom_config([volume]), [])
+
+        ep = MagicMock()
+        ep.snapshot.return_value = MagicMock()
+        mock_choose.return_value = ep
+
+        args = MagicMock()
+        args.config = None
+        args.volume = None
+        args.dry_run = False
+
+        from btrfs_backup_ng.cli.snapshot import execute_snapshot
+
+        execute_snapshot(args)
+
+        endpoint_kwargs = mock_choose.call_args_list[0][0][1]
+        assert endpoint_kwargs["timestamp_format"] == CUSTOM_FMT
+
+    @patch("btrfs_backup_ng.cli.list_cmd.endpoint.choose_endpoint")
+    @patch("btrfs_backup_ng.cli.list_cmd.load_config")
+    @patch("btrfs_backup_ng.cli.list_cmd.find_config_file")
+    def test_list_endpoint_carries_custom_format(
+        self, mock_find, mock_load, mock_choose, tmp_path
+    ):
+        # Real snapshot dir so the source-listing branch builds an endpoint.
+        data = tmp_path / "data"
+        (data / ".snapshots").mkdir(parents=True)
+        volume = VolumeConfig(
+            path=str(data),
+            snapshot_prefix="data-",
+            snapshot_dir=".snapshots",
+        )
+        mock_find.return_value = str(tmp_path / "config.toml")
+        mock_load.return_value = (_custom_config([volume]), [])
+
+        ep = MagicMock()
+        ep.list_snapshots.return_value = []
+        mock_choose.return_value = ep
+
+        args = MagicMock()
+        args.config = None
+        args.volume = None
+        args.json = False
+
+        from btrfs_backup_ng.cli.list_cmd import execute_list
+
+        execute_list(args)
+
+        endpoint_kwargs = mock_choose.call_args_list[0][0][1]
+        assert endpoint_kwargs["timestamp_format"] == CUSTOM_FMT
+
+    @patch("btrfs_backup_ng.cli.status.endpoint.choose_endpoint")
+    @patch("btrfs_backup_ng.cli.status.load_config")
+    @patch("btrfs_backup_ng.cli.status.find_config_file")
+    def test_status_endpoint_carries_custom_format(
+        self, mock_find, mock_load, mock_choose, tmp_path
+    ):
+        data = tmp_path / "data"
+        (data / ".snapshots").mkdir(parents=True)
+        volume = VolumeConfig(
+            path=str(data),
+            snapshot_prefix="data-",
+            snapshot_dir=".snapshots",
+        )
+        mock_find.return_value = str(tmp_path / "config.toml")
+        mock_load.return_value = (_custom_config([volume]), [])
+
+        ep = MagicMock()
+        ep.list_snapshots.return_value = []
+        mock_choose.return_value = ep
+
+        args = MagicMock()
+        args.config = None
+        args.transactions = False
+
+        from btrfs_backup_ng.cli.status import execute_status
+
+        execute_status(args)
+
+        endpoint_kwargs = mock_choose.call_args_list[0][0][1]
+        assert endpoint_kwargs["timestamp_format"] == CUSTOM_FMT
+
+    @patch("btrfs_backup_ng.cli.transfer.sync_snapshots")
+    @patch("btrfs_backup_ng.cli.transfer.endpoint.choose_endpoint")
+    @patch("btrfs_backup_ng.cli.transfer.load_config")
+    @patch("btrfs_backup_ng.cli.transfer.find_config_file")
+    def test_transfer_endpoint_carries_custom_format(
+        self, mock_find, mock_load, mock_choose, mock_sync, tmp_path
+    ):
+        data = tmp_path / "data"
+        (data / ".snapshots").mkdir(parents=True)
+        volume = VolumeConfig(
+            path=str(data),
+            snapshot_prefix="data-",
+            snapshot_dir=".snapshots",
+            targets=[TargetConfig(path="/mnt/backup")],
+        )
+        mock_find.return_value = str(tmp_path / "config.toml")
+        mock_load.return_value = (_custom_config([volume]), [])
+
+        ep = MagicMock()
+        ep.list_snapshots.return_value = [MagicMock()]
+        mock_choose.return_value = ep
+
+        args = MagicMock()
+        args.config = None
+        args.volume = None
+        args.dry_run = False
+        args.compress = None
+        args.rate_limit = None
+
+        from btrfs_backup_ng.cli.transfer import execute_transfer
+
+        execute_transfer(args)
+
+        endpoint_kwargs = mock_choose.call_args_list[0][0][1]
+        assert endpoint_kwargs["timestamp_format"] == CUSTOM_FMT
+
+
+# ---------------------------------------------------------------------------
+# 7. snapper_cmd: backup, status, list
+# ---------------------------------------------------------------------------
+
+
+class TestSnapperBackupThreadsTimestampFormat:
+    """snapper_cmd._handle_backup builds endpoint config with the format."""
+
+    @patch("btrfs_backup_ng.endpoint.choose_endpoint")
+    @patch("btrfs_backup_ng.cli.snapper_cmd.SnapperScanner")
+    def test_endpoint_config_carries_custom_format(
+        self, mock_scanner_cls, mock_choose, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        scanner = MagicMock()
+        scanner.get_config.return_value = MagicMock()
+        mock_scanner_cls.return_value = scanner
+        mock_choose.return_value = MagicMock(_is_remote=False)
+
+        args = argparse.Namespace(
+            config="root",
+            target="/mnt/backup",
+            snapshot=None,
+            type=None,
+            dry_run=True,
+            compress=None,
+            rate_limit=None,
+            verbose=False,
+            quiet=False,
+            log_level=None,
+            min_age="0",
+            timestamp_format=CUSTOM_FMT,
+        )
+
+        with patch(
+            "btrfs_backup_ng.core.operations.get_snapper_snapshots_for_backup",
+            return_value=[],
+        ):
+            from btrfs_backup_ng.cli.snapper_cmd import _handle_backup
+
+            _handle_backup(args)
+
+        endpoint_config = mock_choose.call_args[0][1]
+        assert endpoint_config["timestamp_format"] == CUSTOM_FMT
+
+
+class TestSnapperStatusThreadsTimestampFormat:
+    """snapper_cmd._handle_status threads it into the endpoint config AND uses
+    get_backup_name(status_fmt) to compute local snapshot names."""
+
+    @patch("btrfs_backup_ng.core.operations._list_snapper_backups_at_destination")
+    @patch("btrfs_backup_ng.endpoint.choose_endpoint")
+    @patch("btrfs_backup_ng.cli.snapper_cmd.SnapperScanner")
+    def test_endpoint_config_and_backup_name_use_custom_format(
+        self, mock_scanner_cls, mock_choose, mock_list
+    ):
+        snap = MagicMock()
+        snap.get_backup_name.return_value = "root-1-20240101T120000"
+
+        config = MagicMock()
+        config.name = "root"
+
+        scanner = MagicMock()
+        scanner.list_configs.return_value = [config]
+        scanner.get_snapshots.return_value = [snap]
+        mock_scanner_cls.return_value = scanner
+        mock_choose.return_value = MagicMock()
+        mock_list.return_value = set()
+
+        args = argparse.Namespace(
+            json=False,
+            config=None,
+            target="/mnt/backup",
+            timestamp_format=CUSTOM_FMT,
+        )
+
+        from btrfs_backup_ng.cli.snapper_cmd import _handle_status
+
+        _handle_status(args)
+
+        endpoint_config = mock_choose.call_args[0][1]
+        assert endpoint_config["timestamp_format"] == CUSTOM_FMT
+        # Local names are recomputed via get_backup_name(status_fmt).
+        snap.get_backup_name.assert_called_with(CUSTOM_FMT)
+
+
+class TestSnapperListThreadsTimestampFormat:
+    """snapper_cmd._handle_list resolves the format for displayed backup names."""
+
+    @patch("btrfs_backup_ng.cli.snapper_cmd.SnapperScanner")
+    def test_backup_name_uses_custom_format(self, mock_scanner_cls):
+        snap = MagicMock()
+        snap.number = 1
+        snap.snapshot_type = "single"
+        snap.description = "timeline"
+        snap.cleanup = "timeline"
+        snap.pre_num = None
+        snap.get_backup_name.return_value = "root-1-20240101T120000"
+        from datetime import datetime
+
+        snap.date = datetime(2024, 1, 1, 12, 0, 0)
+
+        config = MagicMock()
+        config.name = "root"
+        config.subvolume = Path("/")
+
+        scanner = MagicMock()
+        scanner.list_configs.return_value = [config]
+        scanner.get_snapshots.return_value = [snap]
+        mock_scanner_cls.return_value = scanner
+
+        args = argparse.Namespace(
+            json=True,
+            config=None,
+            type=None,
+            timestamp_format=CUSTOM_FMT,
+        )
+
+        from btrfs_backup_ng.cli.snapper_cmd import _handle_list
+
+        _handle_list(args)
+
+        # The resolved custom format is what get_backup_name is invoked with.
+        snap.get_backup_name.assert_called_with(CUSTOM_FMT)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Completes the `timestamp_format` theme started in 0.8.3 (#2 fixed native naming for 0.8.3, but the setting was ignored in several other paths). The configured format is now honored **everywhere** a snapshot name is generated or parsed.

## Scope (established by an exhaustive multi-agent sweep + completeness critic + a mechanical whole-tree inventory)

- **snapper backup** naming (raw stream filenames + metadata sidecars) on both entry paths — config-driven `run` and standalone `snapper backup`. (#7)
- **verify** / **restore** direct mode parse custom-named snapshots instead of silently skipping them (`verify` could otherwise report "all verified" while skipping); restore threads the **same** resolved format into both source **and** destination endpoints so skip-existing and incremental-base detection work on re-restore. (#8)
- **retention/prune** parse custom-format times, so custom-named snapshots are pruned rather than kept forever. (#14)
- **estimate** direct mode, **snapper status** counts, and **snapper list** preview honor the format. (#15)
- New `--timestamp-format` flag on `snapper backup`/`list`/`status`, `verify`, `restore`, `estimate`; otherwise `[global] timestamp_format`.
- Removed the unused `_find_snapper_parent` helper.

A `None`-endpoint dereference in the snapper wrapper (introduced while threading the format) was caught in review and fixed, with a regression test that exercises the real wrapper.

## Certainty

- **14 mutation-verified enforcement tests** (`tests/test_timestamp_format_enforcement.py`): each asserts the *custom* format reaches every command, and was verified to **fail** when the threading is removed — so a future regression breaks CI.
- Every date-format site classified: all snapshot-name paths honor the format; every fixed-format site (snapper native info.xml date, display strings, `--before/--after` filters, retention bucket keys, config defaults) is legitimately fixed.
- Full suite green (1996 passed); ruff + mypy clean.