### PR TITLE
fix: make raw backups restorable via the Snapshot interface

### DIFF
--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -1322,7 +1322,13 @@ def _execute_transfers(
             best_snapshot = to_transfer[-1]
             parent = None
         else:
-            # Find snapshots present on destination for incremental
+            # Find snapshots present on destination for incremental.
+            # `snap in destination_snapshots` relies on the DESTINATION element's
+            # __eq__: for a raw target that is RawSnapshot.__eq__ (name-based),
+            # which is how a source btrfs snapshot is matched to its raw backup.
+            # Do NOT rewrite as `snap == d` -- that invokes the source Snapshot's
+            # prefix+time_obj __eq__, which never matches a raw snapshot and would
+            # silently degrade every backup-to-raw to a full send.
             present_snapshots = [
                 snap
                 for snap in source_snapshots

--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -18,6 +18,7 @@ import os
 import shlex
 import shutil
 import subprocess
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, TypedDict
 
@@ -28,6 +29,7 @@ from btrfs_backup_ng.endpoint.raw_metadata import (
     RawSnapshot,
     discover_raw_snapshots,
     get_file_extension,
+    parse_stream_filename,
 )
 
 
@@ -589,10 +591,37 @@ class RawEndpoint(Endpoint):
         prefix = self.config.get("snap_prefix", "")
 
         snapshots = discover_raw_snapshots(path, prefix)
+        # Restore/verify read the stream via this endpoint, so each snapshot must
+        # know which endpoint owns it (mirrors __util__.Snapshot.endpoint).
+        for snapshot in snapshots:
+            snapshot.endpoint = self
         self._cached_snapshots = snapshots
 
         logger.debug("Found %d raw snapshots in %s", len(snapshots), path)
         return list(snapshots)
+
+    def set_lock(
+        self,
+        snapshot: Any,
+        lock_id: Any,
+        lock_state: bool,
+        parent: bool = False,
+    ) -> None:
+        """Update the in-memory retention lock on a raw snapshot.
+
+        Overrides the base Endpoint.set_lock, which requires a ``source`` and
+        writes a LOCAL lock file at ``config['path']`` -- both wrong for a raw
+        target (restore does not set a source, and the path is remote for
+        raw+ssh, so the base write would raise and abort the restore). Raw lock
+        PERSISTENCE across runs is a separate change (audit root R3); until then
+        this mutates only the in-memory lock set so the restore/transfer
+        lock-guard logic works without touching disk.
+        """
+        target = snapshot.parent_locks if parent else snapshot.locks
+        if lock_state:
+            target.add(lock_id)
+        else:
+            target.discard(lock_id)
 
     def delete_snapshots(self, snapshots: list[RawSnapshot], **kwargs: Any) -> None:
         """Delete raw snapshot files and their metadata.
@@ -919,7 +948,82 @@ class SSHRawEndpoint(RawEndpoint):
                 logger.debug("Failed to parse remote metadata %s: %s", meta_path, e)
                 continue
 
+        # Second pass: sidecar-less remote streams (legacy backups, direct
+        # btrfs sends, lost .meta). Without this, remote backups that predate
+        # .meta sidecars are invisible -- unlistable and unrestorable. Mirrors
+        # discover_raw_snapshots' filename-fallback pass.
+        loaded_names = {s.name for s in snapshots}
+        prefix = self.config.get("snap_prefix", "")
+        find_stream_cmd = (
+            f"find {shlex.quote(str(path))} -name '*.btrfs*' -type f 2>/dev/null"
+        )
+        if self.ssh_sudo:
+            find_stream_cmd = f"sudo {find_stream_cmd}"
+        try:
+            result = subprocess.run(
+                ssh_cmd + [find_stream_cmd],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            stream_files = (
+                result.stdout.strip().split("\n") if result.stdout.strip() else []
+            )
+        except subprocess.CalledProcessError:
+            stream_files = []
+
+        # Dedup on the stream PATH (unambiguous) as well as the derived name, so
+        # a stream that also has a .meta is never enumerated twice even if its
+        # recorded name differs from the filename stem.
+        loaded_paths = {str(s.stream_path) for s in snapshots}
+        for stream_path_str in stream_files:
+            if not stream_path_str or stream_path_str.endswith((".meta", ".part")):
+                continue
+            if stream_path_str in loaded_paths:
+                continue
+            stream_path = Path(stream_path_str)
+            parsed = parse_stream_filename(stream_path.name)
+            name = parsed["name"]
+            if name in loaded_names:
+                continue
+            if prefix and not name.startswith(prefix):
+                continue
+            stat_cmd = f"stat -c '%Y %s' {shlex.quote(stream_path_str)}"
+            if self.ssh_sudo:
+                stat_cmd = f"sudo {stat_cmd}"
+            try:
+                stat_result = subprocess.run(
+                    ssh_cmd + [stat_cmd],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+                mtime_str, size_str = stat_result.stdout.strip().split()
+                created = datetime.fromtimestamp(int(mtime_str), tz=timezone.utc)
+                size = int(size_str)
+            except (subprocess.CalledProcessError, ValueError):
+                # A committed stream we cannot stat (removed mid-list, permission
+                # error) must NOT be surfaced with a fabricated created=now, which
+                # would sort as newest and distort prune / parent selection. Skip it.
+                logger.debug("Skipping un-stat-able remote stream %s", stream_path_str)
+                continue
+            snapshots.append(
+                RawSnapshot(
+                    name=name,
+                    stream_path=stream_path,
+                    created=created,
+                    size=size,
+                    compress=parsed["compress"],
+                    encrypt=parsed["encrypt"],
+                )
+            )
+            loaded_names.add(name)
+            loaded_paths.add(stream_path_str)
+
         snapshots.sort(key=lambda s: s.created)
+        # Restore/verify read the stream via this endpoint (see RawEndpoint).
+        for snapshot in snapshots:
+            snapshot.endpoint = self
         self._cached_snapshots = snapshots
         return list(snapshots)
 

--- a/src/btrfs_backup_ng/endpoint/raw_metadata.py
+++ b/src/btrfs_backup_ng/endpoint/raw_metadata.py
@@ -6,7 +6,9 @@ This module provides classes for tracking metadata about raw backup files
 
 from __future__ import annotations
 
+import functools
 import json
+import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -59,9 +61,16 @@ COMPRESSION_CONFIG: dict[str, dict[str, Any]] = {
 }
 
 
-@dataclass
+@functools.total_ordering
+@dataclass(eq=False, repr=False)
 class RawSnapshot:
     """Metadata for a raw backup file (btrfs send stream).
+
+    Implements the ``__util__.Snapshot`` interface (get_name/get_path/time_obj/
+    locks/find_parent/comparison) so raw backups can be listed, restored,
+    verified, and pruned like btrfs snapshots. Identity is by NAME: a source
+    btrfs snapshot and the raw stream backed up from it share a name, so
+    name-based equality is the correct cross-type "same snapshot" relation.
 
     Attributes:
         name: Snapshot name (e.g., 'root.20240115T120000')
@@ -74,6 +83,9 @@ class RawSnapshot:
         compress: Compression algorithm used (or None)
         encrypt: Encryption method used (or None)
         gpg_recipient: GPG recipient if encrypted
+        prefix / time_format: Snapshot-interface fields (name is authoritative)
+        endpoint: the raw endpoint that owns this snapshot (set on discovery)
+        locks / parent_locks: retention lock sets (Snapshot-interface parity)
     """
 
     name: str
@@ -86,6 +98,12 @@ class RawSnapshot:
     compress: str | None = None
     encrypt: str | None = None
     gpg_recipient: str | None = None
+    # --- Snapshot-interface compatibility (0.8.5) ---
+    prefix: str = ""
+    time_format: str | None = None
+    endpoint: Any = None
+    locks: set[str] = field(default_factory=set)
+    parent_locks: set[str] = field(default_factory=set)
 
     @property
     def metadata_path(self) -> Path:
@@ -96,6 +114,61 @@ class RawSnapshot:
     def is_incremental(self) -> bool:
         """Check if this is an incremental backup."""
         return self.parent_uuid is not None or self.parent_name is not None
+
+    # --- __util__.Snapshot interface -------------------------------------
+    def get_name(self) -> str:
+        """Return the snapshot name (authoritative, stored on disk)."""
+        return self.name
+
+    def get_path(self) -> Path:
+        """Return the path to the stream file (the raw analogue of a subvol)."""
+        return self.stream_path
+
+    @property
+    def time_obj(self) -> time.struct_time:
+        """Creation time as a ``struct_time``, matching __util__.Snapshot.time_obj.
+
+        Consumers call ``time.strftime(fmt, snap.time_obj)`` (restore listing /
+        interactive picker) and compare ``snap.time_obj <= target`` where target
+        is a struct_time (``restore --before``); returning the same type as a
+        btrfs Snapshot makes those paths work uniformly across snapshot types
+        (and makes cross-type ordering well-defined) instead of raising TypeError.
+        """
+        return self.created.timetuple()
+
+    def __repr__(self) -> str:
+        return self.name
+
+    def __eq__(self, other: object) -> bool:
+        # Identity by name so a raw backup equals the btrfs snapshot it came
+        # from (both expose get_name()). NotImplemented lets Python try the
+        # reflected comparison for unrelated types.
+        get_name = getattr(other, "get_name", None)
+        if get_name is None:
+            return NotImplemented
+        return self.name == get_name()
+
+    def __lt__(self, other: object) -> bool:
+        other_time = getattr(other, "time_obj", None)
+        if other_time is None:
+            return NotImplemented
+        return self.time_obj < other_time
+
+    # Defining __eq__ without __hash__ makes instances unhashable, matching
+    # __util__.Snapshot and keeping set-based paths consistent across snapshot
+    # types.
+
+    def find_parent(self, present_snapshots: list[RawSnapshot]) -> RawSnapshot | None:
+        """Most suitable already-present snapshot to use as an incremental
+        parent, or None. Mirrors __util__.Snapshot.find_parent."""
+        if self in present_snapshots:
+            return None
+        for present_snapshot in reversed(present_snapshots):
+            if present_snapshot < self:
+                return present_snapshot
+        if present_snapshots:
+            return present_snapshots[0]
+        return None
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize snapshot metadata to a dictionary."""

--- a/tests/test_raw_endpoint.py
+++ b/tests/test_raw_endpoint.py
@@ -1,5 +1,6 @@
 """Tests for raw target endpoint."""
 
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -1025,16 +1026,78 @@ class TestSSHRawEndpointMethods:
         )
 
         with patch("subprocess.run") as mock_run:
-            # First call: find metadata files
-            # Second call: cat metadata file
+            # 1) find *.meta  2) cat the meta  3) second-pass find *.btrfs*
+            # (returns the same stream, which is deduped against the meta pass).
             mock_run.side_effect = [
                 MagicMock(returncode=0, stdout="/backup/test.btrfs.meta\n"),
                 MagicMock(returncode=0, stdout=meta_content),
+                MagicMock(returncode=0, stdout="/backup/test.btrfs\n"),
             ]
             snapshots = endpoint.list_snapshots()
 
         assert len(snapshots) == 1
         assert snapshots[0].name == "test"
+
+    def test_list_snapshots_discovers_sidecar_less_remote(self):
+        """The second pass must surface remote streams that have NO .meta sidecar
+        (legacy/direct backups) -- otherwise they are invisible and unrestorable."""
+        endpoint = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout=""),  # find *.meta -> none
+                # second-pass find *.btrfs* -> a sidecar-less compressed stream
+                MagicMock(returncode=0, stdout="/backup/legacy.btrfs.zst\n"),
+                MagicMock(returncode=0, stdout="1705320000 4096\n"),  # stat: mtime size
+            ]
+            snapshots = endpoint.list_snapshots()
+
+        assert len(snapshots) == 1
+        snap = snapshots[0]
+        assert snap.name == "legacy"
+        assert snap.compress == "zstd"  # inferred from the filename
+        assert snap.size == 4096
+        assert snap.endpoint is endpoint  # restore can read it back
+
+    def test_list_snapshots_dedups_meta_and_stream_by_path(self):
+        """A stream that has a .meta must not be listed twice even when its
+        recorded name differs from the filename stem (dedup on stream PATH)."""
+        endpoint = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+        # .meta records a name ("renamed") different from the filename stem ("x").
+        meta = '{"name": "renamed", "created": "2024-01-15T12:00:00"}'
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="/backup/x.btrfs.meta\n"),
+                MagicMock(returncode=0, stdout=meta),
+                MagicMock(returncode=0, stdout="/backup/x.btrfs\n"),  # same stream
+            ]
+            snapshots = endpoint.list_snapshots()
+        assert len(snapshots) == 1  # deduped by path, not by (divergent) name
+        assert snapshots[0].name == "renamed"
+
+    def test_list_snapshots_second_pass_skips_part(self):
+        """An in-progress remote .part must never be listed as a backup."""
+        endpoint = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout=""),  # find *.meta -> none
+                MagicMock(returncode=0, stdout="/backup/x.btrfs.part\n"),
+            ]
+            snapshots = endpoint.list_snapshots()
+        assert snapshots == []
+
+    def test_list_snapshots_skips_unstatable_stream(self):
+        """A stream that cannot be stat'd is skipped, not surfaced with a
+        fabricated created=now that would sort as newest."""
+        endpoint = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout=""),  # find *.meta -> none
+                MagicMock(returncode=0, stdout="/backup/x.btrfs\n"),  # find stream
+                subprocess.CalledProcessError(1, "stat"),  # stat fails
+            ]
+            snapshots = endpoint.list_snapshots()
+        assert snapshots == []
 
     def test_list_snapshots_caching(self):
         """Test that SSH snapshot listing uses caching."""

