### PR TITLE
fix: write raw backup streams atomically to prevent phantom backups

### DIFF
--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -259,6 +259,18 @@ def send_snapshot(
             _log_process_errors(send_process, receive_process)
             raise __util__.SnapshotTransferError(error_message)
 
+        # Durably publish the received data before declaring success. For raw
+        # endpoints this atomically renames the ".part" stream to its final
+        # name; for btrfs endpoints it is a no-op. A commit failure means the
+        # data is not safely on disk, so treat it as a transfer failure rather
+        # than report a success that is not durably stored.
+        try:
+            destination_endpoint.commit_receive()
+        except Exception as commit_err:
+            raise __util__.SnapshotTransferError(
+                f"Failed to commit received data: {commit_err}"
+            ) from commit_err
+
         logger.info("Transfer completed successfully")
 
         # Log successful transaction
@@ -469,6 +481,10 @@ def _do_chunked_transfer(
                 options=options,
                 show_progress=show_progress,
             )
+
+        # Publish the received data (atomic rename of the raw ".part" stream;
+        # no-op for btrfs endpoints) before marking the transfer complete.
+        destination_endpoint.commit_receive()
 
         # Mark transfer as complete
         chunked_manager.complete_transfer(manifest)
@@ -1243,18 +1259,16 @@ def _cleanup_partial_remote_subvolume(destination_endpoint, manifest) -> None:
 
 
 def _cleanup_partial_raw_stream(destination_endpoint) -> None:
-    """Best-effort removal of the exact raw stream file a failed raw transfer wrote.
+    """Best-effort removal of the uncommitted ``.part`` file a failed raw
+    transfer left behind.
 
-    Raw backups use a distinct timestamped filename each run, and a generic raw
-    backup carries no ``.meta`` sidecar (``finalize_receive`` is unused), so a
-    failed partial is NOT overwritten by the next run and cannot be distinguished
-    from a complete backup by "missing .meta". ``discover_raw_snapshots``' filename
-    fallback would therefore re-list the partial as a phantom backup.
-
-    Delete ONLY the exact ``_pending_metadata['stream_path']`` this run wrote --
-    never a name pattern or a "no .meta" heuristic (which would destroy a good
-    generic raw backup). Called only on the failure path where the transfer
-    pipeline exited nonzero, so the stream file is genuinely incomplete.
+    A raw receive writes to ``<name>.part`` and is renamed to its final name
+    only by ``commit_receive`` after the pipeline succeeds, so a failed transfer
+    leaves an uncommitted ``.part`` file. ``discover_raw_snapshots`` already
+    ignores ``.part`` files, so they can never be listed as a phantom backup --
+    this deletion is hygiene, not the correctness guard. Remove ONLY the exact
+    ``_pending_metadata['part_path']`` this run wrote, never the final name
+    (which could be a prior good backup) and never a name pattern.
     """
     from ..endpoint.raw import RawEndpoint, SSHRawEndpoint
 
@@ -1263,24 +1277,24 @@ def _cleanup_partial_raw_stream(destination_endpoint) -> None:
     pending = getattr(destination_endpoint, "_pending_metadata", None)
     if not pending:
         return
-    stream_path = pending.get("stream_path")
-    if not stream_path:
+    part_path = pending.get("part_path")
+    if not part_path:
         return
     try:
         if isinstance(destination_endpoint, SSHRawEndpoint):
             logger.warning(
-                "Cleaning up partial remote raw stream file at %s", stream_path
+                "Cleaning up partial remote raw stream file at %s", part_path
             )
             destination_endpoint._exec_remote_command(
-                ["rm", "-f", str(stream_path)], check=False
+                ["rm", "-f", str(part_path)], check=False
             )
         else:
-            p = Path(stream_path)
+            p = Path(part_path)
             if p.exists():
                 logger.warning("Cleaning up partial raw stream file at %s", p)
                 p.unlink()
     except Exception as e:
-        logger.debug("Partial raw-stream cleanup failed for %s: %s", stream_path, e)
+        logger.debug("Partial raw-stream cleanup failed for %s: %s", part_path, e)
 
 
 def _execute_transfers(
@@ -1550,7 +1564,11 @@ def _cleanup_snapper_backup(destination_endpoint, snapshot_num, is_raw) -> None:
     import os
 
     if is_raw:
-        # Raw partial files are overwritten on the next attempt; nothing to undo.
+        # A failed raw transfer leaves an uncommitted ".part" file (atomic writes
+        # keep it out of discovery); remove it so partials do not accumulate.
+        # Raw uses a distinct timestamped name per run, so it is NOT overwritten
+        # on the next attempt -- the old "nothing to undo" assumption was wrong.
+        _cleanup_partial_raw_stream(destination_endpoint)
         return
 
     base = str(destination_endpoint.config["path"]).rstrip("/")

--- a/src/btrfs_backup_ng/endpoint/common.py
+++ b/src/btrfs_backup_ng/endpoint/common.py
@@ -66,7 +66,7 @@ class Endpoint:
         self.config["timestamp_format"] = config.get("timestamp_format")
 
         self.btrfs_flags = ["-vv"] if self.config["btrfs_debug"] else []
-        self.__cached_snapshots = None
+        self.__cached_snapshots: List[Any] | None = None
 
         for key, value in kwargs.items():
             self.config[key] = value
@@ -261,6 +261,17 @@ class Endpoint:
         except Exception as e:
             logger.error("Error executing receive command: %s", e)
             raise
+
+    def commit_receive(self) -> None:
+        """Durably commit received data on the success path.
+
+        Called by the transfer engine only after the receive pipeline has been
+        confirmed successful. The base endpoint receives into a btrfs subvolume,
+        which ``btrfs receive`` already commits atomically, so this is a no-op.
+        RawEndpoint overrides it to fsync a temporary stream file and atomically
+        rename it to its final name.
+        """
+        return
 
     def list_snapshots(self, flush_cache: bool = False) -> List[Any]:
         """

--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import shutil
 import subprocess
 from pathlib import Path
@@ -35,6 +36,7 @@ class PendingMetadata(TypedDict):
 
     name: str
     stream_path: Path
+    part_path: Path
     parent_name: str | None
     compress: str | None
     encrypt: str | None
@@ -44,6 +46,13 @@ class PendingMetadata(TypedDict):
 # Environment variable for OpenSSL passphrase (compatible with btrbk)
 OPENSSL_PASSPHRASE_ENV = "BTRFS_BACKUP_PASSPHRASE"
 BTRBK_PASSPHRASE_ENV = "BTRBK_PASSPHRASE"
+
+# Suffix for the in-progress stream file. A raw receive writes here and the
+# transfer engine renames it to the final name only after the pipeline is
+# confirmed successful (see RawEndpoint.commit_receive). A crash therefore
+# leaves at most a ``.part`` file, which discovery ignores -- so a partial
+# transfer can never be listed as a complete backup.
+PARTIAL_SUFFIX = ".part"
 
 
 def _popen_pipeline_pipefail(shell_cmd: str, **popen_kwargs: Any) -> subprocess.Popen:
@@ -151,6 +160,7 @@ class RawEndpoint(Endpoint):
         self._pending_metadata: PendingMetadata = {
             "name": "",
             "stream_path": Path(),
+            "part_path": Path(),
             "parent_name": None,
             "compress": None,
             "encrypt": None,
@@ -243,24 +253,28 @@ class RawEndpoint(Endpoint):
         # Build output filename
         extension = get_file_extension(self.compress, self.encrypt)
         output_path = Path(self.config["path"]) / f"{snapshot_name}{extension}"
+        # Write to a temporary ".part" sibling; commit_receive() renames it to
+        # output_path only after the engine confirms the pipeline succeeded.
+        part_path = Path(f"{output_path}{PARTIAL_SUFFIX}")
 
-        logger.info("Writing raw stream to: %s", output_path)
+        logger.info("Writing raw stream to: %s", part_path)
 
         # Record metadata BEFORE executing: _execute_pipeline reads
-        # _pending_metadata["stream_path"] to know where to write. Setting it
+        # _pending_metadata["part_path"] to know where to write. Setting it
         # afterwards left the default Path() ('.') in place, so the pipeline
         # tried to open the current directory as the output file.
         self._pending_metadata = {
             "name": snapshot_name,
             "stream_path": output_path,
+            "part_path": part_path,
             "parent_name": parent_name,
             "compress": self.compress,
             "encrypt": self.encrypt,
             "gpg_recipient": self.gpg_recipient,
         }
 
-        # Build and execute the pipeline
-        pipeline = self._build_receive_pipeline(output_path)
+        # Build and execute the pipeline (writes to the .part file)
+        pipeline = self._build_receive_pipeline(part_path)
         proc = self._execute_pipeline(pipeline, stdin_pipe)
 
         return proc
@@ -331,7 +345,7 @@ class RawEndpoint(Endpoint):
 
         # For a single command, execute directly
         if len(pipeline) == 1:
-            output_path = self._pending_metadata["stream_path"]
+            output_path = self._pending_metadata["part_path"]
             with open(output_path, "wb") as outfile:
                 proc = subprocess.Popen(
                     pipeline[0],
@@ -343,9 +357,9 @@ class RawEndpoint(Endpoint):
 
         # For multiple commands, chain them together
         # We use shell to handle the pipeline and file output
-        output_path = self._pending_metadata["stream_path"]
+        output_path = self._pending_metadata["part_path"]
         cmd_strs = [" ".join(cmd) for cmd in pipeline]
-        shell_cmd = " | ".join(cmd_strs) + f" > {output_path}"
+        shell_cmd = " | ".join(cmd_strs) + f" > {shlex.quote(str(output_path))}"
 
         logger.debug("Executing pipeline: %s", shell_cmd)
 
@@ -356,6 +370,57 @@ class RawEndpoint(Endpoint):
             stderr=subprocess.PIPE,
         )
         return proc
+
+    @staticmethod
+    def _fsync_dir(directory: Path) -> None:
+        """Best-effort fsync of a directory so a rename into it is durable."""
+        try:
+            dfd = os.open(directory, os.O_RDONLY)
+            try:
+                os.fsync(dfd)
+            finally:
+                os.close(dfd)
+        except OSError as e:
+            logger.debug("Directory fsync failed for %s: %s", directory, e)
+
+    def commit_receive(self) -> None:
+        """Atomically publish the received stream after a successful transfer.
+
+        The receive pipeline writes to a ``.part`` file; only once the engine
+        has confirmed the pipeline exited 0 do we fsync that file, atomically
+        rename it to its final name, and fsync the directory so the rename is
+        durable. A crash before this point leaves only the ``.part`` file, which
+        ``discover_raw_snapshots`` ignores -- so a partial transfer can never be
+        mistaken for a complete backup.
+
+        Raises on failure so the engine treats an un-published stream as a
+        failed transfer rather than reporting a success that is not on disk.
+        """
+        pending = getattr(self, "_pending_metadata", None)
+        # No receive() has run on this endpoint (dummy init) -> nothing to publish.
+        if not pending or not pending.get("name"):
+            return
+        part_path = Path(pending["part_path"])
+        final_path = Path(pending["stream_path"])
+        if not part_path.exists():
+            # The stream we just received is gone; fail loud rather than report a
+            # success with no file on disk -- the exact phantom-success class this
+            # atomic-write scheme exists to prevent.
+            raise RuntimeError(
+                f"commit_receive: received stream {part_path} is missing; "
+                f"cannot publish {final_path}"
+            )
+        # Flush the stream's bytes to disk BEFORE renaming, so the final name can
+        # never refer to unflushed data.
+        fd = os.open(part_path, os.O_RDONLY)
+        try:
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        os.replace(part_path, final_path)
+        # Persist the rename itself.
+        self._fsync_dir(final_path.parent)
+        logger.debug("Committed raw stream: %s", final_path)
 
     def finalize_receive(
         self, proc: subprocess.Popen, uuid: str = "", parent_uuid: str | None = None
@@ -722,13 +787,16 @@ class SSHRawEndpoint(RawEndpoint):
 
         Runs compression/encryption locally, then pipes to remote via SSH.
         """
-        output_path = self._pending_metadata["stream_path"]
+        output_path = self._pending_metadata["part_path"]
         ssh_cmd = self._build_ssh_command()
 
-        # Build the remote write command
-        remote_cmd = f"cat > {output_path}"
+        # Build the remote write command. Quote the destination path so a path
+        # with spaces/metacharacters writes to the intended file, and so the
+        # receive-write and commit_receive halves quote identically (they must
+        # agree on the target or a valid config could fail at commit).
+        remote_cmd = f"cat > {shlex.quote(str(output_path))}"
         if self.ssh_sudo:
-            remote_cmd = f"sudo sh -c '{remote_cmd}'"
+            remote_cmd = f"sudo sh -c {shlex.quote(remote_cmd)}"
 
         if not pipeline or pipeline == [["cat"]]:
             # No local processing, pipe directly to SSH
@@ -744,7 +812,7 @@ class SSHRawEndpoint(RawEndpoint):
         # Local processing then SSH
         cmd_strs = [" ".join(cmd) for cmd in pipeline]
         local_pipeline = " | ".join(cmd_strs)
-        ssh_part = " ".join(ssh_cmd) + f" '{remote_cmd}'"
+        ssh_part = " ".join(ssh_cmd) + " " + shlex.quote(remote_cmd)
         shell_cmd = f"{local_pipeline} | {ssh_part}"
 
         logger.debug("Executing SSH pipeline: %s", shell_cmd)
@@ -756,6 +824,41 @@ class SSHRawEndpoint(RawEndpoint):
             stderr=subprocess.PIPE,
         )
         return proc
+
+    def commit_receive(self) -> None:
+        """Atomically publish the remote stream after a successful transfer.
+
+        The receive pipeline writes to a remote ``.part`` file; once the engine
+        confirms success we ``sync`` the remote filesystem and ``mv -f`` the
+        ``.part`` file to its final name. A crash leaves only the ``.part`` file,
+        which discovery ignores. Raises on failure so an un-published stream is
+        treated as a failed transfer.
+        """
+        pending = getattr(self, "_pending_metadata", None)
+        # No receive() has run on this endpoint (dummy init) -> nothing to publish.
+        if not pending or not pending.get("name"):
+            return
+        part_path = pending["part_path"]
+        final_path = pending["stream_path"]
+        # The leading sync flushes the just-written bytes BEFORE the rename (so
+        # the final name can never refer to unflushed data); the trailing sync
+        # makes the rename itself durable, matching the local path's post-rename
+        # directory fsync. _exec_remote_command quotes each argv element and adds
+        # sudo itself, so the whole shell script is one quoted argument to sh -c.
+        mv_script = (
+            f"sync && mv -f {shlex.quote(str(part_path))} "
+            f"{shlex.quote(str(final_path))} && sync"
+        )
+        result = self._exec_remote_command(["sh", "-c", mv_script], check=False)
+        if result.returncode != 0:
+            stderr = result.stderr
+            if isinstance(stderr, (bytes, bytearray)):
+                stderr = stderr.decode(errors="replace")
+            raise RuntimeError(
+                f"Failed to publish remote raw stream {final_path}: "
+                f"{(stderr or '').strip()}"
+            )
+        logger.debug("Committed remote raw stream: %s", final_path)
 
     def list_snapshots(self, flush_cache: bool = False) -> list[RawSnapshot]:
         """List raw snapshots on the remote host.

--- a/src/btrfs_backup_ng/endpoint/raw_metadata.py
+++ b/src/btrfs_backup_ng/endpoint/raw_metadata.py
@@ -290,6 +290,12 @@ def discover_raw_snapshots(
         if not item.is_file() or item.suffix == ".meta":
             continue
 
+        # Skip in-progress stream files: a ".part" file is a transfer that has
+        # not been committed (renamed to its final name), so it must NEVER be
+        # listed as a complete backup.
+        if item.name.endswith(".part"):
+            continue
+
         # Check if it's a btrfs stream file
         if ".btrfs" not in item.name:
             continue

--- a/tests/integration/test_chunked_operations.py
+++ b/tests/integration/test_chunked_operations.py
@@ -65,6 +65,10 @@ class MockEndpoint:
         mock_process.poll.return_value = None
         return mock_process
 
+    def commit_receive(self):
+        """No-op commit, mirroring the base Endpoint (btrfs receive is atomic)."""
+        return
+
 
 class TestSendSnapshotChunkedOption:
     """Tests for chunked transfer option in send_snapshot."""

--- a/tests/test_atomic_commit_wiring.py
+++ b/tests/test_atomic_commit_wiring.py
@@ -1,0 +1,106 @@
+"""Engine wiring for atomic raw commit (0.8.5 PR1).
+
+These lock the contract that the transfer engine actually CALLS commit_receive()
+on the raw success path and treats a commit failure as a transfer FAILURE.
+Without them, the one-line engine hooks (operations.py send_snapshot and
+_do_chunked_transfer) could be deleted with every endpoint-level test still
+green, silently breaking all raw backups: the pipeline writes a ``.part`` file,
+the engine reports success, discovery ignores ``.part``, and the backup vanishes.
+
+Mutation-verified: deleting the ``commit_receive()`` call, or the commit
+try/except, makes these fail.
+"""
+
+import io
+from unittest.mock import MagicMock
+
+import pytest
+
+from btrfs_backup_ng import __util__
+from btrfs_backup_ng.core import operations as ops
+
+
+class _SpyDest:
+    """Minimal destination endpoint double with a commit_receive spy."""
+
+    def __init__(self, commit=None):
+        self.config = {"path": "/backup"}
+        self._is_remote = False
+        self.commit_receive = commit or MagicMock()
+
+    def receive(self, *args, **kwargs):
+        return MagicMock(returncode=0)
+
+
+def _snapshot():
+    snap = MagicMock()
+    snap.get_path.return_value = "/src/.snapshots/snap"
+    snap.get_name.return_value = "snap"
+    snap.endpoint.send.return_value = MagicMock(returncode=0)
+    return snap
+
+
+def _patch_engine(monkeypatch, return_codes):
+    monkeypatch.setattr(ops, "_ensure_destination_exists", lambda e: None)
+    monkeypatch.setattr(ops, "log_transaction", lambda **k: None)
+    monkeypatch.setattr(ops, "_do_process_transfer", lambda *a, **k: return_codes)
+
+
+def test_send_snapshot_commits_on_success(monkeypatch):
+    """A successful raw transfer must call commit_receive() exactly once -- this
+    is the wiring that actually publishes the .part file."""
+    _patch_engine(monkeypatch, [0, 0])
+    dest = _SpyDest()
+    ops.send_snapshot(_snapshot(), dest, options={"check_space": False})
+    dest.commit_receive.assert_called_once()
+
+
+def test_send_snapshot_does_not_commit_on_pipeline_failure(monkeypatch):
+    """A failed pipeline must NOT commit -- a .part must never be published when
+    the transfer did not actually succeed."""
+    _patch_engine(monkeypatch, [1])  # nonzero return code -> failure
+    dest = _SpyDest()
+    with pytest.raises(__util__.SnapshotTransferError):
+        ops.send_snapshot(_snapshot(), dest, options={"check_space": False})
+    dest.commit_receive.assert_not_called()
+
+
+def test_send_snapshot_commit_failure_is_a_transfer_failure(monkeypatch):
+    """If commit_receive() raises, the transfer must be reported as FAILED (not a
+    success with no file on disk)."""
+    _patch_engine(monkeypatch, [0])
+    dest = _SpyDest(commit=MagicMock(side_effect=RuntimeError("disk full")))
+    with pytest.raises(
+        __util__.SnapshotTransferError, match="Failed to commit received data"
+    ):
+        ops.send_snapshot(_snapshot(), dest, options={"check_space": False})
+
+
+def test_chunked_transfer_commits_on_success(monkeypatch, tmp_path):
+    """The chunked path must also publish the .part via commit_receive()."""
+    from btrfs_backup_ng.core.chunked_transfer import (
+        ChunkedTransferManager,
+        TransferConfig,
+    )
+
+    monkeypatch.setattr(ops, "log_transaction", lambda **k: None)
+    monkeypatch.setattr(ops, "_transfer_chunks_local", lambda **k: None)
+
+    dest = _SpyDest()
+    snap = _snapshot()
+    snap.endpoint.send.return_value = MagicMock(
+        returncode=0, stdout=io.BytesIO(b"x" * 4096)
+    )
+    manager = ChunkedTransferManager(
+        TransferConfig(cache_directory=tmp_path, chunk_size_mb=1)
+    )
+
+    ops._do_chunked_transfer(
+        snapshot=snap,
+        destination_endpoint=dest,
+        parent=None,
+        clones=None,
+        options={},
+        chunked_manager=manager,
+    )
+    dest.commit_receive.assert_called_once()

--- a/tests/test_r1_raw_chunked_contract.py
+++ b/tests/test_r1_raw_chunked_contract.py
@@ -82,7 +82,10 @@ class TestExecutePipelineRoutesThroughPipefail:
     def test_local_multistage_uses_pipefail_helper(self, monkeypatch, tmp_path):
         captured = self._spy(monkeypatch)
         ep = RawEndpoint.__new__(RawEndpoint)
-        ep._pending_metadata = {"stream_path": tmp_path / "out"}  # type: ignore[attr-defined]
+        ep._pending_metadata = {  # type: ignore[attr-defined]
+            "stream_path": tmp_path / "out",
+            "part_path": tmp_path / "out.part",
+        }
         proc = ep._execute_pipeline([["gzip"], ["cat"]], subprocess.DEVNULL)
         proc.wait()
         assert "gzip" in captured.get("shell_cmd", "")
@@ -90,7 +93,10 @@ class TestExecutePipelineRoutesThroughPipefail:
     def test_ssh_multistage_uses_pipefail_helper(self, monkeypatch, tmp_path):
         captured = self._spy(monkeypatch)
         ep = SSHRawEndpoint.__new__(SSHRawEndpoint)
-        ep._pending_metadata = {"stream_path": tmp_path / "out"}  # type: ignore[attr-defined]
+        ep._pending_metadata = {  # type: ignore[attr-defined]
+            "stream_path": tmp_path / "out",
+            "part_path": tmp_path / "out.part",
+        }
         ep.ssh_sudo = False  # type: ignore[attr-defined]
         ep._build_ssh_command = lambda: ["ssh", "host"]  # type: ignore[method-assign]
         proc = ep._execute_pipeline([["gzip"], ["cat"]], subprocess.DEVNULL)

--- a/tests/test_r2_cleanup_recovery.py
+++ b/tests/test_r2_cleanup_recovery.py
@@ -173,29 +173,47 @@ class TestChunkedPartialCleanup:
 
 
 class TestRawPartialCleanup:
-    """A failed raw transfer's partial stream file must be removed by its EXACT
-    path (never by a 'missing .meta' heuristic -- a complete generic raw backup
-    also lacks .meta, so that would delete good backups)."""
+    """A failed raw transfer leaves an uncommitted ``.part`` file; cleanup must
+    remove exactly that ``part_path`` (never the final name, which could be a
+    prior good backup, and never a name pattern)."""
 
-    def test_local_raw_deletes_exact_stream_file(self, tmp_path):
+    def test_local_raw_deletes_exact_part_file(self, tmp_path):
         from btrfs_backup_ng.endpoint.raw import RawEndpoint
 
-        f = tmp_path / "host-20260719.btrfs"
-        f.write_bytes(b"partial stream")
+        final = tmp_path / "host-20260719.btrfs"
+        part = tmp_path / "host-20260719.btrfs.part"
+        part.write_bytes(b"partial stream")
         ep = RawEndpoint.__new__(RawEndpoint)
-        ep._pending_metadata = {"stream_path": f}
+        ep._pending_metadata = {"stream_path": final, "part_path": part}
         ops._cleanup_partial_raw_stream(ep)
-        assert not f.exists()
+        assert not part.exists()
+
+    def test_local_raw_preserves_committed_final(self, tmp_path):
+        """False-negative guard: cleanup must NEVER delete a committed backup
+        that happens to sit at the final name."""
+        from btrfs_backup_ng.endpoint.raw import RawEndpoint
+
+        final = tmp_path / "host-20260719.btrfs"
+        final.write_bytes(b"good backup")
+        part = tmp_path / "host-20260719.btrfs.part"
+        ep = RawEndpoint.__new__(RawEndpoint)
+        ep._pending_metadata = {"stream_path": final, "part_path": part}
+        ops._cleanup_partial_raw_stream(ep)
+        assert final.exists()
+        assert final.read_bytes() == b"good backup"
 
     def test_ssh_raw_deletes_via_remote_command(self):
         from btrfs_backup_ng.endpoint.raw import SSHRawEndpoint
 
         ep = SSHRawEndpoint.__new__(SSHRawEndpoint)
-        ep._pending_metadata = {"stream_path": "/remote/host-20260719.btrfs"}
+        ep._pending_metadata = {
+            "stream_path": "/remote/host-20260719.btrfs",
+            "part_path": "/remote/host-20260719.btrfs.part",
+        }
         ep._exec_remote_command = MagicMock()
         ops._cleanup_partial_raw_stream(ep)
         ep._exec_remote_command.assert_called_once_with(
-            ["rm", "-f", "/remote/host-20260719.btrfs"], check=False
+            ["rm", "-f", "/remote/host-20260719.btrfs.part"], check=False
         )
 
     def test_non_raw_endpoint_is_noop(self):

--- a/tests/test_raw_atomic_write.py
+++ b/tests/test_raw_atomic_write.py
@@ -1,0 +1,172 @@
+"""Atomic raw stream write (0.8.5 PR1).
+
+A raw receive writes to a ``.part`` file and is published to its final name only
+by ``commit_receive()``, which the transfer engine calls after confirming the
+pipeline succeeded. A crash therefore leaves at most a ``.part`` file, which
+discovery must ignore -- so a partial transfer can never be listed as a complete
+backup (the raw phantom-backup bug).
+
+These tests are written to FAIL if the atomic-write behavior is reverted:
+  * remove the ``.part`` exclusion in discover_raw_snapshots -> the phantom
+    tests fail (a partial is listed as a backup);
+  * make receive() write straight to the final name -> the "final absent before
+    commit" assertions fail.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from btrfs_backup_ng.endpoint.raw import RawEndpoint, SSHRawEndpoint
+from btrfs_backup_ng.endpoint.raw_metadata import discover_raw_snapshots
+
+
+def test_part_file_is_never_discovered(tmp_path):
+    """A leftover ``.part`` file (a crashed/uncommitted transfer) is not a backup."""
+    (tmp_path / "good-20260101.btrfs").write_bytes(b"complete")
+    (tmp_path / "crashed-20260102.btrfs.part").write_bytes(b"partial")
+
+    found = discover_raw_snapshots(tmp_path)
+    names = {s.name for s in found}
+    assert "good-20260101" in names
+    # The partial must not appear under any name...
+    assert not any("crashed" in n for n in names)
+    # ...and no discovered stream is ever a .part file.
+    assert all(not s.stream_path.name.endswith(".part") for s in found)
+
+
+def test_receive_then_commit_publishes_atomically(tmp_path):
+    """receive() writes to .part; the final name appears only after commit."""
+    endpoint = RawEndpoint(config={"path": str(tmp_path)})
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"payload-bytes")
+
+    with open(src, "rb") as stdin:
+        proc = endpoint.receive(stdin, snapshot_name="snap")
+        proc.communicate()
+    assert proc.returncode == 0
+
+    final = tmp_path / "snap.btrfs"
+    part = tmp_path / "snap.btrfs.part"
+    # Uncommitted: only the .part exists, and discovery ignores it -- so a crash
+    # here leaves nothing that looks like a complete backup.
+    assert part.exists()
+    assert not final.exists()
+    assert discover_raw_snapshots(tmp_path) == []
+
+    endpoint.commit_receive()
+    # Committed: the final name exists, the .part is gone, and it is now the only
+    # discoverable snapshot.
+    assert final.exists()
+    assert not part.exists()
+    assert final.read_bytes() == b"payload-bytes"
+    assert [s.name for s in discover_raw_snapshots(tmp_path)] == ["snap"]
+
+
+def test_commit_missing_part_fails_loud(tmp_path):
+    """If a receive ran but its .part is gone at commit time, fail loud rather
+    than report a success with no file on disk (never fabricate a final file)."""
+    endpoint = RawEndpoint(config={"path": str(tmp_path)})
+    endpoint._pending_metadata = {
+        "name": "x",
+        "stream_path": tmp_path / "x.btrfs",
+        "part_path": tmp_path / "x.btrfs.part",  # does not exist
+        "parent_name": None,
+        "compress": None,
+        "encrypt": None,
+        "gpg_recipient": None,
+    }
+    with pytest.raises(RuntimeError, match="is missing"):
+        endpoint.commit_receive()
+    assert not (tmp_path / "x.btrfs").exists()
+
+
+def test_commit_without_receive_is_noop(tmp_path):
+    """A fresh endpoint that never received anything must commit as a safe no-op
+    (its dummy metadata has no name), not touch the filesystem, and not raise."""
+    endpoint = RawEndpoint(config={"path": str(tmp_path)})
+    # Do NOT call receive(); _pending_metadata is the dummy init.
+    endpoint.commit_receive()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_ssh_commit_builds_sync_mv_sync_script_and_publishes():
+    """SSH commit runs exactly 'sync && mv -f <part> <final> && sync' remotely
+    (leading sync flushes bytes before rename; trailing sync makes the rename
+    durable). Mocked -- runs without any real SSH."""
+    ep = SSHRawEndpoint.__new__(SSHRawEndpoint)
+    ep._pending_metadata = {
+        "name": "snap",
+        "stream_path": "/remote/snap.btrfs",
+        "part_path": "/remote/snap.btrfs.part",
+    }
+    ep._exec_remote_command = MagicMock(
+        return_value=MagicMock(returncode=0, stderr=b"")
+    )
+    ep.commit_receive()
+
+    ep._exec_remote_command.assert_called_once()
+    argv = ep._exec_remote_command.call_args[0][0]
+    assert argv[0] == "sh"
+    assert argv[1] == "-c"
+    assert argv[2] == (
+        "sync && mv -f /remote/snap.btrfs.part /remote/snap.btrfs && sync"
+    )
+
+
+def test_ssh_commit_raises_on_remote_failure():
+    """A nonzero remote return must raise, so the engine treats an unpublished
+    remote stream as a failed transfer."""
+    ep = SSHRawEndpoint.__new__(SSHRawEndpoint)
+    ep._pending_metadata = {
+        "name": "snap",
+        "stream_path": "/remote/snap.btrfs",
+        "part_path": "/remote/snap.btrfs.part",
+    }
+    ep._exec_remote_command = MagicMock(
+        return_value=MagicMock(returncode=1, stderr=b"mv: cannot stat")
+    )
+    with pytest.raises(RuntimeError, match="Failed to publish remote raw stream"):
+        ep.commit_receive()
+
+
+def test_ssh_commit_wraps_in_sudo_when_configured():
+    """With ssh_sudo, the remote commit is wrapped in sudo. Exercises the real
+    command construction (only subprocess.run is mocked) -- no live SSH -- so the
+    sudo path is proven without setting up passwordless root access."""
+    from unittest.mock import patch
+
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas", "ssh_sudo": True})
+    ep._pending_metadata = {
+        "name": "snap",
+        "stream_path": "/backup/snap.btrfs",
+        "part_path": "/backup/snap.btrfs.part",
+    }
+    with patch("btrfs_backup_ng.endpoint.raw.subprocess.run") as mrun:
+        mrun.return_value = MagicMock(returncode=0, stderr=b"")
+        ep.commit_receive()
+
+    mrun.assert_called_once()
+    remote = mrun.call_args[0][0][-1]  # last element of the ssh argv
+    assert remote.startswith("sudo ")
+    assert "sync && mv -f" in remote
+    assert remote.rstrip().endswith("&& sync") or "&& sync" in remote
+
+
+def test_commit_never_overwrites_a_committed_final(tmp_path):
+    """commit_receive publishes the current .part; it must not touch an unrelated
+    already-committed backup that shares the directory."""
+    endpoint = RawEndpoint(config={"path": str(tmp_path)})
+    prior = tmp_path / "prior.btrfs"
+    prior.write_bytes(b"prior-good-backup")
+
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"new-stream")
+    with open(src, "rb") as stdin:
+        proc = endpoint.receive(stdin, snapshot_name="new")
+        proc.communicate()
+    endpoint.commit_receive()
+
+    # The prior backup is untouched; the new one is published alongside it.
+    assert prior.read_bytes() == b"prior-good-backup"
+    assert (tmp_path / "new.btrfs").read_bytes() == b"new-stream"

--- a/tests/test_raw_endpoint.py
+++ b/tests/test_raw_endpoint.py
@@ -554,12 +554,13 @@ class TestRawEndpointReceive:
         assert endpoint._pending_metadata["encrypt"] is None
 
     def test_receive_writes_stream_to_output_file(self, tmp_path):
-        """receive() writes the stream to the named file, not the cwd.
+        """receive() writes to a .part file; commit_receive() publishes it atomically.
 
-        Regression: _execute_pipeline reads stream_path from _pending_metadata,
-        which receive() previously set only AFTER executing, so the default
-        Path() ('.') was used and the pipeline opened the current directory
-        (IsADirectoryError). This runs the real pipeline (no mocks).
+        Regression: _execute_pipeline reads part_path from _pending_metadata,
+        which receive() sets BEFORE executing. This also pins the atomic-write
+        contract: the final name must NOT appear until commit_receive(), so a
+        crashed transfer can never be listed as a complete backup. Runs the real
+        pipeline (no mocks).
         """
         endpoint = RawEndpoint(config={"path": str(tmp_path)})
         src = tmp_path / "src.bin"
@@ -571,7 +572,15 @@ class TestRawEndpointReceive:
 
         assert proc.returncode == 0
         out = tmp_path / "snap-1.btrfs"
+        part = tmp_path / "snap-1.btrfs.part"
+        # Before commit, only the .part file exists -- the final name must not
+        # appear until commit_receive() atomically publishes it.
+        assert part.exists()
+        assert not out.exists()
+
+        endpoint.commit_receive()
         assert out.exists()
+        assert not part.exists()
         assert out.read_bytes() == b"hello-raw-stream"
 
     def test_receive_with_compression(self, tmp_path):
@@ -624,7 +633,10 @@ class TestRawEndpointExecutePipeline:
         """Test executing single-command pipeline."""
         endpoint = RawEndpoint(config={"path": tmp_path})
         output_path = tmp_path / "test.btrfs"
-        endpoint._pending_metadata = {"stream_path": output_path}
+        endpoint._pending_metadata = {
+            "stream_path": output_path,
+            "part_path": tmp_path / "test.btrfs.part",
+        }
 
         mock_stdin = MagicMock()
 
@@ -640,7 +652,10 @@ class TestRawEndpointExecutePipeline:
         """Test executing multi-command pipeline."""
         endpoint = RawEndpoint(config={"path": tmp_path})
         output_path = tmp_path / "test.btrfs.gz"
-        endpoint._pending_metadata = {"stream_path": output_path}
+        endpoint._pending_metadata = {
+            "stream_path": output_path,
+            "part_path": tmp_path / "test.btrfs.gz.part",
+        }
 
         mock_stdin = MagicMock()
 
@@ -917,7 +932,10 @@ class TestSSHRawEndpointMethods:
                 "username": "backup",
             }
         )
-        endpoint._pending_metadata = {"stream_path": Path("/backup/test.btrfs")}
+        endpoint._pending_metadata = {
+            "stream_path": Path("/backup/test.btrfs"),
+            "part_path": Path("/backup/test.btrfs.part"),
+        }
         mock_stdin = MagicMock()
 
         with patch("subprocess.Popen") as mock_popen:
@@ -939,7 +957,10 @@ class TestSSHRawEndpointMethods:
                 "compress": "zstd",
             }
         )
