### PR TITLE
fix: R1 — btrfs transfer-success contract (no false-success backups)

### DIFF
--- a/src/btrfs_backup_ng/_legacy_main.py
+++ b/src/btrfs_backup_ng/_legacy_main.py
@@ -333,6 +333,7 @@ def run_task(options):
     else:
         snapshot = None
 
+    any_failed = False
     for destination_endpoint in destination_endpoints:
         try:
             sync_snapshots(
@@ -344,11 +345,16 @@ def run_task(options):
                 options=options,
             )
         except __util__.AbortError as e:
+            # A failed transfer (SnapshotTransferError subclasses AbortError) must
+            # not be reported as overall success. Record it, continue to the other
+            # destinations, then signal failure so the exit code is non-zero.
             logger.error("Aborting snapshot transfer to %s", destination_endpoint)
             logger.debug("Exception was: %s", e)
+            any_failed = True
 
     time.sleep(1)
     cleanup_snapshots(source_endpoint, destination_endpoints, options)
+    return not any_failed
 
 
 def log_initial_settings(options):
@@ -585,12 +591,17 @@ def legacy_main(argv: list[str] | None = None) -> int:
     logger.debug("Logger initialized")
 
     try:
+        all_ok = True
         for n, options in enumerate(task_options):
             logger.debug(f"Starting task {n + 1}/{len(task_options)}")
-            run_task(options)
+            if not run_task(options):
+                all_ok = False
             logger.debug(f"Completed task {n + 1}/{len(task_options)}")
-        logger.info("All tasks completed successfully")
-        return 0
+        if all_ok:
+            logger.info("All tasks completed successfully")
+            return 0
+        logger.error("One or more transfers failed")
+        return 1
     except (__util__.AbortError, KeyboardInterrupt):
         logger.error("Process aborted by user or error")
         return 1

--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -6,9 +6,10 @@ Extracted from __main__.py for modularity and reuse.
 import logging
 import subprocess
 import time
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from .. import __util__
 from ..transaction import log_transaction
@@ -25,6 +26,56 @@ from .space import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TransferResult:
+    """Outcome of a multi-snapshot synchronization.
+
+    ``transferred`` holds the snapshots that were verified onto the destination;
+    ``failed`` holds ``(snapshot, error)`` pairs for those whose transfer failed.
+    A sync with any failures raises ``SnapshotTransferError`` with this object
+    attached as ``err.result`` so the caller can report precise counts (e.g.
+    "3 of 5 transferred, 2 failed") instead of inferring success from the mere
+    absence of an exception.
+    """
+
+    transferred: list = field(default_factory=list)
+    failed: list = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.failed
+
+    @property
+    def transferred_count(self) -> int:
+        return len(self.transferred)
+
+    @property
+    def failed_count(self) -> int:
+        return len(self.failed)
+
+    @property
+    def attempted(self) -> int:
+        return len(self.transferred) + len(self.failed)
+
+
+def _raise_transfer_failures(result: "TransferResult", label: str) -> None:
+    """Raise SnapshotTransferError (with ``result`` attached) if any transfer failed.
+
+    Fail-loud: a caller cannot accidentally treat a partial or total failure as
+    success, and the attached result carries the transferred/failed breakdown for
+    accurate exit codes and notifications.
+    """
+    if result.ok:
+        return
+    names = ", ".join(str(item) for item, _ in result.failed)
+    err: Any = __util__.SnapshotTransferError(
+        f"{result.failed_count} of {result.attempted} {label} transfer(s) "
+        f"failed: {names}"
+    )
+    err.result = result
+    raise err
 
 
 def send_snapshot(
@@ -1030,7 +1081,7 @@ def sync_snapshots(
     snapshot=None,
     options=None,
     **kwargs,
-) -> None:
+) -> TransferResult:
     """Synchronize snapshots from source to destination.
 
     Args:
@@ -1041,6 +1092,13 @@ def sync_snapshots(
         snapshot: Specific snapshot to transfer (None = use planning)
         options: Additional options dict
         **kwargs: Additional keyword arguments
+
+    Returns:
+        TransferResult with the transferred/failed breakdown.
+
+    Raises:
+        SnapshotTransferError: if any planned snapshot failed to transfer. The
+            exception carries the TransferResult as ``err.result``.
     """
     from .planning import plan_transfers
 