--- a/tests/test_raw_snapshot_interface.py
+++ b/tests/test_raw_snapshot_interface.py
@@ -1,0 +1,134 @@
+"""RawSnapshot satisfies the __util__.Snapshot interface (0.8.5 PR2).
+
+Before this, raw backups AttributeError'd in restore/verify/prune: those paths
+call get_name()/get_path()/time_obj/find_parent and compare/sort snapshots, none
+of which a plain dataclass RawSnapshot supported. Identity is by NAME so a raw
+backup equals the btrfs snapshot it was made from.
+
+Written to FAIL if the interface is removed (no get_name -> AttributeError; no
+__lt__ -> sorting/find_parent break; field-wise equality -> find_parent's
+already-present check breaks).
+"""
+
+import datetime
+import time
+from pathlib import Path
+
+import pytest
+
+from btrfs_backup_ng import __util__
+from btrfs_backup_ng.endpoint.raw import RawEndpoint, SSHRawEndpoint
+from btrfs_backup_ng.endpoint.raw_metadata import RawSnapshot
+
+UTC = datetime.timezone.utc
+
+
+def _raw(name, day):
+    return RawSnapshot(
+        name=name,
+        stream_path=Path(f"/b/{name}.btrfs"),
+        created=datetime.datetime(2024, 1, day, tzinfo=UTC),
+    )
+
+
+def test_basic_interface():
+    s = _raw("root.20240115", 15)
+    assert s.get_name() == "root.20240115"
+    assert s.get_path() == Path("/b/root.20240115.btrfs")
+    assert repr(s) == "root.20240115"
+    assert isinstance(s.locks, set)
+    assert isinstance(s.parent_locks, set)
+
+
+def test_time_obj_is_struct_time_like_btrfs_snapshot():
+    """time_obj must be a struct_time (not a datetime): restore listing calls
+    time.strftime(fmt, snap.time_obj) and `restore --before` compares
+    snap.time_obj <= struct_time. A datetime raises TypeError on both, breaking
+    the exact restore paths raw snapshots are meant to support."""
+    s = _raw("root.20240115", 15)
+    assert isinstance(s.time_obj, time.struct_time)
+    # The two operations the CLI restore paths actually perform:
+    assert time.strftime("%Y-%m-%d", s.time_obj) == "2024-01-15"
+    later = time.strptime("2024-06-01", "%Y-%m-%d")
+    assert s.time_obj <= later  # `restore --before` comparison must not raise
+
+
+def test_ordering_and_sort():
+    a, b, c = _raw("a", 1), _raw("b", 2), _raw("c", 3)
+    assert a < b < c
+    assert c > a
+    assert sorted([c, a, b]) == [a, b, c]
+
+
+def test_name_based_equality():
+    # Same name, different time/fields -> the same snapshot.
+    assert _raw("same", 1) == _raw("same", 9)
+    assert _raw("x", 1) != _raw("y", 1)
+    # Not equal to unrelated objects (NotImplemented -> False), no crash.
+    assert _raw("x", 1) != 42
+
+
+def test_cross_type_equality_with_btrfs_snapshot():
+    """A raw backup equals the btrfs Snapshot it came from (shared name), which
+    is exactly how incremental parent-matching finds a source snapshot already
+    present at a raw destination. (Cross-type *ordering* is not supported --
+    btrfs time_obj is a struct_time, raw's is a datetime -- but the live paths
+    only ever compare like with like; equality is by name.)"""
+    fmt = "%Y%m%d-%H%M%S"
+    btrfs = __util__.Snapshot(
+        "/src",
+        "root.",
+        None,
+        time_obj=time.strptime("20240115-120000", fmt),
+        time_format=fmt,
+    )
+    raw = RawSnapshot(name=btrfs.get_name(), stream_path=Path("/b/x.btrfs"))
+    assert raw == btrfs
+    # The live path: `source_snap in destination_list` -> element(raw).__eq__.
+    assert btrfs in [raw]
+
+
+def test_unhashable_like_snapshot():
+    # Matches __util__.Snapshot (unhashable); keeps set-based paths consistent.
+    with pytest.raises(TypeError):
+        hash(_raw("x", 1))
+
+
+def test_find_parent_picks_most_recent_older():
+    a, b, c = _raw("a", 1), _raw("b", 2), _raw("c", 3)
+    present = [a, b]
+    assert c.find_parent(present) is b
+    # `a` is already present (equal by name) -> no parent needed.
+    assert a.find_parent(present) is None
+    # Nothing present -> no parent.
+    assert c.find_parent([]) is None
+
+
+def test_set_lock_is_in_memory_only_and_never_raises(tmp_path):
+    """Restore locks/unlocks the backup snapshot. The raw override must mutate
+    only the in-memory lock set -- no `source` requirement, no local lock-file
+    write (which would fail for a remote raw+ssh target and abort the restore).
+    Persisting locks across runs is deferred (R3)."""
+    for ep in (
+        RawEndpoint(config={"path": str(tmp_path)}),
+        SSHRawEndpoint(config={"path": "/remote/backup", "hostname": "nas"}),
+    ):
+        snap = _raw("root.20240115", 15)
+        ep.set_lock(snap, "restore:abc", True)
+        assert snap.locks == {"restore:abc"}
+        ep.set_lock(snap, "restore:abc", False)
+        assert snap.locks == set()
+        ep.set_lock(snap, "xfer:1", True, parent=True)
+        assert snap.parent_locks == {"xfer:1"}
+        # No lock file was written next to a local raw target.
+        assert not (tmp_path / ".btrfs-backup-ng.locks").exists()
+
+
+def test_list_snapshots_threads_endpoint_locally(tmp_path):
+    """Every snapshot from RawEndpoint.list_snapshots must carry endpoint=self so
+    restore/verify can read the stream back."""
+    (tmp_path / "snap.20240115.btrfs").write_bytes(b"stream")
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    snaps = ep.list_snapshots()
+    assert len(snaps) == 1
+    assert snaps[0].endpoint is ep