-        endpoint._pending_metadata = {"stream_path": Path("/backup/test.btrfs.zst")}
+        endpoint._pending_metadata = {
+            "stream_path": Path("/backup/test.btrfs.zst"),
+            "part_path": Path("/backup/test.btrfs.zst.part"),
+        }
         mock_stdin = MagicMock()
 
         with patch("subprocess.Popen") as mock_popen:
@@ -960,7 +981,10 @@ class TestSSHRawEndpointMethods:
                 "ssh_sudo": True,
             }
         )
-        endpoint._pending_metadata = {"stream_path": Path("/backup/test.btrfs")}
+        endpoint._pending_metadata = {
+            "stream_path": Path("/backup/test.btrfs"),
+            "part_path": Path("/backup/test.btrfs.part"),
+        }
         mock_stdin = MagicMock()
 
         with patch("subprocess.Popen") as mock_popen:

--- a/tests/test_raw_endpoint_integration.py
+++ b/tests/test_raw_endpoint_integration.py
@@ -430,6 +430,7 @@ class TestShellPipelineExecution:
         endpoint._pending_metadata = {
             "name": "test-snapshot",
             "stream_path": output_file,
+            "part_path": output_file.parent / (output_file.name + ".part"),
             "parent_name": None,
             "compress": "gzip",
             "encrypt": None,
@@ -444,6 +445,7 @@ class TestShellPipelineExecution:
             proc.wait()
 
         assert proc.returncode == 0
+        endpoint.commit_receive()  # publish .part -> final
         assert output_file.exists()
         assert output_file.stat().st_size > 0
 
@@ -477,6 +479,7 @@ class TestShellPipelineExecution:
         endpoint._pending_metadata = {
             "name": "test",
             "stream_path": output_file,
+            "part_path": output_file.parent / (output_file.name + ".part"),
             "parent_name": None,
             "compress": "gzip",
             "encrypt": None,
@@ -491,6 +494,7 @@ class TestShellPipelineExecution:
             proc.wait()
 
         assert proc.returncode == 0
+        endpoint.commit_receive()  # publish .part -> final
         assert output_file.exists()
 
 
@@ -1064,6 +1068,7 @@ class TestSSHRawEndpointIntegration:
         endpoint._pending_metadata = {
             "name": "test",
             "stream_path": output_file,
+            "part_path": output_file.parent / (output_file.name + ".part"),
             "parent_name": None,
             "compress": "zstd",
             "encrypt": None,
@@ -1085,6 +1090,7 @@ class TestSSHRawEndpointIntegration:
         proc.wait()
 
         assert result.returncode == 0
+        endpoint.commit_receive()  # remote sync + atomic mv .part -> final
         assert output_file.exists()
 
         # Verify data can be decompressed
@@ -1257,6 +1263,7 @@ class TestEdgeCases:
         endpoint._pending_metadata = {
             "name": "empty",
             "stream_path": output_file,
+            "part_path": output_file.parent / (output_file.name + ".part"),
             "parent_name": None,
             "compress": "gzip",
             "encrypt": None,
@@ -1268,6 +1275,7 @@ class TestEdgeCases:
             proc.wait()
 
         assert proc.returncode == 0
+        endpoint.commit_receive()  # publish .part -> final
         assert output_file.exists()
 
         # Decompress should return empty
@@ -1292,6 +1300,7 @@ class TestEdgeCases:
         endpoint._pending_metadata = {
             "name": "large",
             "stream_path": output_file,
+            "part_path": output_file.parent / (output_file.name + ".part"),
             "parent_name": None,
             "compress": "gzip",
             "encrypt": None,
@@ -1303,6 +1312,7 @@ class TestEdgeCases:
             proc.wait()
 
         assert proc.returncode == 0
+        endpoint.commit_receive()  # publish .part -> final
         assert output_file.exists()
         # Highly repetitive data should compress very well
         assert output_file.stat().st_size < len(large_data) / 100


### PR DESCRIPTION
## Problem
Raw-target backups streamed directly to their final filename with no fsync, so a crash or kill mid-transfer left a **truncated** stream under the final name that `discover_raw_snapshots` listed as a **complete backup** (a phantom). `_cleanup_snapper_backup` compounded this with a no-op that wrongly assumed raw partials are overwritten on the next run.

## Fix
Raw streams are written to a `<name>.part` sibling and published to the final name only **after the transfer engine confirms the pipeline succeeded**, via a new `Endpoint.commit_receive()` hook:
- **base `Endpoint`** — no-op (`btrfs receive` is already atomic)
- **`RawEndpoint`** — fsync the file → `os.replace` → fsync the directory
- **`SSHRawEndpoint`** — remote `sync && mv -f && sync`

A commit failure is raised as a `SnapshotTransferError` (never reported as success). `discover_raw_snapshots` ignores `.part`; failure-path cleanup removes the exact `.part` (never the final name). The SSH receive-write path now quotes the destination consistently with commit (fixing a latent `sudo sh -c` nesting bug for paths containing spaces). `Endpoint.__cached_snapshots` is annotated so the package is mypy-clean.

## Why it's safe
A crash at any point leaves at most a `.part` (ignored by discovery) or the fully-committed final name — never a truncated file under the final name. Non-raw endpoints are unaffected (base no-op).

## Testing
- New `test_raw_atomic_write.py` (atomic invariant, fail-loud on missing `.part`, SSH commit script/quoting) and `test_atomic_commit_wiring.py` (engine calls commit on success / not on pipeline failure / commit-failure becomes a transfer failure).
- **Mutation-verified 4×**: removing the `.part` discovery exclusion, reverting the atomic write, neutering the commit hook, and stripping the commit `try/except` each make specific tests fail.
- Full suite **2103 passed**; ruff + mypy clean.
- **Hardware-validated on real btrfs** (isolated loopback image): atomic write, restore round-trip (byte-identical via real `btrfs receive`), and a crash test (killed `btrfs send | receive` mid-stream → real truncated `.part`, no final, no phantom). `raw+ssh` commit exercised over real ssh-to-localhost.

First of the 0.8.5 "raw backups become first-class" series. Merge at your discretion.
