### PR TITLE
fix: R2 — clean up partial artifacts so failed transfers don't poison re-runs

### DIFF
--- a/src/btrfs_backup_ng/core/__init__.py
+++ b/src/btrfs_backup_ng/core/__init__.py
@@ -6,7 +6,7 @@ monolithic __main__.py, organized into focused modules.
 
 from .execution import execute_parallel, run_task
 from .operations import send_snapshot, sync_snapshots
-from .planning import delete_corrupt_snapshots, plan_transfers
+from .planning import plan_transfers
 
 # Error classification and retry framework
 from .errors import (
@@ -76,7 +76,6 @@ __all__ = [
     "send_snapshot",
     "sync_snapshots",
     "plan_transfers",
-    "delete_corrupt_snapshots",
     "run_task",
     "execute_parallel",
     # Errors

--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -1243,6 +1243,47 @@ def _cleanup_partial_remote_subvolume(destination_endpoint, manifest) -> None:
         logger.debug("Partial remote-subvolume cleanup failed: %s", e)
 
 
+def _cleanup_partial_raw_stream(destination_endpoint) -> None:
+    """Best-effort removal of the exact raw stream file a failed raw transfer wrote.
+
+    Raw backups use a distinct timestamped filename each run, and a generic raw
+    backup carries no ``.meta`` sidecar (``finalize_receive`` is unused), so a
+    failed partial is NOT overwritten by the next run and cannot be distinguished
+    from a complete backup by "missing .meta". ``discover_raw_snapshots``' filename
+    fallback would therefore re-list the partial as a phantom backup.
+
+    Delete ONLY the exact ``_pending_metadata['stream_path']`` this run wrote --
+    never a name pattern or a "no .meta" heuristic (which would destroy a good
+    generic raw backup). Called only on the failure path where the transfer
+    pipeline exited nonzero, so the stream file is genuinely incomplete.
+    """
+    from ..endpoint.raw import RawEndpoint, SSHRawEndpoint
+
+    if not isinstance(destination_endpoint, RawEndpoint):
+        return
+    pending = getattr(destination_endpoint, "_pending_metadata", None)
+    if not pending:
+        return
+    stream_path = pending.get("stream_path")
+    if not stream_path:
+        return
+    try:
+        if isinstance(destination_endpoint, SSHRawEndpoint):
+            logger.warning(
+                "Cleaning up partial remote raw stream file at %s", stream_path
+            )
+            destination_endpoint._exec_remote_command(
+                ["rm", "-f", str(stream_path)], check=False
+            )
+        else:
+            p = Path(stream_path)
+            if p.exists():
+                logger.warning("Cleaning up partial raw stream file at %s", p)
+                p.unlink()
+    except Exception as e:
+        logger.debug("Partial raw-stream cleanup failed for %s: %s", stream_path, e)
+
+
 def _execute_transfers(
     source_endpoint,
     destination_endpoint,
@@ -1320,10 +1361,13 @@ def _execute_transfers(
             result.failed.append((best_snapshot, e))
             # Remove any partial received subvolume the failed transfer left at the
             # destination so the next run's skip-detection cannot mistake it for a
-            # completed backup (local btrfs only; SSH/raw clean their own).
+            # completed backup. Local btrfs and raw (whose distinct-per-run stream
+            # file would otherwise be re-listed as a phantom backup) are cleaned
+            # here; SSH btrfs endpoints clean their own partials during transfer.
             _cleanup_partial_local_subvolume(
                 destination_endpoint, best_snapshot.get_name()
             )
+            _cleanup_partial_raw_stream(destination_endpoint)
 
         to_transfer.remove(best_snapshot)
         logger.debug("%d snapshots left to transfer", len(to_transfer))

--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -959,7 +959,10 @@ def _do_process_transfer(
     )
 
     try:
-        return_code_receive = receive_process.wait(timeout=300)
+        # Match the send timeout: applying a large received stream can legitimately
+        # take well over the old 300s, and killing it here manufactures exactly the
+        # partial subvolume this path must avoid.
+        return_code_receive = receive_process.wait(timeout=timeout_seconds)
         logger.debug(
             "Receive process completed with return code: %d", return_code_receive
         )
@@ -1163,6 +1166,56 @@ def sync_snapshots(
     return result
 
 
+def _cleanup_partial_local_subvolume(destination_endpoint, snapshot) -> None:
+    """Best-effort removal of a partial received subvolume after a failed transfer.
+
+    A killed or failed local ``btrfs receive`` leaves an incomplete subvolume at
+    ``{dest}/{name}`` (named after the source basename, == ``snapshot.get_name()``),
+    which the next run's skip-detection would enumerate and mistake for a completed
+    backup -- silently skipping the real transfer. Remove it so a re-run starts
+    clean.
+
+    Safety (the received subvolume is never a good backup here):
+      * only called on the failure path, so a successful transfer never triggers it;
+      * skip-detection already excluded any snapshot whose name is present at the
+        destination BEFORE the transfer was attempted, so anything now at the exact
+        path is this failed run's partial, not a prior good backup;
+      * scoped to the EXACT single path via ``Path.exists()`` -- never a
+        filesystem-wide name search -- so siblings are untouched.
+
+    Only handles LOCAL btrfs destinations: SSH endpoints clean their own partials
+    during the transfer, and raw destinations are handled by the raw cleanup path.
+    """
+    import os
+
+    from ..endpoint.raw import RawEndpoint
+
+    if getattr(destination_endpoint, "_is_remote", False):
+        return
+    if isinstance(destination_endpoint, RawEndpoint):
+        return
+
+    name = snapshot.get_name()
+    base = str(destination_endpoint.config["path"]).rstrip("/")
+    expected = f"{base}/{name}"
+    try:
+        if not Path(expected).exists():
+            return
+        logger.warning("Cleaning up partial local transfer artifact at %s", expected)
+        sudo = [] if os.geteuid() == 0 else ["sudo"]
+        deleted = subprocess.run(
+            [*sudo, "btrfs", "subvolume", "delete", expected],
+            capture_output=True,
+        )
+        if deleted.returncode != 0:
+            # A killed receive can leave a plain directory rather than a subvolume.
+            subprocess.run([*sudo, "rm", "-rf", expected], capture_output=True)
+    except Exception as cleanup_e:
+        logger.debug(
+            "Partial local-subvolume cleanup failed for %s: %s", expected, cleanup_e
+        )
+
+
 def _execute_transfers(
     source_endpoint,
     destination_endpoint,
@@ -1238,6 +1291,10 @@ def _execute_transfers(
             logger.error("Snapshot transfer failed for %s: %s", best_snapshot, e)
             logger.info("Keeping %s locked to prevent deletion.", best_snapshot)
             result.failed.append((best_snapshot, e))
+            # Remove any partial received subvolume the failed transfer left at the
+            # destination so the next run's skip-detection cannot mistake it for a
+            # completed backup (local btrfs only; SSH/raw clean their own).
+            _cleanup_partial_local_subvolume(destination_endpoint, best_snapshot)
 
         to_transfer.remove(best_snapshot)
         logger.debug("%d snapshots left to transfer", len(to_transfer))

--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -573,6 +573,9 @@ def _transfer_chunks_local(
 
     except subprocess.TimeoutExpired:
         receive_process.kill()
+        _cleanup_partial_local_subvolume(
+            destination_endpoint, Path(manifest.snapshot_path).name
+        )
         raise __util__.SnapshotTransferError("Timeout waiting for btrfs receive")
 
     except Exception:
@@ -580,6 +583,9 @@ def _transfer_chunks_local(
             receive_process.kill()
         except Exception:
             pass
+        _cleanup_partial_local_subvolume(
+            destination_endpoint, Path(manifest.snapshot_path).name
+        )
         raise
 
 
@@ -688,6 +694,7 @@ def _transfer_chunks_ssh(
 
         except subprocess.TimeoutExpired:
             receive_process.kill()
+            _cleanup_partial_remote_subvolume(destination_endpoint, manifest)
             raise __util__.SnapshotTransferError(
                 "Timeout waiting for SSH btrfs receive"
             )
@@ -697,6 +704,7 @@ def _transfer_chunks_ssh(
                 receive_process.kill()
             except Exception:
                 pass
+            _cleanup_partial_remote_subvolume(destination_endpoint, manifest)
             # Re-raise with context about which chunk failed
             if chunks_sent < len(manifest.chunks):
                 chunk = manifest.chunks[chunks_sent]
@@ -1166,14 +1174,14 @@ def sync_snapshots(
     return result
 
 
-def _cleanup_partial_local_subvolume(destination_endpoint, snapshot) -> None:
+def _cleanup_partial_local_subvolume(destination_endpoint, name: str) -> None:
     """Best-effort removal of a partial received subvolume after a failed transfer.
 
     A killed or failed local ``btrfs receive`` leaves an incomplete subvolume at
-    ``{dest}/{name}`` (named after the source basename, == ``snapshot.get_name()``),
-    which the next run's skip-detection would enumerate and mistake for a completed
-    backup -- silently skipping the real transfer. Remove it so a re-run starts
-    clean.
+    ``{dest}/{name}`` (``name`` is the received subvolume's on-disk name, i.e. the
+    SOURCE basename), which the next run's skip-detection would enumerate and
+    mistake for a completed backup -- silently skipping the real transfer. Remove
+    it so a re-run starts clean.
 
     Safety (the received subvolume is never a good backup here):
       * only called on the failure path, so a successful transfer never triggers it;
@@ -1195,7 +1203,6 @@ def _cleanup_partial_local_subvolume(destination_endpoint, snapshot) -> None:
     if isinstance(destination_endpoint, RawEndpoint):
         return
 
-    name = snapshot.get_name()
     base = str(destination_endpoint.config["path"]).rstrip("/")
     expected = f"{base}/{name}"
     try:
@@ -1214,6 +1221,26 @@ def _cleanup_partial_local_subvolume(destination_endpoint, snapshot) -> None:
         logger.debug(
             "Partial local-subvolume cleanup failed for %s: %s", expected, cleanup_e
         )
+
+
+def _cleanup_partial_remote_subvolume(destination_endpoint, manifest) -> None:
+    """Best-effort removal of a partial REMOTE subvolume after a failed chunked
+    SSH transfer, using the endpoint's own exact-path cleaner when present.
+
+    Scoped to the exact received path (``{dest}/{source_basename}``) by the
+    underlying ``_cleanup_partial_subvolume``, which guards on existence and never
+    searches by name -- so a good backup is never deleted. A no-op for endpoints
+    that do not expose the cleaner.
+    """
+    cleaner = getattr(destination_endpoint, "_cleanup_partial_subvolume", None)
+    if cleaner is None:
+        return
+    try:
+        dest_path = str(destination_endpoint.config["path"])
+        received_name = Path(manifest.snapshot_path).name
+        cleaner(dest_path, received_name)
+    except Exception as e:
+        logger.debug("Partial remote-subvolume cleanup failed: %s", e)
 
 
 def _execute_transfers(
@@ -1294,7 +1321,9 @@ def _execute_transfers(
             # Remove any partial received subvolume the failed transfer left at the
             # destination so the next run's skip-detection cannot mistake it for a
             # completed backup (local btrfs only; SSH/raw clean their own).
-            _cleanup_partial_local_subvolume(destination_endpoint, best_snapshot)
+            _cleanup_partial_local_subvolume(
+                destination_endpoint, best_snapshot.get_name()
+            )
 
         to_transfer.remove(best_snapshot)
         logger.debug("%d snapshots left to transfer", len(to_transfer))

--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -1203,9 +1203,9 @@ def _cleanup_partial_local_subvolume(destination_endpoint, name: str) -> None:
     if isinstance(destination_endpoint, RawEndpoint):
         return
 
-    base = str(destination_endpoint.config["path"]).rstrip("/")
-    expected = f"{base}/{name}"
     try:
+        base = str(destination_endpoint.config["path"]).rstrip("/")
+        expected = f"{base}/{name}"
         if not Path(expected).exists():
             return
         logger.warning("Cleaning up partial local transfer artifact at %s", expected)
@@ -1218,9 +1218,8 @@ def _cleanup_partial_local_subvolume(destination_endpoint, name: str) -> None:
             # A killed receive can leave a plain directory rather than a subvolume.
             subprocess.run([*sudo, "rm", "-rf", expected], capture_output=True)
     except Exception as cleanup_e:
-        logger.debug(
-            "Partial local-subvolume cleanup failed for %s: %s", expected, cleanup_e
-        )
+        # Best-effort: never let a cleanup problem mask the original transfer error.
+        logger.debug("Partial local-subvolume cleanup failed: %s", cleanup_e)
 
 
 def _cleanup_partial_remote_subvolume(destination_endpoint, manifest) -> None:

--- a/src/btrfs_backup_ng/core/planning.py
+++ b/src/btrfs_backup_ng/core/planning.py
@@ -40,66 +40,6 @@ def plan_transfers(
     return to_transfer
 
 
-def delete_corrupt_snapshots(
-    destination_endpoint,
-    source_snapshots: list,
-    destination_snapshots: list,
-) -> list:
-    """Delete corrupt snapshots from destination.
-
-    Corrupt snapshots are those that exist at destination but have
-    locks indicating a transfer was interrupted.
-
-    Args:
-        destination_endpoint: The destination endpoint
-        source_snapshots: List of source snapshots
-        destination_snapshots: List of destination snapshots
-
-    Returns:
-        Updated list of destination snapshots after deletion
-    """
-    to_remove = []
-    destination_id = destination_endpoint.get_id()
-
-    for snapshot in source_snapshots:
-        if snapshot in destination_snapshots and destination_id in snapshot.locks:
-            destination_snapshot = destination_snapshots[
-                destination_snapshots.index(snapshot)
-            ]
-            logger.info(
-                "Potentially corrupt snapshot %s found at %s",
-                destination_snapshot,
-                destination_endpoint,
-            )
-            to_remove.append(destination_snapshot)
-
-    if to_remove:
-        destination_endpoint.delete_snapshots(to_remove)
-        # Refresh after deletion
-        destination_snapshots = destination_endpoint.list_snapshots()
-
-    return destination_snapshots
-
-
-def clear_locks(
-    source_endpoint,
-    source_snapshots: list,
-    destination_id: str,
-) -> None:
-    """Clear locks for a destination from source snapshots.
-
-    Args:
-        source_endpoint: The source endpoint
-        source_snapshots: List of source snapshots
-        destination_id: ID of the destination to clear locks for
-    """
-    for snapshot in source_snapshots:
-        if destination_id in snapshot.locks:
-            source_endpoint.set_lock(snapshot, destination_id, False)
-        if destination_id in snapshot.parent_locks:
-            source_endpoint.set_lock(snapshot, destination_id, False, parent=True)
-
-
 def find_best_transfer_order(
     to_transfer: list,
     source_snapshots: list,

--- a/tests/test_r2_cleanup_recovery.py
+++ b/tests/test_r2_cleanup_recovery.py
@@ -8,8 +8,11 @@ deleted (the R1 false-negative guard, extended to the local/standard path).
 
 from __future__ import annotations
 
+import io
 from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+import pytest
 
 import btrfs_backup_ng.core.operations as ops
 from btrfs_backup_ng import __util__
@@ -33,7 +36,6 @@ class TestCleanupPartialLocalSubvolume:
     def test_deletes_exact_local_path_when_present(self, monkeypatch, tmp_path):
         (tmp_path / "snap-1").mkdir()  # the partial artifact this failed run left
         ep = self._local_endpoint(tmp_path)
-        snap = _fake_snap("snap-1")
 
         calls: list[list[str]] = []
 
@@ -42,7 +44,7 @@ class TestCleanupPartialLocalSubvolume:
             return SimpleNamespace(returncode=0)
 
         monkeypatch.setattr(ops.subprocess, "run", fake_run)
-        ops._cleanup_partial_local_subvolume(ep, snap)
+        ops._cleanup_partial_local_subvolume(ep, "snap-1")
 
         deletes = [c for c in calls if c[-3:-1] == ["subvolume", "delete"]]
         assert deletes, "expected a btrfs subvolume delete of the partial"
@@ -50,10 +52,9 @@ class TestCleanupPartialLocalSubvolume:
 
     def test_noop_when_nothing_present(self, monkeypatch, tmp_path):
         ep = self._local_endpoint(tmp_path)
-        snap = _fake_snap("absent")
         called: list[int] = []
         monkeypatch.setattr(ops.subprocess, "run", lambda *a, **k: called.append(1))
-        ops._cleanup_partial_local_subvolume(ep, snap)
+        ops._cleanup_partial_local_subvolume(ep, "absent")
         assert not called
 
     def test_skips_remote_endpoint(self, monkeypatch, tmp_path):
@@ -61,10 +62,9 @@ class TestCleanupPartialLocalSubvolume:
         ep = MagicMock()
         ep._is_remote = True  # SSH cleans its own partials during the transfer
         ep.config = {"path": str(tmp_path)}
-        snap = _fake_snap("snap-1")
         called: list[int] = []
         monkeypatch.setattr(ops.subprocess, "run", lambda *a, **k: called.append(1))
-        ops._cleanup_partial_local_subvolume(ep, snap)
+        ops._cleanup_partial_local_subvolume(ep, "snap-1")
         assert not called
 
     def test_skips_raw_endpoint(self, monkeypatch, tmp_path):
@@ -74,10 +74,9 @@ class TestCleanupPartialLocalSubvolume:
         ep = RawEndpoint.__new__(RawEndpoint)
         ep._is_remote = False  # local raw: handled by the raw cleanup path, not here
         ep.config = {"path": str(tmp_path)}
-        snap = _fake_snap("snap-1")
         called: list[int] = []
         monkeypatch.setattr(ops.subprocess, "run", lambda *a, **k: called.append(1))
-        ops._cleanup_partial_local_subvolume(ep, snap)
+        ops._cleanup_partial_local_subvolume(ep, "snap-1")
         assert not called
 
 
@@ -100,8 +99,8 @@ class TestExecuteTransfersCleansPartialOnFailure:
         ops._execute_transfers(src, dst, [snap], [], [snap], True, {})
 
         spy.assert_called_once()
-        # cleanup targets the exact snapshot that failed
-        assert spy.call_args[0][1] is snap
+        # cleanup targets the exact received name of the snapshot that failed
+        assert spy.call_args[0][1] == "s1"
 
     def test_success_does_not_trigger_cleanup(self, monkeypatch):
         snap = _fake_snap("s1")
@@ -116,3 +115,50 @@ class TestExecuteTransfersCleansPartialOnFailure:
 
         ops._execute_transfers(src, dst, [snap], [], [snap], True, {})
         spy.assert_not_called()
+
+
+class TestChunkedPartialCleanup:
+    def test_local_chunked_failure_cleans_exact_partial(self, monkeypatch):
+        manifest = SimpleNamespace(
+            snapshot_path="/src/snapshot",
+            snapshot_name="snap",
+            chunk_count=1,
+            chunks=[SimpleNamespace(sequence=0)],
+        )
+        dst = MagicMock()
+        dst._is_remote = False
+        recv = MagicMock()
+        recv.wait.return_value = 1  # btrfs receive fails
+        recv.stderr = io.BytesIO(b"boom")
+        dst.receive.return_value = recv
+
+        mgr = MagicMock()
+        reader = MagicMock()
+        reader.pipe_to_process.return_value = 100
+        mgr.create_reassembly_reader.return_value = reader
+
+        spy = MagicMock()
+        monkeypatch.setattr(ops, "_cleanup_partial_local_subvolume", spy)
+
+        with pytest.raises(__util__.SnapshotTransferError):
+            ops._transfer_chunks_local(manifest, dst, mgr, {})
+
+        spy.assert_called_once()
+        # cleanup uses the source basename, NOT manifest.snapshot_name
+        assert spy.call_args[0][1] == "snapshot"
+
+    def test_remote_cleanup_calls_endpoint_cleaner(self):
+        manifest = SimpleNamespace(snapshot_path="/src/snapshot")
+        ep = MagicMock()
+        ep.config = {"path": "/remote/dest"}
+        ops._cleanup_partial_remote_subvolume(ep, manifest)
+        ep._cleanup_partial_subvolume.assert_called_once_with(
+            "/remote/dest", "snapshot"
+        )
+
+    def test_remote_cleanup_noop_without_cleaner(self):
+        manifest = SimpleNamespace(snapshot_path="/src/snapshot")
+        ep = MagicMock(spec=["config"])  # no _cleanup_partial_subvolume
+        ep.config = {"path": "/remote/dest"}
+        # must not raise
+        ops._cleanup_partial_remote_subvolume(ep, manifest)

--- a/tests/test_r2_cleanup_recovery.py
+++ b/tests/test_r2_cleanup_recovery.py
@@ -1,0 +1,118 @@
+"""Enforcement tests for R2 — no cleanup / poisoned re-runs.
+
+A failed/killed transfer must not leave a partial artifact that the next run's
+skip-detection mistakes for a completed backup. Cleanup is scoped to the EXACT
+artifact path and runs only on the failure path, so a good backup is never
+deleted (the R1 false-negative guard, extended to the local/standard path).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import btrfs_backup_ng.core.operations as ops
+from btrfs_backup_ng import __util__
+
+
+def _fake_snap(name: str) -> MagicMock:
+    s = MagicMock()
+    s.locks = {}
+    s.parent_locks = {}
+    s.get_name.return_value = name
+    return s
+
+
+class TestCleanupPartialLocalSubvolume:
+    def _local_endpoint(self, path):
+        ep = MagicMock()
+        ep._is_remote = False
+        ep.config = {"path": str(path)}
+        return ep
+
+    def test_deletes_exact_local_path_when_present(self, monkeypatch, tmp_path):
+        (tmp_path / "snap-1").mkdir()  # the partial artifact this failed run left
+        ep = self._local_endpoint(tmp_path)
+        snap = _fake_snap("snap-1")
+
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(list(cmd))
+            return SimpleNamespace(returncode=0)
+
+        monkeypatch.setattr(ops.subprocess, "run", fake_run)
+        ops._cleanup_partial_local_subvolume(ep, snap)
+
+        deletes = [c for c in calls if c[-3:-1] == ["subvolume", "delete"]]
+        assert deletes, "expected a btrfs subvolume delete of the partial"
+        assert deletes[0][-1] == str(tmp_path / "snap-1")
+
+    def test_noop_when_nothing_present(self, monkeypatch, tmp_path):
+        ep = self._local_endpoint(tmp_path)
+        snap = _fake_snap("absent")
+        called: list[int] = []
+        monkeypatch.setattr(ops.subprocess, "run", lambda *a, **k: called.append(1))
+        ops._cleanup_partial_local_subvolume(ep, snap)
+        assert not called
+
+    def test_skips_remote_endpoint(self, monkeypatch, tmp_path):
+        (tmp_path / "snap-1").mkdir()
+        ep = MagicMock()
+        ep._is_remote = True  # SSH cleans its own partials during the transfer
+        ep.config = {"path": str(tmp_path)}
+        snap = _fake_snap("snap-1")
+        called: list[int] = []
+        monkeypatch.setattr(ops.subprocess, "run", lambda *a, **k: called.append(1))
+        ops._cleanup_partial_local_subvolume(ep, snap)
+        assert not called
+
+    def test_skips_raw_endpoint(self, monkeypatch, tmp_path):
+        from btrfs_backup_ng.endpoint.raw import RawEndpoint
+
+        (tmp_path / "snap-1").mkdir()
+        ep = RawEndpoint.__new__(RawEndpoint)
+        ep._is_remote = False  # local raw: handled by the raw cleanup path, not here
+        ep.config = {"path": str(tmp_path)}
+        snap = _fake_snap("snap-1")
+        called: list[int] = []
+        monkeypatch.setattr(ops.subprocess, "run", lambda *a, **k: called.append(1))
+        ops._cleanup_partial_local_subvolume(ep, snap)
+        assert not called
+
+
+class TestExecuteTransfersCleansPartialOnFailure:
+    def test_failure_triggers_local_cleanup(self, monkeypatch):
+        snap = _fake_snap("s1")
+        src = MagicMock()
+        dst = MagicMock()
+        dst.get_id.return_value = "d"
+        dst._is_remote = False
+
+        monkeypatch.setattr(
+            ops,
+            "send_snapshot",
+            MagicMock(side_effect=__util__.SnapshotTransferError("boom")),
+        )
+        spy = MagicMock()
+        monkeypatch.setattr(ops, "_cleanup_partial_local_subvolume", spy)
+
+        ops._execute_transfers(src, dst, [snap], [], [snap], True, {})
+
+        spy.assert_called_once()
+        # cleanup targets the exact snapshot that failed
+        assert spy.call_args[0][1] is snap
+
+    def test_success_does_not_trigger_cleanup(self, monkeypatch):
+        snap = _fake_snap("s1")
+        src = MagicMock()
+        dst = MagicMock()
+        dst.get_id.return_value = "d"
+        dst._is_remote = False
+
+        monkeypatch.setattr(ops, "send_snapshot", MagicMock(return_value=None))
+        spy = MagicMock()
+        monkeypatch.setattr(ops, "_cleanup_partial_local_subvolume", spy)
+
+        ops._execute_transfers(src, dst, [snap], [], [snap], True, {})
+        spy.assert_not_called()

--- a/tests/test_r2_cleanup_recovery.py
+++ b/tests/test_r2_cleanup_recovery.py
@@ -162,3 +162,56 @@ class TestChunkedPartialCleanup:
         ep.config = {"path": "/remote/dest"}
         # must not raise
         ops._cleanup_partial_remote_subvolume(ep, manifest)
+
+
+class TestRawPartialCleanup:
+    """A failed raw transfer's partial stream file must be removed by its EXACT
+    path (never by a 'missing .meta' heuristic -- a complete generic raw backup
+    also lacks .meta, so that would delete good backups)."""
+
+    def test_local_raw_deletes_exact_stream_file(self, tmp_path):
+        from btrfs_backup_ng.endpoint.raw import RawEndpoint
+
+        f = tmp_path / "host-20260719.btrfs"
+        f.write_bytes(b"partial stream")
+        ep = RawEndpoint.__new__(RawEndpoint)
+        ep._pending_metadata = {"stream_path": f}
+        ops._cleanup_partial_raw_stream(ep)
+        assert not f.exists()
+
+    def test_ssh_raw_deletes_via_remote_command(self):
+        from btrfs_backup_ng.endpoint.raw import SSHRawEndpoint
+
+        ep = SSHRawEndpoint.__new__(SSHRawEndpoint)
+        ep._pending_metadata = {"stream_path": "/remote/host-20260719.btrfs"}
+        ep._exec_remote_command = MagicMock()
+        ops._cleanup_partial_raw_stream(ep)
+        ep._exec_remote_command.assert_called_once_with(
+            ["rm", "-f", "/remote/host-20260719.btrfs"], check=False
+        )
+
+    def test_non_raw_endpoint_is_noop(self):
+        ep = MagicMock()  # not a RawEndpoint
+        ops._cleanup_partial_raw_stream(ep)  # must not raise
+
+    def test_no_pending_metadata_is_noop(self):
+        from btrfs_backup_ng.endpoint.raw import RawEndpoint
+
+        ep = RawEndpoint.__new__(RawEndpoint)  # no _pending_metadata set
+        ops._cleanup_partial_raw_stream(ep)  # must not raise
+
+    def test_funnel_cleans_raw_stream_on_failure(self, monkeypatch):
+        snap = _fake_snap("s1")
+        src = MagicMock()
+        dst = MagicMock()
+        dst.get_id.return_value = "d"
+        monkeypatch.setattr(
+            ops,
+            "send_snapshot",
+            MagicMock(side_effect=__util__.SnapshotTransferError("boom")),
+        )
+        monkeypatch.setattr(ops, "_cleanup_partial_local_subvolume", MagicMock())
+        spy = MagicMock()
+        monkeypatch.setattr(ops, "_cleanup_partial_raw_stream", spy)
+        ops._execute_transfers(src, dst, [snap], [], [snap], True, {})
+        spy.assert_called_once_with(dst)

--- a/tests/test_r2_cleanup_recovery.py
+++ b/tests/test_r2_cleanup_recovery.py
@@ -67,6 +67,14 @@ class TestCleanupPartialLocalSubvolume:
         ops._cleanup_partial_local_subvolume(ep, "snap-1")
         assert not called
 
+    def test_bad_config_does_not_escape(self):
+        # Best-effort contract: a malformed endpoint config must never raise out
+        # of cleanup and mask the original transfer error.
+        ep = MagicMock()
+        ep._is_remote = False
+        ep.config = {}  # missing "path"
+        ops._cleanup_partial_local_subvolume(ep, "snap-1")  # must not raise
+
     def test_skips_raw_endpoint(self, monkeypatch, tmp_path):
         from btrfs_backup_ng.endpoint.raw import RawEndpoint
 


### PR DESCRIPTION
## R2 — no cleanup / poisoned re-runs

Second root of the whole-project audit. A failed/killed transfer left a partial
artifact at the destination that the next run's skip-detection mistook for a
completed backup -- so a failed backup silently poisoned every future run into
thinking it had succeeded. This closes that class, with the same false-negative
discipline as R1: **cleanup runs only on the failure path, scoped to the EXACT
artifact this run created, so a good backup is never deleted.**

### Commits
1. **fix(core)** — local btrfs partial-subvolume cleanup in the standard failure
   funnel (`_execute_transfers`); plus raise the receive-wait timeout from a
   hardcoded 300s to the 3600s send timeout (the 300s killed legitimately-slow
   receives, manufacturing the very partial this cleans).
2. **fix(chunked)** — clean partial subvolumes on the chunked failure branches
   (local + the ssh fallback via the endpoint's own exact-path cleaner).
3. **fix(raw)** — remove the partial raw stream file (the audit critic's catch:
   raw uses a distinct timestamped filename each run and carries no `.meta`, so a
   partial is re-listed as a phantom backup). Deletes ONLY the exact
   `_pending_metadata['stream_path']`, never a "missing .meta" heuristic (which
   would delete a complete generic raw backup).
4. **refactor(core)** — remove dead, non-functional `delete_corrupt_snapshots`
   (its lock signal is always false and it skips locked snaps, so it could never
   delete anything) + the dead `clear_locks` duplicate.
5. **fix(core)** — keep cleanup best-effort even on a malformed config (review
   finding: config access moved inside the try so it can't mask the original
   transfer error).

### Verification
- Full suite **2052 passing**; ruff/format/mypy clean.
- **15 enforcement tests**; every fix **mutation-verified**.
- Two adversarial review lenses (false-negative risk + correctness/completeness).
  The false-negative lens found **no risk** in any cleanup; every deletion is
  failure-path-only, exact-path, and structurally cannot fire on a name that was
  present (a prior good backup) at run start. The one correctness finding (a
  config access outside the try) was fixed (commit 5).

### Deferred (tracked, safety-driven)
- SSH chunked-resume pre-receive cleanup (the only *proactive* delete) — deferred
  to a temp-name-then-rename approach; without it a resumed transfer over a prior
  partial fails loud rather than silently poisoning.
- snapper→raw partial cleanup — its sidecar is written after the stream in the
  same try, so cleaning there could delete a good stream on a sidecar failure;
  needs a send-vs-sidecar split first.
- Lock entry-clear reconcile → **R3** (inert until locks are loaded from disk).

No behavior change for successful backups.