### PR DESCRIPTION
Stacked on #21 (base: `pr1-atomic-raw-write`). Retarget to `master` once #21 merges.

## Problem
Raw backups were effectively write-only (audit root R5): `RawSnapshot` was a plain dataclass with none of the `Snapshot` interface, so `restore`/`verify`/`prune` `AttributeError`'d on `get_name`/`get_path`/`time_obj`/`find_parent`/comparison. Remote (`raw+ssh`) backups without a `.meta` sidecar were invisible to `list_snapshots` (it only found `*.meta`).

## Fix
- **RawSnapshot implements the `Snapshot` interface**: `get_name()`/`get_path()`, `time_obj` as a **struct_time** (matches btrfs snapshots — `restore --list` and `restore --before` no longer `TypeError`), name-based equality (a raw backup equals the btrfs snapshot it was made from), time ordering, `find_parent`, `locks`/`parent_locks`, `__repr__`. Unhashable, matching `Snapshot`. `list_snapshots` threads `endpoint` onto each snapshot so restore can read the stream back.
- **`RawEndpoint.set_lock` override**: mutates the in-memory lock only — no `source` requirement, no local lock-file write (which would abort a `raw+ssh` restore). Lock *persistence* across runs is deferred (R3).
- **SSH remote enumeration**: a second pass over `*.btrfs*` + `stat`, deduped by stream path, skipping `.part` and un-stat-able files — sidecar-less remote backups are now listable/restorable.

## Testing
- New `test_raw_snapshot_interface.py` (interface, cross-type equality, struct_time `time_obj`, `set_lock` in-memory, endpoint threading) + SSH-enumeration tests (sidecar-less discovery, dedup-by-path, `.part` skip, un-stat skip).
- **Mutation-verified 4×**: the SSH second pass, name-based `__eq__`, `time_obj` struct_time, and the `set_lock` override.
- ruff/mypy clean, **2116 passed**.
- **Hardware-validated on real btrfs**: the data round-trip *and* the full `restore_snapshot()` orchestration (`set_lock` + `send_snapshot` + `btrfs receive`), restored data byte-identical; `raw+ssh` listing exercised over real ssh.

The adversarial review caught two `time_obj`/struct_time `TypeError`s (breaking `restore --list`/`--before`) and the `set_lock` crash — all missed by a `send()`-only test, now fixed and mutation-verified.

Second of the 0.8.5 "raw backups become first-class" series.