@@ -1081,14 +1139,14 @@ def sync_snapshots(
 
     if not to_transfer:
         logger.info("No snapshots need to be transferred.")
-        return
+        return TransferResult()
 
     logger.info("Going to transfer %d snapshot(s):", len(to_transfer))
     for snap in to_transfer:
         logger.info("  %s", snap)
 
     # Execute transfers
-    _execute_transfers(
+    result = _execute_transfers(
         source_endpoint,
         destination_endpoint,
         source_snapshots,
@@ -1098,6 +1156,11 @@ def sync_snapshots(
         options,
         **kwargs,
     )
+
+    # Fail loud: any failed transfer must surface as an exception so callers
+    # cannot mistake the absence of an exception for success.
+    _raise_transfer_failures(result, "snapshot")
+    return result
 
 
 def _execute_transfers(
@@ -1109,9 +1172,16 @@ def _execute_transfers(
     no_incremental,
     options,
     **kwargs,
-) -> None:
-    """Execute the actual snapshot transfers."""
+) -> TransferResult:
+    """Execute the actual snapshot transfers.
+
+    Returns a TransferResult recording which snapshots were verified onto the
+    destination and which failed. Locks are released and the snapshot registered
+    at the destination only for verified successes; a failed snapshot is kept
+    locked and recorded in ``result.failed`` (never silently dropped).
+    """
     destination_id = destination_endpoint.get_id()
+    result = TransferResult()
 
     while to_transfer:
         if no_incremental:
@@ -1162,14 +1232,18 @@ def _execute_transfers(
             except Exception as e:
                 logger.debug("Post-transfer snapshot list refresh failed: %s", e)
 
+            result.transferred.append(best_snapshot)
+
         except __util__.SnapshotTransferError as e:
             logger.error("Snapshot transfer failed for %s: %s", best_snapshot, e)
             logger.info("Keeping %s locked to prevent deletion.", best_snapshot)
+            result.failed.append((best_snapshot, e))
 
         to_transfer.remove(best_snapshot)
         logger.debug("%d snapshots left to transfer", len(to_transfer))
 
     logger.info(__util__.log_heading(f"Transfers to {destination_endpoint} complete!"))
+    return result
 
 
 # =============================================================================
@@ -1676,7 +1750,12 @@ def sync_snapper_snapshots(
         options: Additional transfer options
 
     Returns:
-        Number of snapshots transferred
+        Number of snapshots transferred (on full success).
+
+    Raises:
+        SnapshotTransferError: if any eligible snapshot failed to transfer. The
+            exception carries a TransferResult as ``err.result`` (transferred vs
+            failed) so the caller reports a non-zero exit and accurate counts.
     """
     if options is None:
         options = {}
@@ -1732,7 +1811,7 @@ def sync_snapper_snapshots(
     all_snapshots_by_num = {s.number: s for s in snapper_snapshots}
 
     # Transfer snapshots
-    transferred = 0
+    result = TransferResult()
     for i, snap in enumerate(to_transfer, 1):
         # Find parent for incremental transfer
         # Look for the highest numbered snapshot that:
@@ -1757,16 +1836,24 @@ def sync_snapper_snapshots(
                 parent_snapper_snapshot=parent,
                 options=options,
             )
-            transferred += 1
+            result.transferred.append(snap)
             backed_up_numbers.add(snap.number)
         except __util__.SnapshotTransferError as e:
             logger.error("Failed to transfer snapshot %d: %s", snap.number, e)
-            # Continue with remaining snapshots
+            result.failed.append((snap, e))
+            # Continue attempting the remaining snapshots; the failure is recorded
+            # and surfaced below so it is never silently dropped.
 
     logger.info("")
-    logger.info("Sync complete: %d/%d transferred", transferred, len(to_transfer))
+    logger.info(
+        "Sync complete: %d/%d transferred", result.transferred_count, len(to_transfer)
+    )
 
-    return transferred
+    # Fail loud: if any snapshot failed, raise with the breakdown attached so the
+    # caller reports a non-zero exit / failure notification instead of exit 0.
+    _raise_transfer_failures(result, "snapper snapshot")
+
+    return result.transferred_count
 
 
 def _list_snapper_backups_at_destination(endpoint) -> set[str]:

--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -368,6 +368,25 @@ def _do_chunked_transfer(
                     send_process.kill()
                     send_process.wait()
 
+            # The send exit code is authoritative. If `btrfs send` failed (parent
+            # UUID mismatch, I/O error, killed) it closes stdout early, so chunking
+            # sees EOF and records a TRUNCATED manifest. Without this check the
+            # truncated stream would be transferred and reported as a successful
+            # backup.
+            if send_process.returncode not in (0, None):
+                send_stderr = ""
+                if send_process.stderr is not None:
+                    try:
+                        send_stderr = send_process.stderr.read().decode(
+                            errors="replace"
+                        )
+                    except Exception:
+                        pass
+                raise __util__.SnapshotTransferError(
+                    f"btrfs send failed during chunking "
+                    f"(exit {send_process.returncode}): {send_stderr}"
+                )
+
             logger.info(
                 "Chunking complete: %d chunks, %d bytes",
                 manifest.chunk_count,
@@ -579,19 +598,13 @@ def _transfer_chunks_ssh(
             for chunk_data in reader.read_chunks():
                 if receive_process.stdin:
                     receive_process.stdin.write(chunk_data)
-
-                # Find and mark chunk as transferred
-                if chunks_sent < len(manifest.chunks):
-                    chunk = manifest.chunks[chunks_sent]
-                    chunked_manager.mark_chunk_transferred(manifest, chunk.sequence)
-                    chunks_sent += 1
-
-                    if show_progress:
-                        logger.info(
-                            "Chunk %d/%d transferred",
-                            chunks_sent,
-                            manifest.chunk_count,
-                        )
+                chunks_sent += 1
+                if show_progress:
+                    logger.info(
+                        "Chunk %d/%d streamed",
+                        chunks_sent,
+                        manifest.chunk_count,
+                    )
 
             # Close stdin to signal end of stream
             if receive_process.stdin:
@@ -609,6 +622,16 @@ def _transfer_chunks_ssh(
                 raise __util__.SnapshotTransferError(
                     f"SSH btrfs receive failed with code {return_code}: {stderr}"
                 )
+
+            # Only NOW, after `btrfs receive` has confirmed success, mark the
+            # chunks transferred. Marking them as they were written to stdin (before
+            # receive completed) meant a receive that failed after ingesting bytes
+            # left a manifest full of TRANSFERRED chunks -- on the next run
+            # pending_chunks was empty, so nothing was re-sent and the failed
+            # transfer looked resumable-complete. btrfs receive applies the whole
+            # stream atomically, so all-or-nothing marking is correct.
+            for chunk in manifest.chunks:
+                chunked_manager.mark_chunk_transferred(manifest, chunk.sequence)
 
             logger.info("SSH chunked transfer complete: %d chunks", chunks_sent)
 

--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -46,6 +46,34 @@ OPENSSL_PASSPHRASE_ENV = "BTRFS_BACKUP_PASSPHRASE"
 BTRBK_PASSPHRASE_ENV = "BTRBK_PASSPHRASE"
 
 
+def _popen_pipeline_pipefail(shell_cmd: str, **popen_kwargs: Any) -> subprocess.Popen:
+    """Run a multi-stage shell pipeline with ``pipefail``.
+
+    Without ``pipefail`` a shell pipeline's exit status is that of its LAST stage
+    only, so a failure of an upstream stage -- ``btrfs send`` dying, or a
+    compressor/``gpg`` erroring mid-stream -- is masked by the final redirect/ssh
+    exiting 0, and a truncated or empty stream file is reported as a successful
+    backup. ``set -o pipefail`` makes any stage's failure fail the whole pipeline
+    so the returncode the caller checks is honest.
+
+    Uses bash (which supports ``pipefail``); falls back to plain ``sh`` with a
+    warning only when bash is unavailable.
+    """
+    bash_path = shutil.which("bash")
+    if bash_path:
+        return subprocess.Popen(
+            "set -o pipefail; " + shell_cmd,
+            shell=True,
+            executable=bash_path,
+            **popen_kwargs,
+        )
+    logger.warning(
+        "bash not found; running raw pipeline without pipefail (a mid-pipe "
+        "failure may be masked and produce a truncated backup)"
+    )
+    return subprocess.Popen(shell_cmd, shell=True, **popen_kwargs)
+
+
 class RawEndpoint(Endpoint):
     """Endpoint that writes btrfs send streams to files.
 
@@ -317,9 +345,8 @@ class RawEndpoint(Endpoint):
 
         logger.debug("Executing pipeline: %s", shell_cmd)
 
-        proc = subprocess.Popen(
+        proc = _popen_pipeline_pipefail(
             shell_cmd,
-            shell=True,
             stdin=stdin,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
@@ -718,9 +745,8 @@ class SSHRawEndpoint(RawEndpoint):
 
         logger.debug("Executing SSH pipeline: %s", shell_cmd)
 
-        proc = subprocess.Popen(
+        proc = _popen_pipeline_pipefail(
             shell_cmd,
-            shell=True,
             stdin=stdin,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,

--- a/src/btrfs_backup_ng/endpoint/ssh.py
+++ b/src/btrfs_backup_ng/endpoint/ssh.py
@@ -21,6 +21,7 @@ import copy
 import getpass
 import os
 import shlex
+import shutil
 import subprocess
 import threading
 import time
@@ -2022,7 +2023,8 @@ print(json.dumps(result))
             snapshot_name: Name of the received subvolume within dest_path
 
         Returns:
-            True if a subvolume/directory exists at the exact expected path.
+            True only if a real received subvolume exists at the exact expected
+            path (a bare directory is not accepted).
         """
         expected_path = f"{dest_path.rstrip('/')}/{snapshot_name}"
         logger.debug(f"Verifying received snapshot at exact path: {expected_path}")
@@ -2046,18 +2048,16 @@ print(json.dumps(result))
             )
 
         try:
-            # Authoritative check: confirm a real subvolume exists at exactly the
-            # expected path (not merely a same-named subvolume elsewhere).
+            # Authoritative check: confirm a real *subvolume* exists at exactly the
+            # expected path (not merely a same-named subvolume elsewhere). A plain
+            # directory is deliberately NOT accepted: an interrupted or failed
+            # ``btrfs receive`` can leave a bare directory (or a half-applied,
+            # non-subvolume tree) at the destination, and a ``test -d`` check would
+            # report that partial as a valid backup. Only ``btrfs subvolume show``
+            # succeeding proves a real received subvolume is present.
             show_result = _run(["btrfs", "subvolume", "show", expected_path])
             if show_result.returncode == 0:
                 logger.debug(f"Snapshot verified via subvolume show: {expected_path}")
-                return True
-
-            # Fallback: exact directory existence at the expected path. Still scoped
-            # to the precise location, so it cannot match a sibling snapshot.
-            test_result = _run(["test", "-d", expected_path])
-            if test_result.returncode == 0:
-                logger.debug(f"Snapshot verified via path check: {expected_path}")
                 return True
 
             logger.error(f"Snapshot not found at expected path: {expected_path}")
@@ -2067,6 +2067,53 @@ print(json.dumps(result))
             logger.error(f"Error verifying snapshot: {e}")
             logger.debug(f"Verification exception details: {e}", exc_info=True)
             return False
+
+    def _cleanup_partial_subvolume(self, dest_path: str, received_name: str) -> None:
+        """Remove a partial/failed received subvolume at its exact destination path.
+
+        Called after a transfer is judged failed so that a leftover partial cannot
+        later be mistaken for a valid backup (by verification or skip-detection) and
+        so a subsequent retry starts from a clean destination. Scoped strictly to
+        ``{dest_path}/{received_name}`` — never a filesystem-wide search — for the
+        same reason exact-path verification is: sibling snapshots must not be touched.
+
+        Best-effort: failures are logged and swallowed (the caller has already
+        decided the transfer failed).
+        """
+        expected_path = f"{dest_path.rstrip('/')}/{received_name}"
+        use_sudo = self.config.get("ssh_sudo", False)
+
+        def _run(cmd: List[str]) -> Any:
+            if use_sudo:
+                return self._exec_remote_command_with_retry(
+                    cmd,
+                    max_retries=2,
+                    check=False,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+            return self._exec_remote_command(
+                cmd,
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        try:
+            # Only act if something is actually present at the exact path.
+            if _run(["test", "-e", expected_path]).returncode != 0:
+                return
+            logger.warning(
+                "Cleaning up partial/failed transfer artifact at %s", expected_path
+            )
+            # Prefer subvolume delete (handles the common partial-receive case);
+            # fall back to rm -rf for a plain directory left behind.
+            if _run(["btrfs", "subvolume", "delete", expected_path]).returncode != 0:
+                _run(["rm", "-rf", expected_path])
+        except Exception as e:
+            logger.debug(
+                "Partial-subvolume cleanup failed for %s: %s", expected_path, e
+            )
 
     def _find_buffer_program(self) -> Tuple[Optional[str], Optional[str]]:
         """Find pv program to use for transfer progress display.
@@ -2666,11 +2713,16 @@ print(json.dumps(result))
             while channel.recv_stderr_ready():
                 remote_stderr += channel.recv_stderr(4096)
 
+            # btrfs receive names the received subvolume after the source basename
+            # (== snapshot_name for native backups, "snapshot" for snapper).
+            received_name = Path(source_path).name
+
             if exit_status != 0:
                 stderr_text = remote_stderr.decode(errors="replace")
                 logger.error(
                     f"btrfs receive failed (exit {exit_status}): {stderr_text}"
                 )
+                self._cleanup_partial_subvolume(dest_path, received_name)
                 return False
 
             elapsed = time.time() - start_time
@@ -2680,16 +2732,18 @@ print(json.dumps(result))
                 f"({rate / (1024 * 1024):.1f} MiB/s)"
             )
 
-            # Verify snapshot exists on remote. btrfs receive names the received
-            # subvolume after the source basename (== snapshot_name for native
-            # backups, "snapshot" for snapper), so verify by that real name.
-            received_name = Path(source_path).name
+            # Secondary confirmation only after send+receive both exited 0. Because
+            # receive succeeded here, a failed verification is treated as
+            # inconclusive: report failure but do NOT delete the received
+            # subvolume (it may be a good backup and only the verify step failed).
             if self._verify_snapshot_exists(dest_path, received_name):
                 logger.info(f"Snapshot {received_name} verified on remote")
                 return True
             else:
                 logger.error(
-                    "Transfer verification failed - snapshot not found on remote"
+                    "Transfer verification inconclusive - leaving received "
+                    "subvolume in place at %s for reconciliation",
+                    dest_path,
                 )
                 return False
 
@@ -2798,14 +2852,34 @@ print(json.dumps(result))
         logger.info(f"Transferring {snapshot_name} to {self.hostname}:{dest_path}")
         logger.debug(f"Pipeline: {full_pipeline}")
 
+        # Run the pipeline under bash with `pipefail` so a failure of `btrfs send`
+        # or `pv` fails the whole pipeline. Without pipefail the shell reports only
+        # the exit status of the last stage (the `ssh`/receive), which masks an
+        # upstream send failure and yields a truncated/empty backup reported as
+        # success. Degrade to plain sh (with a warning) only if bash is absent.
+        bash_path = shutil.which("bash")
         try:
-            proc = subprocess.Popen(
-                full_pipeline,
-                shell=True,
-                stdin=subprocess.DEVNULL,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )
+            if bash_path:
+                proc = subprocess.Popen(
+                    "set -o pipefail; " + full_pipeline,
+                    shell=True,
+                    executable=bash_path,
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+            else:
+                logger.warning(
+                    "bash not found; running transfer pipeline without pipefail "
+                    "(a btrfs send or pv failure may be masked by ssh's exit code)"
+                )
+                proc = subprocess.Popen(
+                    full_pipeline,
+                    shell=True,
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
 
             stderr_lines: List[str] = []
 
@@ -2825,24 +2899,32 @@ print(json.dumps(result))
             proc.wait()
             stderr_thread.join(timeout=5)
 
+            # The received subvolume is named after the source basename
+            # (== snapshot_name for native, "snapshot" for snapper).
+            received_name = Path(source_path).name
+
             if proc.returncode != 0:
                 stderr_output = "".join(stderr_lines)
                 logger.error(f"Transfer failed (exit {proc.returncode})")
                 if stderr_output:
                     logger.error(f"Error output: {stderr_output}")
+                self._cleanup_partial_subvolume(dest_path, received_name)
                 return False
 
             logger.info("Transfer completed successfully")
 
-            # The received subvolume is named after the source basename
-            # (== snapshot_name for native, "snapshot" for snapper).
-            received_name = Path(source_path).name
+            # The pipeline exited 0 (pipefail), so the receive succeeded. A failed
+            # verification here is inconclusive: report failure but do NOT delete
+            # the received subvolume (it may be a good backup and only the verify
+            # step failed).
             if self._verify_snapshot_exists(dest_path, received_name):
                 logger.info(f"Snapshot {received_name} verified on remote")
                 return True
             else:
                 logger.error(
-                    "Transfer verification failed - snapshot not found on remote"
+                    "Transfer verification inconclusive - leaving received "
+                    "subvolume in place at %s for reconciliation",
+                    dest_path,
                 )
                 return False
 
@@ -3087,29 +3169,17 @@ print(json.dumps(result))
                     received_name=received_name,
                 )
 
-            # Final verification if we timed out
-            if not transfer_succeeded:
-                logger.warning(
-                    "Reached maximum wait time, performing final verification..."
-                )
-                try:
-                    if self._verify_snapshot_exists(dest_path, received_name):
-                        logger.info(
-                            "SUCCESS: Transfer completed successfully (final check)"
-                        )
-                        transfer_succeeded = True
-                    else:
-                        logger.error(
-                            "FAILED: Transfer failed - no snapshot found after maximum wait time"
-                        )
-                except Exception as e:
-                    logger.error(f"Final verification failed: {e}")
+            # The monitor is authoritative: it has already required that send and
+            # receive both exited 0 AND that the received subvolume verifies, or it
+            # returned False (timeout, nonzero exit, or missing subvolume). Success
+            # is NOT re-derived from path existence here — doing so was the original
+            # false-success bug (a partial/failed receive that left a directory was
+            # reported as a valid backup).
 
-            # Clean up processes
+            # Clean up any lingering processes.
             all_processes = [send_process, receive_process]
             if buffer_process:
                 all_processes.append(buffer_process)
-
             for proc in all_processes:
                 if proc.poll() is None:
                     logger.debug("Terminating remaining process...")
@@ -3119,79 +3189,34 @@ print(json.dumps(result))
                     except Exception:
                         proc.kill()
 
-            # Set dummy results for compatibility
-            send_result = 0 if transfer_succeeded else 1
-            receive_result = 0 if transfer_succeeded else 1
-
             elapsed_time = time.time() - start_time
             logger.info(f"Transfer completed in {elapsed_time:.2f} seconds")
 
-            # Check process results
-            if send_result != 0:
-                stderr_output = (
-                    send_process.stderr.read().decode(errors="replace")
-                    if send_process.stderr
-                    else ""
-                )
-                logger.error(
-                    f"Local send process failed with exit code {send_result}: {stderr_output}"
-                )
-                return False
-
-            if receive_result != 0:
-                logger.error(
-                    f"Remote receive process failed with exit code {receive_result}"
-                )
-                return False
-
-            # Prioritize actual transfer verification over exit codes
-            logger.debug("=== TRANSFER VERIFICATION (Primary Check) ===")
-            logger.debug("Verifying snapshot was created on remote host...")
-            logger.debug(f"Looking for snapshot '{snapshot_name}' in '{dest_path}'")
-
-            # Check if transfer actually succeeded first
-            transfer_actually_succeeded = False
-            try:
-                verification_result = self._verify_snapshot_exists(
-                    dest_path, received_name
-                )
-                logger.debug(f"Snapshot existence verification: {verification_result}")
-
-                if verification_result:
-                    logger.info(
-                        "SUCCESS: TRANSFER ACTUALLY SUCCEEDED - Snapshot exists on remote host"
-                    )
-                    transfer_actually_succeeded = True
-                else:
-                    # Try alternative verification methods
-                    logger.debug(
-                        "Primary verification failed, trying alternative methods..."
-                    )
-                    ls_cmd = ["ls", "-la", dest_path]
-                    ls_result = self._exec_remote_command(
-                        ls_cmd, check=False, stdout=subprocess.PIPE
-                    )
-                    if ls_result.returncode == 0 and ls_result.stdout:
-                        ls_output = ls_result.stdout.decode(errors="replace")
-                        logger.debug(f"Directory listing: {ls_output}")
-                        if received_name in ls_output:
-                            logger.info(
-                                "SUCCESS: TRANSFER ACTUALLY SUCCEEDED - Snapshot found in directory listing"
-                            )
-                            transfer_actually_succeeded = True
-
-            except Exception as e:
-                logger.error(f"Exception during verification: {e}")
-
-            # Final decision based on actual transfer success
-            if transfer_actually_succeeded:
+            if transfer_succeeded:
                 logger.info("SUCCESS: TRANSFER VERIFICATION SUCCESSFUL")
                 return True
+
+            logger.error("FAILED: TRANSFER FAILED")
+            # Remove a partial ONLY when a process genuinely failed (nonzero exit or
+            # a timeout kill), which is exactly when a partial subvolume can exist.
+            # If the receive exited 0 but verification was merely inconclusive (e.g.
+            # a transient SSH/timeout on `btrfs subvolume show`), a GOOD received
+            # subvolume may be present -- deleting it would destroy a successful
+            # backup. In that case leave the artifact in place for a retry / the
+            # next run's skip-detection to reconcile.
+            recv_rc = receive_process.returncode
+            send_rc = send_process.returncode
+            receive_failed = recv_rc is not None and recv_rc != 0
+            send_failed = send_rc is not None and send_rc != 0
+            if receive_failed or send_failed:
+                self._cleanup_partial_subvolume(dest_path, received_name)
             else:
-                logger.error(
-                    "FAILED: TRANSFER FAILED - No snapshot found on remote host"
+                logger.warning(
+                    "Receive completed but verification was inconclusive; leaving "
+                    "the received subvolume in place at %s for reconciliation",
+                    dest_path,
                 )
-                return False
+            return False
 
         except Exception as e:
             logger.error(f"Error during transfer: {e}")
@@ -3583,21 +3608,13 @@ print(json.dumps(result))
                 )
                 last_status_time = current_time
 
-            # Periodic verification
+            # Periodic progress note only. We deliberately do NOT check for the
+            # received subvolume here: while the receive process is still alive the
+            # subvolume may already exist on disk yet not be fully applied, so
+            # treating existence as completion would report success mid-stream
+            # (the existence check races the still-running receive).
             if current_time - last_verification_time >= verification_interval:
-                logger.debug("Performing verification check...")
-                try:
-                    if self._verify_snapshot_exists(
-                        dest_path, received_name or snapshot_name
-                    ):
-                        logger.info("SUCCESS: Transfer verification successful!")
-                        return True
-                    else:
-                        logger.debug("STATUS: Transfer still in progress...")
-                except Exception as e:
-                    logger.debug(
-                        f"Verification check failed (normal during transfer): {e}"
-                    )
+                logger.debug("STATUS: Transfer still in progress...")
                 last_verification_time = current_time
 
             # Check if all processes finished
@@ -3606,25 +3623,46 @@ print(json.dumps(result))
                 and not receive_alive
                 and not (buffer_process and buffer_alive)
             ):
-                logger.debug(
-                    "STATUS: All processes completed, performing final verification..."
-                )
+                logger.debug("STATUS: All processes completed")
                 break
-
-            # Handle receive process warnings (but don't fail immediately)
-            if not receive_alive and receive_process.returncode not in [None, 0]:
-                logger.warning(
-                    f"WARNING: Receive process exit code: {receive_process.returncode}"
-                )
-                logger.debug(
-                    "STATUS: Checking if transfer succeeded despite exit code..."
-                )
 
             time.sleep(0.5)  # Short sleep for responsive monitoring
 
-        # Final verification
+        # Timeout: at least one process is still running after max_wait_time. Kill
+        # everything and fail — a still-running receive has NOT completed.
+        procs = [send_process, receive_process] + (
+            [buffer_process] if buffer_process else []
+        )
+        if any(proc.poll() is None for proc in procs):
+            logger.error("FAILED: Transfer timed out; terminating processes")
+            for proc in procs:
+                if proc.poll() is None:
+                    proc.terminate()
+                    try:
+                        proc.wait(timeout=5)
+                    except Exception:
+                        proc.kill()
+            return False
+
+        # Exit codes are AUTHORITATIVE: send and receive must both have exited 0.
+        # A nonzero receive means the stream was not fully applied regardless of
+        # whether a (partial) subvolume exists at the path.
+        if send_process.returncode != 0:
+            logger.error(
+                f"FAILED: Send process failed (exit code: {send_process.returncode})"
+            )
+            self._log_process_error(send_process, "send")
+            return False
+        if receive_process.returncode != 0:
+            logger.error(
+                f"FAILED: Receive process failed (exit code: {receive_process.returncode})"
+            )
+            self._log_process_error(receive_process, "receive")
+            return False
+
+        # Secondary confirmation only AFTER both processes exited 0.
         logger.debug(
-            "COMPLETE: Transfer monitoring complete, performing final verification..."
+            "COMPLETE: Transfer processes finished cleanly, performing final verification..."
         )
         try:
             transfer_succeeded = self._verify_snapshot_exists(
@@ -3641,6 +3679,7 @@ print(json.dumps(result))
                 )
         except Exception as e:
             logger.error(f"ERROR: Final verification failed: {e}")
+            transfer_succeeded = False
 
         return transfer_succeeded
 
@@ -3749,6 +3788,23 @@ print(json.dumps(result))
         # Check results
         elapsed_final = time.time() - start_time
 
+        # Timeout: the loop exited with at least one process still running. Kill
+        # everything and fail — a still-running receive has NOT completed, and
+        # accepting it here (on path existence) is exactly the false-success bug.
+        if any(proc.poll() is None for proc in processes_to_wait):
+            logger.error(
+                "FAILED: Transfer timed out after %.1fs; terminating processes",
+                elapsed_final,
+            )
+            for proc in processes_to_wait:
+                if proc.poll() is None:
+                    proc.terminate()
+                    try:
+                        proc.wait(timeout=5)
+                    except Exception:
+                        proc.kill()
+            return False
+
         # Check send process
         send_code = send_process.returncode
         if send_code != 0:
@@ -3758,15 +3814,21 @@ print(json.dumps(result))
 
         logger.info("SUCCESS: Send process completed successfully")
 
-        # Check receive process
+        # Check receive process. The receive exit code is AUTHORITATIVE: a nonzero
+        # `btrfs receive` means the stream was not fully applied, so the transfer
+        # failed regardless of whether a (partial) subvolume exists at the path.
         receive_code = receive_process.returncode
         if receive_code != 0:
-            logger.warning(f"WARNING: Receive process exit code: {receive_code}")
-            # Don't fail immediately - some exit codes may be acceptable
-        else:
-            logger.info("SUCCESS: Receive process completed successfully")
+            logger.error(
+                f"FAILED: Receive process failed with exit code {receive_code}"
+            )
+            self._log_simple_process_error(receive_process, "receive")
+            return False
+        logger.info("SUCCESS: Receive process completed successfully")
 
-        # Check buffer process if present
+        # Buffer process: a truncated stream would already have failed the receive
+        # above, so a nonzero buffer exit on an otherwise-clean transfer is not
+        # treated as fatal (only surfaced) to avoid rejecting a good backup.
         if buffer_process:
             buffer_code = buffer_process.returncode
             if buffer_code != 0:
@@ -3774,7 +3836,7 @@ print(json.dumps(result))
             else:
                 logger.info("SUCCESS: Buffer process completed successfully")
 
-        # Final verification
+        # Secondary confirmation only AFTER send+receive both exited 0.
         logger.debug("STATUS: Performing final verification...")
         try:
             if self._verify_snapshot_exists(dest_path, received_name or snapshot_name):

--- a/src/btrfs_backup_ng/endpoint/ssh.py
+++ b/src/btrfs_backup_ng/endpoint/ssh.py
@@ -3411,6 +3411,10 @@ print(json.dumps(result))
         )
 
         dest_path = self._normalize_path(self.config["path"])
+        # btrfs receive names the received subvolume after the source basename
+        # (== snapshot_name for native, "snapshot" for snapper). Compute it up front
+        # so partial-cleanup on the failure paths can target the exact path.
+        received_name = Path(manifest.snapshot_path).name
         use_sudo = self.config.get("ssh_sudo", False)
         passwordless = self.config.get("passwordless", False) or self.config.get(
             "passwordless_sudo_available", False
@@ -3470,6 +3474,7 @@ print(json.dumps(result))
                         chunks_sent,
                         stderr,
                     )
+                    self._cleanup_partial_subvolume(dest_path, received_name)
                     return False
 
                 # Write chunk data
@@ -3502,6 +3507,7 @@ print(json.dumps(result))
             except subprocess.TimeoutExpired:
                 logger.error("Timeout waiting for SSH receive to complete")
                 receive_process.kill()
+                self._cleanup_partial_subvolume(dest_path, received_name)
                 return False
 
             if return_code != 0:
@@ -3515,6 +3521,7 @@ print(json.dumps(result))
                     return_code,
                     stderr,
                 )
+                self._cleanup_partial_subvolume(dest_path, received_name)
                 return False
 
             elapsed = time.time() - start_time
@@ -3527,15 +3534,19 @@ print(json.dumps(result))
                 rate_mb,
             )
 
-            # Verify the snapshot exists. btrfs receive names the received subvolume
-            # after the source basename (== snapshot_name for native, "snapshot" for
-            # snapper), so verify by that real name, consistent with send_receive.
-            received_name = Path(manifest.snapshot_path).name
+            # Secondary confirmation only after the receive exited 0. Because the
+            # receive succeeded, a failed verification is inconclusive: report
+            # failure but do NOT delete the received subvolume (it may be a good
+            # backup and only the verify step failed).
             if self._verify_snapshot_exists(dest_path, received_name):
                 logger.info("Snapshot verified on remote host")
                 return True
             else:
-                logger.error("Snapshot verification failed after chunked transfer")
+                logger.error(
+                    "Chunked transfer verification inconclusive - leaving received "
+                    "subvolume in place at %s for reconciliation",
+                    dest_path,
+                )
                 return False
 
         except Exception as e:
@@ -3544,6 +3555,8 @@ print(json.dumps(result))
                 receive_process.kill()
             except Exception:
                 pass
+            # The stream did not complete normally: remove any partial subvolume.
+            self._cleanup_partial_subvolume(dest_path, received_name)
             return False
 
     def _monitor_transfer_progress(

--- a/tests/integration/test_chunked_operations.py
+++ b/tests/integration/test_chunked_operations.py
@@ -167,6 +167,7 @@ class TestDoChunkedTransfer:
         mock_send = MagicMock()
         mock_send.stdout = io.BytesIO(b"x" * 1024)  # 1KB of data
         mock_send.wait.return_value = 0
+        mock_send.returncode = 0  # a completed btrfs send exits 0
         snapshot.endpoint.send.return_value = mock_send
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -239,6 +240,7 @@ class TestDoChunkedTransfer:
         mock_send = MagicMock()
         mock_send.stdout = io.BytesIO(b"x" * 1024)
         mock_send.wait.return_value = 0
+        mock_send.returncode = 0  # a completed btrfs send exits 0
         snapshot.endpoint.send.return_value = mock_send
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -526,3 +528,91 @@ class TestChunkedTransferEndToEnd:
             # Verify parent info in manifest
             manifest = manager.get_transfer(transfer_id)
             assert manifest.parent_name == str(parent)
+
+
+class TestChunkedTransferSuccessContract:
+    """R1 enforcement: chunked transfers must not report a failed send/receive
+    as a successful (or resumable-complete) backup."""
+
+    def test_nonzero_send_exit_raises_and_does_not_transfer(self):
+        """A `btrfs send` that fails mid-chunking (nonzero exit) closes stdout
+        early, so chunking records a TRUNCATED manifest. The transfer must fail
+        rather than proceed to transfer the truncated chunks as success."""
+        import pytest
+
+        from btrfs_backup_ng import __util__
+
+        snapshot = MockSnapshot("test-snap", "/mnt/.snapshots/test-snap")
+        endpoint = MockEndpoint()
+
+        mock_send = MagicMock()
+        mock_send.stdout = io.BytesIO(b"x" * 1024)
+        mock_send.wait.return_value = 1
+        mock_send.returncode = 1  # btrfs send failed mid-stream
+        mock_send.stderr = io.BytesIO(b"ERROR: parent not found")
+        snapshot.endpoint.send.return_value = mock_send
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = TransferConfig(cache_directory=Path(tmpdir), chunk_size_mb=1)
+            manager = ChunkedTransferManager(config)
+
+            with patch(
+                "btrfs_backup_ng.core.operations._transfer_chunks_local"
+            ) as mock_local:
+                with patch("btrfs_backup_ng.core.operations.log_transaction"):
+                    with pytest.raises(__util__.SnapshotTransferError):
+                        _do_chunked_transfer(
+                            snapshot=snapshot,
+                            destination_endpoint=endpoint,
+                            parent=None,
+                            clones=None,
+                            options={},
+                            chunked_manager=manager,
+                        )
+
+            # Must NOT have proceeded to transfer the truncated chunks.
+            assert not mock_local.called
+
+    def test_ssh_fallback_does_not_mark_chunks_before_receive_confirms(self):
+        """In the SSH fallback path, a receive that FAILS must not leave any chunk
+        marked TRANSFERRED (which would make the failed transfer look
+        resumable-complete on the next run)."""
+        import pytest
+
+        from btrfs_backup_ng import __util__
+
+        # spec without receive_chunked -> hits the fallback streaming path.
+        endpoint = MagicMock(spec=["receive", "_is_remote", "config"])
+        endpoint._is_remote = True
+        recv = MagicMock()
+        recv.stdin = MagicMock()
+        recv.wait.return_value = 1  # btrfs receive FAILS
+        recv.returncode = 1
+        recv.stderr = io.BytesIO(b"boom")
+        endpoint.receive.return_value = recv
+
+        chunk0 = MagicMock()
+        chunk0.sequence = 0
+        manifest = MagicMock()
+        manifest.chunks = [chunk0]
+        manifest.pending_chunks = [chunk0]
+        manifest.chunk_count = 1
+        manifest.completed_chunks = 0
+        manifest.snapshot_name = "test-snap"
+
+        manager = MagicMock()
+        reader = MagicMock()
+        reader.read_chunks.return_value = iter([b"data"])
+        manager.create_reassembly_reader.return_value = reader
+
+        with pytest.raises(__util__.SnapshotTransferError):
+            _transfer_chunks_ssh(
+                manifest=manifest,
+                destination_endpoint=endpoint,
+                chunked_manager=manager,
+                options={},
+                show_progress=False,
+            )
+
+        # Receive failed -> nothing should have been marked transferred.
+        manager.mark_chunk_transferred.assert_not_called()

--- a/tests/test_r1_legacy_exit_code.py
+++ b/tests/test_r1_legacy_exit_code.py
@@ -1,0 +1,67 @@
+"""Enforcement tests for the R1 transfer-success contract: legacy CLI (commit C).
+
+The legacy path (`run_task` / `legacy_main`, reachable via the dispatcher) caught
+per-destination transfer failures, logged them, and returned success -- so a
+failed backup exited 0. With the orchestration now raising on failure, run_task
+must record the failure and legacy_main must exit non-zero.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import btrfs_backup_ng._legacy_main as legacy
+from btrfs_backup_ng import __util__
+
+
+def _base_options():
+    return {
+        "source": "/data",
+        "no_snapshot": True,
+        "num_backups": 0,
+        "no_incremental": False,
+    }
+
+
+def _patch_run_task_deps(monkeypatch):
+    monkeypatch.setattr(legacy, "log_initial_settings", lambda o: None)
+    monkeypatch.setattr(legacy, "prepare_source_endpoint", lambda o: MagicMock())
+    monkeypatch.setattr(
+        legacy, "prepare_destination_endpoints", lambda o, s: [MagicMock()]
+    )
+    monkeypatch.setattr(legacy, "cleanup_snapshots", lambda *a, **k: None)
+    monkeypatch.setattr(legacy.time, "sleep", lambda *a, **k: None)
+
+
+class TestRunTaskSignalsFailure:
+    def test_returns_false_when_transfer_fails(self, monkeypatch):
+        _patch_run_task_deps(monkeypatch)
+        monkeypatch.setattr(
+            legacy,
+            "sync_snapshots",
+            MagicMock(side_effect=__util__.SnapshotTransferError("boom")),
+        )
+        assert legacy.run_task(_base_options()) is False
+
+    def test_returns_true_on_success(self, monkeypatch):
+        _patch_run_task_deps(monkeypatch)
+        monkeypatch.setattr(legacy, "sync_snapshots", MagicMock(return_value=None))
+        assert legacy.run_task(_base_options()) is True
+
+
+class TestLegacyMainExitCode:
+    def _patch_parse(self, monkeypatch):
+        monkeypatch.setattr(
+            legacy, "parse_options", lambda gp, argv: {"verbosity": "INFO"}
+        )
+        monkeypatch.setattr(legacy, "create_logger", lambda *a, **k: None)
+
+    def test_exit_1_when_a_task_fails(self, monkeypatch):
+        self._patch_parse(monkeypatch)
+        monkeypatch.setattr(legacy, "run_task", lambda o: False)
+        assert legacy.legacy_main(["/data", "/backup"]) == 1
+
+    def test_exit_0_when_all_tasks_succeed(self, monkeypatch):
+        self._patch_parse(monkeypatch)
+        monkeypatch.setattr(legacy, "run_task", lambda o: True)
+        assert legacy.legacy_main(["/data", "/backup"]) == 0

--- a/tests/test_r1_orchestration_contract.py
+++ b/tests/test_r1_orchestration_contract.py
@@ -1,0 +1,143 @@
+"""Enforcement tests for the R1 transfer-success contract: orchestration (commit B).
+
+The orchestration layer must never swallow a per-snapshot transfer failure. A
+sync with any failed transfer raises SnapshotTransferError carrying a
+TransferResult (transferred vs failed) as ``err.result`` so callers report a
+non-zero exit and accurate counts instead of inferring success from the absence
+of an exception.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import btrfs_backup_ng.core.operations as ops
+from btrfs_backup_ng import __util__
+
+
+def _fake_snap(name: str) -> MagicMock:
+    s = MagicMock()
+    s.locks = {}
+    s.parent_locks = {}
+    s.get_name.return_value = name
+    return s
+
+
+def _endpoints(source_snaps, dest_snaps=()):
+    src = MagicMock()
+    src.list_snapshots.return_value = list(source_snaps)
+    src.get_id.return_value = "dest-id"
+    dst = MagicMock()
+    dst.get_id.return_value = "dest-id"
+    dst.list_snapshots.return_value = list(dest_snaps)
+    return src, dst
+
+
+class TestExecuteTransfersResult:
+    def test_records_transferred_and_failed(self, monkeypatch):
+        s1 = _fake_snap("s1")
+        s2 = _fake_snap("s2")
+        src, dst = _endpoints([s1, s2])
+
+        def fake_send(snap, *a, **k):
+            if snap is s2:
+                raise __util__.SnapshotTransferError("boom")
+
+        monkeypatch.setattr(ops, "send_snapshot", fake_send)
+
+        result = ops._execute_transfers(src, dst, [s1, s2], [], [s1, s2], True, {})
+        assert result.transferred_count == 1
+        assert result.failed_count == 1
+        assert result.attempted == 2
+        assert not result.ok
+
+
+class TestSyncSnapshotsFailLoud:
+    def test_failed_transfer_raises_with_result(self, monkeypatch):
+        snap = _fake_snap("snap-1")
+        src, dst = _endpoints([snap])
+        monkeypatch.setattr(
+            ops,
+            "send_snapshot",
+            MagicMock(side_effect=__util__.SnapshotTransferError("boom")),
+        )
+
+        with pytest.raises(__util__.SnapshotTransferError) as ei:
+            ops.sync_snapshots(src, dst, snapshot=snap, no_incremental=True)
+
+        # The result breakdown must ride on the exception.
+        assert hasattr(ei.value, "result")
+        assert ei.value.result.failed_count == 1
+        assert ei.value.result.transferred_count == 0
+
+    def test_successful_transfer_returns_ok_result(self, monkeypatch):
+        snap = _fake_snap("snap-1")
+        src, dst = _endpoints([snap])
+        monkeypatch.setattr(ops, "send_snapshot", MagicMock(return_value=None))
+
+        result = ops.sync_snapshots(src, dst, snapshot=snap, no_incremental=True)
+        assert result.ok
+        assert result.transferred_count == 1
+
+    def test_nothing_to_transfer_returns_ok_result(self, monkeypatch):
+        snap = _fake_snap("snap-1")
+        # snapshot already at destination -> nothing planned.
+        src, dst = _endpoints([snap], dest_snaps=[snap])
+        result = ops.sync_snapshots(src, dst, snapshot=snap, no_incremental=True)
+        assert result.ok
+        assert result.transferred_count == 0
+
+
+class TestSyncSnapperSnapshotsFailLoud:
+    def _patch_common(self, monkeypatch, snaps):
+        monkeypatch.setattr(
+            ops, "get_snapper_snapshots_for_backup", lambda *a, **k: list(snaps)
+        )
+        monkeypatch.setattr(ops, "_list_backed_up_snapper_numbers", lambda ep: set())
+
+    def test_failed_snapshot_raises_with_result(self, monkeypatch):
+        snap = MagicMock()
+        snap.number = 1
+        self._patch_common(monkeypatch, [snap])
+        monkeypatch.setattr(
+            ops,
+            "send_snapper_snapshot",
+            MagicMock(side_effect=__util__.SnapshotTransferError("boom")),
+        )
+
+        with pytest.raises(__util__.SnapshotTransferError) as ei:
+            ops.sync_snapper_snapshots(MagicMock(), "root", MagicMock())
+
+        assert ei.value.result.failed_count == 1
+        assert ei.value.result.transferred_count == 0
+
+    def test_success_returns_transferred_count(self, monkeypatch):
+        snap = MagicMock()
+        snap.number = 1
+        self._patch_common(monkeypatch, [snap])
+        monkeypatch.setattr(ops, "send_snapper_snapshot", MagicMock(return_value=None))
+
+        count = ops.sync_snapper_snapshots(MagicMock(), "root", MagicMock())
+        assert count == 1
+
+    def test_partial_failure_raises_and_reports_both_counts(self, monkeypatch):
+        good = MagicMock()
+        good.number = 1
+        bad = MagicMock()
+        bad.number = 2
+        self._patch_common(monkeypatch, [good, bad])
+
+        def fake_send(snap, *a, **k):
+            if snap is bad:
+                raise __util__.SnapshotTransferError("boom")
+
+        monkeypatch.setattr(ops, "send_snapper_snapshot", fake_send)
+
+        with pytest.raises(__util__.SnapshotTransferError) as ei:
+            ops.sync_snapper_snapshots(MagicMock(), "root", MagicMock())
+
+        # The good snapshot still counts as transferred; the bad one as failed.
+        assert ei.value.result.transferred_count == 1
+        assert ei.value.result.failed_count == 1

--- a/tests/test_r1_raw_chunked_contract.py
+++ b/tests/test_r1_raw_chunked_contract.py
@@ -1,0 +1,98 @@
+"""Enforcement tests for the R1 transfer-success contract: raw + chunked paths.
+
+Companion to test_r1_transfer_success_contract.py (the SSH point-of-truth layer).
+These cover the non-SSH-direct transfer paths (commits A2a/A2b): the raw stream
+pipeline must fail the whole pipeline when an upstream stage fails (pipefail), and
+chunked transfers must not report success before `btrfs receive` confirms.
+"""
+
+from __future__ import annotations
+
+import shlex
+import shutil
+import subprocess
+
+import pytest
+
+import btrfs_backup_ng.endpoint.raw as raw_mod
+from btrfs_backup_ng.endpoint.raw import (
+    RawEndpoint,
+    SSHRawEndpoint,
+    _popen_pipeline_pipefail,
+)
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None, reason="bash required for pipefail behavior"
+)
+
+
+class TestRawPipelinePipefail:
+    """A raw stream pipeline fails when ANY stage fails, not just the last.
+
+    Without pipefail, `false | cat > file` exits 0 (the redirect succeeds),
+    masking the upstream failure and writing a truncated/empty stream file that
+    is then reported as a successful backup.
+    """
+
+    def test_pipefail_surfaces_upstream_failure(self, tmp_path):
+        out = tmp_path / "out"
+        proc = _popen_pipeline_pipefail(
+            f"false | cat > {shlex.quote(str(out))}",
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+        proc.wait()
+        assert proc.returncode != 0
+
+    def test_successful_pipeline_returns_zero_and_writes(self, tmp_path):
+        out = tmp_path / "out"
+        proc = _popen_pipeline_pipefail(
+            f"printf hello | cat > {shlex.quote(str(out))}",
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+        proc.wait()
+        assert proc.returncode == 0
+        assert out.read_bytes() == b"hello"
+
+
+class TestExecutePipelineRoutesThroughPipefail:
+    """Both multi-stage `_execute_pipeline` implementations use the pipefail helper.
+
+    A multi-stage pipeline exists whenever compression and/or encryption is
+    configured on a raw target -- the live, vulnerable case.
+    """
+
+    @staticmethod
+    def _spy(monkeypatch):
+        captured: dict = {}
+
+        def spy(shell_cmd, **kwargs):
+            captured["shell_cmd"] = shell_cmd
+            allowed = {
+                k: v for k, v in kwargs.items() if k in ("stdin", "stdout", "stderr")
+            }
+            return subprocess.Popen("true", shell=True, **allowed)
+
+        monkeypatch.setattr(raw_mod, "_popen_pipeline_pipefail", spy)
+        return captured
+
+    def test_local_multistage_uses_pipefail_helper(self, monkeypatch, tmp_path):
+        captured = self._spy(monkeypatch)
+        ep = RawEndpoint.__new__(RawEndpoint)
+        ep._pending_metadata = {"stream_path": tmp_path / "out"}  # type: ignore[attr-defined]
+        proc = ep._execute_pipeline([["gzip"], ["cat"]], subprocess.DEVNULL)
+        proc.wait()
+        assert "gzip" in captured.get("shell_cmd", "")
+
+    def test_ssh_multistage_uses_pipefail_helper(self, monkeypatch, tmp_path):
+        captured = self._spy(monkeypatch)
+        ep = SSHRawEndpoint.__new__(SSHRawEndpoint)
+        ep._pending_metadata = {"stream_path": tmp_path / "out"}  # type: ignore[attr-defined]
+        ep.ssh_sudo = False  # type: ignore[attr-defined]
+        ep._build_ssh_command = lambda: ["ssh", "host"]  # type: ignore[method-assign]
+        proc = ep._execute_pipeline([["gzip"], ["cat"]], subprocess.DEVNULL)
+        proc.wait()
+        assert "gzip" in captured.get("shell_cmd", "")

--- a/tests/test_r1_transfer_success_contract.py
+++ b/tests/test_r1_transfer_success_contract.py
@@ -13,6 +13,7 @@ fail. They guard the SSH point-of-truth layer (commit A1).
 
 from __future__ import annotations
 
+import io
 import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -385,5 +386,59 @@ class TestDirectTransferCleanupGating:
         result, cleanup = self._run(
             monkeypatch, monitor_result=True, send_rc=0, recv_rc=0
         )
+        assert result is True
+        cleanup.assert_not_called()
+
+
+class TestReceiveChunkedCleanupGating:
+    """`receive_chunked` cleans a partial only when the receive genuinely failed.
+
+    Same false-negative discipline as the direct SSH path: a nonzero receive is
+    cleaned, but a receive that exited 0 followed by an inconclusive verification
+    must NOT delete the received subvolume.
+    """
+
+    @staticmethod
+    def _run(monkeypatch, *, return_code, verify_result):
+        ep = _bare_endpoint({"path": "/d/5"})
+        ep._normalize_path = lambda p: p  # type: ignore[method-assign]
+        ep.ssh_manager = SimpleNamespace(  # type: ignore[attr-defined]
+            get_ssh_base_cmd=lambda force_tty=False: ["ssh", "host"]
+        )
+        ep._verify_snapshot_exists = MagicMock(return_value=verify_result)  # type: ignore[method-assign]
+        ep._cleanup_partial_subvolume = MagicMock()  # type: ignore[method-assign]
+
+        recv = MagicMock()
+        recv.stdin = MagicMock()
+        recv.stderr = io.BytesIO(b"err")
+        recv.poll.return_value = None  # alive during the streaming loop
+        recv.wait.return_value = return_code
+        recv.returncode = return_code
+        monkeypatch.setattr(ssh_mod.subprocess, "Popen", lambda *a, **k: recv)
+
+        manifest = SimpleNamespace(
+            snapshot_name="snap",
+            snapshot_path="/src/snapshot",
+            chunk_count=1,
+        )
+        reader = MagicMock()
+        reader.read_chunks.return_value = iter([b"data"])
+
+        result = ep.receive_chunked(reader, manifest, show_progress=False, timeout=3600)
+        return result, ep._cleanup_partial_subvolume
+
+    def test_nonzero_receive_cleans_up(self, monkeypatch):
+        result, cleanup = self._run(monkeypatch, return_code=1, verify_result=True)
+        assert result is False
+        cleanup.assert_called_once()
+
+    def test_inconclusive_verify_after_good_receive_keeps_backup(self, monkeypatch):
+        # receive exited 0 but verification failed -> inconclusive -> keep artifact.
+        result, cleanup = self._run(monkeypatch, return_code=0, verify_result=False)
+        assert result is False
+        cleanup.assert_not_called()
+
+    def test_success_returns_true_without_cleanup(self, monkeypatch):
+        result, cleanup = self._run(monkeypatch, return_code=0, verify_result=True)
         assert result is True
         cleanup.assert_not_called()

--- a/tests/test_r1_transfer_success_contract.py
+++ b/tests/test_r1_transfer_success_contract.py
@@ -1,0 +1,389 @@
+"""Enforcement tests for the R1 transfer-success contract.
+
+The contract (see the R1 design): a snapshot transfer succeeds *iff* every process
+in the pipeline exited 0 AND a post-completion check confirms a well-formed
+received subvolume. Existence is checked only AFTER the processes exit 0, never
+during the transfer and never as a substitute for the exit code.
+
+These tests are mutation-verified: reverting any one fix (re-adding the ``test -d``
+fallback, downgrading a nonzero receive to a warning, restoring the mid-flight
+existence short-circuit, or dropping ``pipefail``) makes the corresponding test
+fail. They guard the SSH point-of-truth layer (commit A1).
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import btrfs_backup_ng.endpoint.ssh as ssh_mod
+from btrfs_backup_ng.endpoint.ssh import SSHEndpoint
+
+
+def _bare_endpoint(config: dict | None = None) -> SSHEndpoint:
+    """An SSHEndpoint with no SSH connection, for unit-testing pure logic."""
+    ep = SSHEndpoint.__new__(SSHEndpoint)
+    ep.config = {"ssh_sudo": False, **(config or {})}
+    return ep
+
+
+def _proc(returncode: int | None) -> MagicMock:
+    """A fake process. returncode None == still running (poll returns None)."""
+    p = MagicMock()
+    p.poll.return_value = returncode
+    p.returncode = returncode
+    p.stderr = None
+    return p
+
+
+def _proc_alive_then(returncode: int) -> MagicMock:
+    """A fake process that reports alive (poll -> None) on the FIRST poll and
+    finished (poll -> returncode) on every poll thereafter.
+
+    Robust to the exact number of poll() calls the code makes (unlike a fixed
+    side_effect list, which raises StopIteration if the call count shifts). The
+    code only reads ``.returncode`` after a poll has reported the process
+    finished, so a static returncode value is faithful at every read site.
+    """
+    p = MagicMock()
+    state = {"polled": False}
+
+    def poll():
+        if not state["polled"]:
+            state["polled"] = True
+            return None
+        return returncode
+
+    p.poll.side_effect = poll
+    p.returncode = returncode
+    p.stderr = None
+    return p
+
+
+class TestVerifyRejectsPlainDirectory:
+    """`_verify_snapshot_exists` requires a real subvolume, not just a directory.
+
+    A failed/interrupted `btrfs receive` can leave a bare directory at the exact
+    destination path. The removed `test -d` fallback would have accepted it as a
+    valid backup. Only a successful `btrfs subvolume show` counts.
+    """
+
+    @staticmethod
+    def _endpoint(subvolume_paths: set[str], dir_paths: set[str]) -> SSHEndpoint:
+        ep = _bare_endpoint()
+
+        def fake_exec(cmd, **kwargs):
+            target = cmd[-1]
+            if cmd[:3] == ["btrfs", "subvolume", "show"]:
+                rc = 0 if target in subvolume_paths else 1
+            elif cmd[:2] == ["test", "-d"]:
+                rc = 0 if target in dir_paths else 1
+            else:
+                rc = 1
+            return SimpleNamespace(returncode=rc, stdout=b"", stderr=b"")
+
+        ep._exec_remote_command = MagicMock(side_effect=fake_exec)  # type: ignore[method-assign]
+        ep._exec_remote_command_with_retry = MagicMock(side_effect=fake_exec)  # type: ignore[method-assign]
+        return ep
+
+    def test_real_subvolume_verifies(self):
+        ep = self._endpoint(subvolume_paths={"/d/5/snapshot"}, dir_paths=set())
+        assert ep._verify_snapshot_exists("/d/5", "snapshot") is True
+
+    def test_plain_directory_is_not_accepted(self):
+        # `btrfs subvolume show` fails (not a subvolume) but the directory exists.
+        # The old `test -d` fallback reported success here; the contract rejects it.
+        ep = self._endpoint(subvolume_paths=set(), dir_paths={"/d/5/snapshot"})
+        assert ep._verify_snapshot_exists("/d/5", "snapshot") is False
+
+
+class TestSimpleMonitorReceiveExitAuthoritative:
+    """`_simple_transfer_monitor`: a nonzero `btrfs receive` exit is a failure."""
+
+    def _run(self, send_rc, receive_rc, verify_result):
+        ep = _bare_endpoint()
+        ep._verify_snapshot_exists = MagicMock(return_value=verify_result)  # type: ignore[method-assign]
+        ep._log_simple_process_error = MagicMock()  # type: ignore[method-assign]
+        processes = {
+            "send": _proc(send_rc),
+            "receive": _proc(receive_rc),
+            "buffer": None,
+        }
+        return ep._simple_transfer_monitor(
+            processes=processes,
+            start_time=time.time(),
+            dest_path="/d/5",
+            snapshot_name="snapshot",
+            max_wait_time=3600,
+            received_name="snapshot",
+        )
+
+    def test_nonzero_receive_fails_even_when_subvolume_exists(self):
+        # Both processes finished; receive exited nonzero. Even though existence
+        # verification would pass, the transfer MUST be reported as failed.
+        assert self._run(send_rc=0, receive_rc=1, verify_result=True) is False
+
+    def test_nonzero_send_fails_even_when_subvolume_exists(self):
+        # The contract requires EVERY process to exit 0, not just receive.
+        assert self._run(send_rc=1, receive_rc=0, verify_result=True) is False
+
+    def test_success_requires_both_exit_zero_and_verification(self):
+        # Guards against a false-negative: a genuinely good transfer still passes.
+        assert self._run(send_rc=0, receive_rc=0, verify_result=True) is True
+
+    def test_zero_exit_but_missing_subvolume_fails(self):
+        assert self._run(send_rc=0, receive_rc=0, verify_result=False) is False
+
+    def test_timeout_with_live_processes_fails(self):
+        # start_time in the past forces the wait loop to exit immediately with the
+        # processes still "alive" (poll() -> None): a timeout, which must fail
+        # rather than fall through to an existence check.
+        ep = _bare_endpoint()
+        ep._verify_snapshot_exists = MagicMock(return_value=True)  # type: ignore[method-assign]
+        processes = {"send": _proc(None), "receive": _proc(None), "buffer": None}
+        result = ep._simple_transfer_monitor(
+            processes=processes,
+            start_time=time.time() - 10_000,
+            dest_path="/d/5",
+            snapshot_name="snapshot",
+            max_wait_time=1,
+            received_name="snapshot",
+        )
+        assert result is False
+
+
+class TestEnhancedMonitorReceiveExitAuthoritative:
+    """`_monitor_transfer_progress`: nonzero receive fails; no mid-flight success."""
+
+    def _run(self, send, receive, verify_result, start_time=None):
+        ep = _bare_endpoint()
+        ep._verify_snapshot_exists = MagicMock(return_value=verify_result)  # type: ignore[method-assign]
+        ep._log_process_error = MagicMock()  # type: ignore[method-assign]
+        processes = {"send": send, "receive": receive, "buffer": None}
+        return ep._monitor_transfer_progress(
+            processes=processes,
+            start_time=start_time if start_time is not None else time.time(),
+            dest_path="/d/5",
+            snapshot_name="snapshot",
+            max_wait_time=3600,
+            received_name="snapshot",
+        )
+
+    def test_nonzero_receive_fails_even_when_subvolume_exists(self):
+        assert self._run(_proc(0), _proc(1), verify_result=True) is False
+
+    def test_nonzero_send_fails_even_when_subvolume_exists(self):
+        assert self._run(_proc(1), _proc(0), verify_result=True) is False
+
+    def test_success_requires_both_exit_zero_and_verification(self):
+        # Green-path guard against a false-negative in the enhanced monitor.
+        assert self._run(_proc(0), _proc(0), verify_result=True) is True
+
+    def test_zero_exit_but_missing_subvolume_fails(self):
+        assert self._run(_proc(0), _proc(0), verify_result=False) is False
+
+    def test_timeout_with_live_processes_fails(self):
+        # Processes still running past max_wait_time: a timeout, which must fail
+        # rather than fall through to an existence check.
+        ep = _bare_endpoint()
+        ep._verify_snapshot_exists = MagicMock(return_value=True)  # type: ignore[method-assign]
+        ep._log_process_error = MagicMock()  # type: ignore[method-assign]
+        processes = {"send": _proc(None), "receive": _proc(None), "buffer": None}
+        result = ep._monitor_transfer_progress(
+            processes=processes,
+            start_time=time.time() - 10_000,
+            dest_path="/d/5",
+            snapshot_name="snapshot",
+            max_wait_time=1,
+            received_name="snapshot",
+        )
+        assert result is False
+
+    def test_no_mid_flight_success_when_receive_later_fails(self):
+        # Force the periodic-verification branch to fire on the first loop
+        # iteration (start_time set 31s in the past so the 30s interval elapses),
+        # while the subvolume already "exists". The receive process is alive on
+        # that first iteration and then exits NONZERO. The old code returned True
+        # from the periodic existence check (racing the still-running receive); the
+        # contract requires waiting for the authoritative exit code -> failure.
+        send = _proc(0)  # finished cleanly throughout
+        receive = _proc_alive_then(1)  # alive on first poll, then exits nonzero
+        result = self._run(
+            send, receive, verify_result=True, start_time=time.time() - 31
+        )
+        assert result is False
+
+
+class TestShellPipeline:
+    """`_do_shell_pipeline_transfer`: pipefail + exit-code authority + safe cleanup.
+
+    Without pipefail the shell reports only the last stage's (ssh/receive) exit
+    code, masking a `btrfs send` or `pv` failure -> a truncated/empty backup
+    reported as success. And because a zero pipeline exit means the receive
+    succeeded, an inconclusive verification there must NOT delete the artifact.
+    """
+
+    @staticmethod
+    def _run(monkeypatch, *, pipeline_rc, verify_result):
+        ep = _bare_endpoint({"username": "u", "port": None, "ssh_sudo": True})
+        ep.hostname = "host"
+        ep.ssh_manager = SimpleNamespace(control_path="/tmp/cp")
+        ep._estimate_snapshot_size = MagicMock(return_value=None)  # type: ignore[method-assign]
+        ep._check_command_exists = MagicMock(return_value=False)  # type: ignore[method-assign]
+        ep._verify_snapshot_exists = MagicMock(return_value=verify_result)  # type: ignore[method-assign]
+        ep._cleanup_partial_subvolume = MagicMock()  # type: ignore[method-assign]
+
+        captured: dict = {}
+
+        class FakeStderr:
+            def read(self, _n=-1):
+                return b""
+
+        def fake_popen(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["executable"] = kwargs.get("executable")
+            proc = MagicMock()
+            proc.stderr = FakeStderr()
+            proc.wait.return_value = pipeline_rc
+            proc.returncode = pipeline_rc
+            return proc
+
+        monkeypatch.setattr(ssh_mod.shutil, "which", lambda name: "/bin/bash")
+        monkeypatch.setattr(ssh_mod.subprocess, "Popen", fake_popen)
+
+        ok = ep._do_shell_pipeline_transfer(
+            source_path="/src/snapshot",
+            dest_path="/d/5",
+            snapshot_name="snapshot",
+        )
+        return ok, ep._cleanup_partial_subvolume, captured
+
+    def test_pipeline_launched_with_pipefail_under_bash(self, monkeypatch):
+        ok, _cleanup, captured = self._run(
+            monkeypatch, pipeline_rc=0, verify_result=True
+        )
+        assert ok is True
+        assert captured["cmd"].startswith("set -o pipefail;")
+        assert captured["executable"] == "/bin/bash"
+
+    def test_pipeline_failure_fails_and_cleans_up(self, monkeypatch):
+        # Nonzero pipeline exit (a real send/pv/receive failure) -> failure, and
+        # the partial artifact IS removed.
+        ok, cleanup, _captured = self._run(
+            monkeypatch, pipeline_rc=1, verify_result=True
+        )
+        assert ok is False
+        cleanup.assert_called_once()
+
+    def test_pipeline_success_but_inconclusive_verify_keeps_artifact(self, monkeypatch):
+        # Pipeline exited 0 (receive succeeded) but verification failed: report
+        # failure but do NOT delete -- the received subvolume may be a good backup
+        # and only the verify step failed. This is the false-negative guard.
+        ok, cleanup, _captured = self._run(
+            monkeypatch, pipeline_rc=0, verify_result=False
+        )
+        assert ok is False
+        cleanup.assert_not_called()
+
+
+class TestCleanupPartialSubvolume:
+    """Failed transfers remove their partial artifact at the exact path only."""
+
+    def _endpoint(self):
+        ep = _bare_endpoint()
+        calls: list[list[str]] = []
+
+        def fake_exec(cmd, **kwargs):
+            calls.append(list(cmd))
+            # `test -e` succeeds (something is present); delete succeeds.
+            return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+        ep._exec_remote_command = MagicMock(side_effect=fake_exec)  # type: ignore[method-assign]
+        ep._exec_remote_command_with_retry = MagicMock(side_effect=fake_exec)  # type: ignore[method-assign]
+        return ep, calls
+
+    def test_deletes_exact_path_when_present(self):
+        ep, calls = self._endpoint()
+        ep._cleanup_partial_subvolume("/d/5", "snapshot")
+        delete_cmds = [c for c in calls if c[:3] == ["btrfs", "subvolume", "delete"]]
+        assert delete_cmds, "expected a subvolume delete of the partial"
+        assert delete_cmds[0][-1] == "/d/5/snapshot"
+
+    def test_no_delete_when_nothing_present(self):
+        ep = _bare_endpoint()
+        calls: list[list[str]] = []
+
+        def fake_exec(cmd, **kwargs):
+            calls.append(list(cmd))
+            # `test -e` fails -> nothing at the path -> no delete attempted.
+            return SimpleNamespace(returncode=1, stdout=b"", stderr=b"")
+
+        ep._exec_remote_command = MagicMock(side_effect=fake_exec)  # type: ignore[method-assign]
+        ep._exec_remote_command_with_retry = MagicMock(side_effect=fake_exec)  # type: ignore[method-assign]
+        ep._cleanup_partial_subvolume("/d/5", "snapshot")
+        assert not [c for c in calls if c[:3] == ["btrfs", "subvolume", "delete"]]
+
+
+class TestDirectTransferCleanupGating:
+    """`_try_direct_transfer` deletes a partial ONLY when a process actually failed.
+
+    This pins the false-negative guard: if the receive exited 0 but the monitor
+    returned failure because verification was inconclusive (e.g. a transient
+    timeout on `btrfs subvolume show`), the just-received subvolume must be LEFT
+    IN PLACE — deleting it would destroy a successful backup. Cleanup runs only
+    when the receive (or send) genuinely failed / was killed.
+    """
+
+    @staticmethod
+    def _run(monkeypatch, *, monitor_result, send_rc, recv_rc):
+        ep = _bare_endpoint({"path": "/d/5", "simple_progress": True})
+        ep.hostname = "host"
+        ep._run_diagnostics = MagicMock(  # type: ignore[method-assign]
+            return_value={
+                "ssh_connection": True,
+                "btrfs_command": True,
+                "write_permissions": True,
+                "btrfs_filesystem": True,
+                "passwordless_sudo": True,
+            }
+        )
+        ep._find_buffer_program = MagicMock(return_value=(None, None))  # type: ignore[method-assign]
+        send = _proc(send_rc)
+        receive = _proc(recv_rc)
+        ep._btrfs_receive = MagicMock(return_value=receive)  # type: ignore[method-assign]
+        ep._simple_transfer_monitor = MagicMock(return_value=monitor_result)  # type: ignore[method-assign]
+        ep._cleanup_partial_subvolume = MagicMock()  # type: ignore[method-assign]
+
+        monkeypatch.setattr(ssh_mod.subprocess, "Popen", lambda *a, **k: send)
+        monkeypatch.setattr(ssh_mod.os.path, "exists", lambda p: True)
+
+        result = ep._try_direct_transfer(
+            source_path="/src/snapshot",
+            dest_path="/d/5",
+            snapshot_name="snapshot",
+        )
+        return result, ep._cleanup_partial_subvolume
+
+    def test_receive_failure_triggers_cleanup(self, monkeypatch):
+        result, cleanup = self._run(
+            monkeypatch, monitor_result=False, send_rc=0, recv_rc=1
+        )
+        assert result is False
+        cleanup.assert_called_once()
+
+    def test_inconclusive_verify_with_good_receive_keeps_backup(self, monkeypatch):
+        # THE false-negative guard: receive exited 0, monitor returned failure
+        # (verification inconclusive) -> the good subvolume must NOT be deleted.
+        result, cleanup = self._run(
+            monkeypatch, monitor_result=False, send_rc=0, recv_rc=0
+        )
+        assert result is False
+        cleanup.assert_not_called()
+
+    def test_success_returns_true_without_cleanup(self, monkeypatch):
+        result, cleanup = self._run(
+            monkeypatch, monitor_result=True, send_rc=0, recv_rc=0
+        )
+        assert result is True
+        cleanup.assert_not_called()


### PR DESCRIPTION
## R1 — the transfer-success contract

First root of the whole-project audit (0.9.0-scale reliability work). Fixes the
most dangerous bug class for a backup tool: **a failed transfer being reported
as a successful backup (exit 0, "success" notification).** The audit found this
root proliferating from the endpoint layer all the way to the CLI exit codes.

### The contract
A snapshot transfer succeeds **iff** every process in the pipeline (send,
buffer, receive, and every stage of a raw/compression pipe) exited 0 **and** a
post-completion check confirms a well-formed artifact. Existence is checked only
*after* the processes exit 0 — never during the transfer, never as a substitute
for the exit code. A transfer that isn't successful must not release the source
lock, must clean up its partial artifact (only when a process actually failed),
and must propagate as an observable failure that drives a non-zero exit and a
failure notification.

### Commits (bottom-up: each layer only has truth to report once the one below it does)
1. **fix(ssh)** — receive/send exit codes are authoritative across every live SSH
   transfer path; removed the `test -d` fallback, the mid-flight existence
   short-circuit that raced the live receive, the fabricated exit codes, and the
   `ls` name-search; `pipefail` on the shell pipeline. Partial cleanup is gated
   on *actual process failure*, so a good backup is never deleted on an
   inconclusive verification.
2. **fix(raw)** — raw stream pipeline runs under `set -o pipefail`, so a mid-pipe
   `btrfs send`/compressor/gpg failure is no longer masked by the last stage
   (which produced a truncated/empty stream reported as success).
3. **fix(chunked)** — `btrfs send` exit code checked (a mid-stream send death no
   longer yields a truncated manifest transferred as success); chunks marked
   TRANSFERRED only after `btrfs receive` confirms (a failed receive no longer
   looks resumable-complete); `receive_chunked` cleans partials on real failure
   (same false-negative guard).
4. **fix(core)** — orchestration stops swallowing: `TransferResult` +
   `sync_snapshots`/`sync_snapper_snapshots` raise on any failure with the
   transferred/failed breakdown attached as `err.result`.
5. **fix(legacy)** — the legacy CLI path exits non-zero when a transfer fails
   (it caught the failure but returned 0).

### Verification
- Full suite **2037 passing**, 1 skipped; ruff/format/mypy clean.
- **New enforcement tests** across 4 files; **every fix is mutation-verified**
  (revert the fix → the guarding test fails → restore).
- Each commit adversarially reviewed (correctness / false-negative / completeness
  / test-quality lenses). The one real finding — a transient verify timeout after
  a *successful* receive could delete the good backup — was fixed before A1
  landed and is mutation-guarded.

### Tracked follow-ups (deferred deliberately, not forgotten)
- Local/standard partial-cleanup on receive timeout/kill (hygiene; needs the same
  exact-path derivation to avoid wrong-path deletion).
- Standard-path wait-order deadlock avoidance (reliability).
- Notification metric *precision* (exact per-snapshot "N of M" counts; the status
  is already correct — failure is reported, this is number accuracy only).
- Raw `shlex.quote` (→ R9 shell-injection root); raw stream size-check + `.meta`
  sidecar wiring (→ R5 raw-restore root); chunked manifest byte-count validation.
- `InsufficientSpaceError` does not carry a `TransferResult` (pre-existing; a
  uniform-contract follow-up).

No behavior change for successful backups; the change is that failures now tell
the truth.
