### PR TITLE
feat: auto-write authoritative .meta sidecar on every raw backup (schema v2)

### DIFF
--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -27,6 +27,7 @@ from btrfs_backup_ng.endpoint.common import Endpoint
 from btrfs_backup_ng.endpoint.raw_metadata import (
     COMPRESSION_CONFIG,
     RawSnapshot,
+    _fsync_directory,
     discover_raw_snapshots,
     get_file_extension,
     parse_stream_filename,
@@ -43,6 +44,7 @@ class PendingMetadata(TypedDict):
     compress: str | None
     encrypt: str | None
     gpg_recipient: str | None
+    openssl_cipher: str | None
 
 
 # Environment variable for OpenSSL passphrase (compatible with btrbk)
@@ -167,6 +169,7 @@ class RawEndpoint(Endpoint):
             "compress": None,
             "encrypt": None,
             "gpg_recipient": None,
+            "openssl_cipher": None,
         }
 
     def _get_openssl_passphrase(self) -> str | None:
@@ -273,6 +276,11 @@ class RawEndpoint(Endpoint):
             "compress": self.compress,
             "encrypt": self.encrypt,
             "gpg_recipient": self.gpg_recipient,
+            # Only meaningful for openssl_enc; recorded so restore uses the exact
+            # cipher instead of guessing aes-256-cbc.
+            "openssl_cipher": (
+                self.openssl_cipher if self.encrypt == "openssl_enc" else None
+            ),
         }
 
         # Build and execute the pipeline (writes to the .part file)
@@ -375,15 +383,11 @@ class RawEndpoint(Endpoint):
 
     @staticmethod
     def _fsync_dir(directory: Path) -> None:
-        """Best-effort fsync of a directory so a rename into it is durable."""
-        try:
-            dfd = os.open(directory, os.O_RDONLY)
-            try:
-                os.fsync(dfd)
-            finally:
-                os.close(dfd)
-        except OSError as e:
-            logger.debug("Directory fsync failed for %s: %s", directory, e)
+        """Best-effort fsync of a directory so a rename into it is durable.
+
+        Delegates to the single shared implementation so the durability primitive
+        has one definition."""
+        _fsync_directory(directory)
 
     def commit_receive(self) -> None:
         """Atomically publish the received stream after a successful transfer.
@@ -422,7 +426,41 @@ class RawEndpoint(Endpoint):
         os.replace(part_path, final_path)
         # Persist the rename itself.
         self._fsync_dir(final_path.parent)
-        logger.debug("Committed raw stream: %s", final_path)
+        # Write the authoritative sidecar now that the stream is durable at its
+        # final name. Written last + atomically, so a crash yields at most a
+        # stream-without-sidecar (discovery falls back to filename inference),
+        # never a sidecar describing a missing/partial stream. Best-effort: the
+        # backup data already succeeded, so a sidecar error must not fail it.
+        try:
+            self._sidecar_snapshot(
+                final_path, final_path.stat().st_size
+            ).save_metadata()
+        except Exception as e:
+            # The backup data is already durable; a sidecar error must NEVER flip
+            # an already-successful transfer into a reported failure (PR1 contract).
+            # A missing sidecar just degrades to filename inference.
+            logger.warning("Failed to write sidecar for %s: %s", final_path, e)
+        self._cached_snapshots = None  # re-discover to include the new sidecar
+        logger.debug("Committed raw stream + sidecar: %s", final_path)
+
+    def _sidecar_snapshot(self, final_path: Path, size: int) -> RawSnapshot:
+        """Build the authoritative RawSnapshot to persist for a just-committed
+        stream, from the pending receive metadata. openssl_cipher is recorded so
+        restore uses the exact cipher; the checksum is reserved (filled later by
+        ``raw verify``)."""
+        pending = self._pending_metadata
+        return RawSnapshot(
+            name=pending["name"],
+            stream_path=final_path,
+            parent_name=pending.get("parent_name"),
+            created=datetime.now(timezone.utc),
+            size=size,
+            compress=pending.get("compress"),
+            encrypt=pending.get("encrypt"),
+            gpg_recipient=pending.get("gpg_recipient"),
+            openssl_cipher=pending.get("openssl_cipher"),
+            provenance_origin="native-write",
+        )
 
     def finalize_receive(
         self, proc: subprocess.Popen, uuid: str = "", parent_uuid: str | None = None
@@ -887,7 +925,63 @@ class SSHRawEndpoint(RawEndpoint):
                 f"Failed to publish remote raw stream {final_path}: "
                 f"{(stderr or '').strip()}"
             )
-        logger.debug("Committed remote raw stream: %s", final_path)
+        # Write the authoritative sidecar remotely (best-effort: the stream is
+        # already durable, so a sidecar error must not fail the backup).
+        self._write_remote_sidecar(Path(str(final_path)))
+        self._cached_snapshots = None
+        logger.debug("Committed remote raw stream + sidecar: %s", final_path)
+
+    def _write_remote_sidecar(self, final_path: Path) -> None:
+        """Stat the committed remote stream for its size, then write its .meta
+        sidecar remotely and atomically (temp -> sync -> mv -> chmod 600)."""
+        size = 0
+        # Portable remote size: GNU `stat -c %s`, else BSD/macOS `stat -f %z`,
+        # else POSIX `wc -c`. A raw target is often a non-Linux box (NAS, macOS),
+        # so GNU-only stat would record a bogus size on those.
+        q = shlex.quote(str(final_path))
+        size_cmd = (
+            f"stat -c %s {q} 2>/dev/null || stat -f %z {q} 2>/dev/null || wc -c < {q}"
+        )
+        try:
+            stat_res = self._exec_remote_command(["sh", "-c", size_cmd], check=False)
+            out = stat_res.stdout
+            if isinstance(out, (bytes, bytearray)):
+                out = out.decode(errors="replace")
+            if stat_res.returncode == 0:
+                size = int((str(out) or "0").strip() or "0")
+            else:
+                # Do not silently persist a bogus authoritative size of 0 -- make
+                # the failure observable (size stays 0, best-effort).
+                logger.warning(
+                    "Remote size of %s failed (rc=%s); recording sidecar size=0",
+                    final_path,
+                    stat_res.returncode,
+                )
+        except (ValueError, TypeError, OSError) as e:
+            logger.warning(
+                "Could not size remote stream %s: %s; recording sidecar size=0",
+                final_path,
+                e,
+            )
+        snapshot = self._sidecar_snapshot(final_path, size)
+        payload = json.dumps(snapshot.to_dict(), indent=2).encode("utf-8")
+        meta = f"{final_path}.meta"
+        tmp = f"{meta}.tmp"
+        script = (
+            f"cat > {shlex.quote(tmp)} && sync && "
+            f"mv -f {shlex.quote(tmp)} {shlex.quote(meta)} && "
+            f"chmod 600 {shlex.quote(meta)}"
+        )
+        result = self._exec_remote_command(
+            ["sh", "-c", script], input=payload, check=False
+        )
+        if result.returncode != 0:
+            stderr = result.stderr
+            if isinstance(stderr, (bytes, bytearray)):
+                stderr = stderr.decode(errors="replace")
+            logger.warning(
+                "Failed to write remote sidecar %s: %s", meta, (stderr or "").strip()
+            )
 
     def list_snapshots(self, flush_cache: bool = False) -> list[RawSnapshot]:
         """List raw snapshots on the remote host.
@@ -977,7 +1071,9 @@ class SSHRawEndpoint(RawEndpoint):
         # recorded name differs from the filename stem.
         loaded_paths = {str(s.stream_path) for s in snapshots}
         for stream_path_str in stream_files:
-            if not stream_path_str or stream_path_str.endswith((".meta", ".part")):
+            if not stream_path_str or stream_path_str.endswith(
+                (".meta", ".part", ".tmp")
+            ):
                 continue
             if stream_path_str in loaded_paths:
                 continue

--- a/src/btrfs_backup_ng/endpoint/raw_metadata.py
+++ b/src/btrfs_backup_ng/endpoint/raw_metadata.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import functools
 import json
+import os
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -61,6 +62,26 @@ COMPRESSION_CONFIG: dict[str, dict[str, Any]] = {
 }
 
 
+def _to_utc(dt: datetime) -> datetime:
+    """Return ``dt`` as a UTC-aware datetime so sidecars record unambiguous
+    ISO-8601 UTC (a naive datetime is assumed to already be UTC)."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _fsync_directory(directory: Path) -> None:
+    """Best-effort fsync of a directory so a rename into it is durable."""
+    try:
+        dfd = os.open(directory, os.O_RDONLY)
+        try:
+            os.fsync(dfd)
+        finally:
+            os.close(dfd)
+    except OSError:
+        pass
+
+
 @functools.total_ordering
 @dataclass(eq=False, repr=False)
 class RawSnapshot:
@@ -98,6 +119,13 @@ class RawSnapshot:
     compress: str | None = None
     encrypt: str | None = None
     gpg_recipient: str | None = None
+    openssl_cipher: str | None = None
+    # --- authoritative sidecar (0.8.5) ---
+    # checksum_value is RESERVED: the schema carries checksum{algorithm,value} but
+    # the value is populated later by `raw verify` (computed via a Python-native
+    # stream tee), so the zero-copy write pipeline is not taxed with a second read.
+    checksum_value: str | None = None
+    provenance_origin: str = "native-write"
     # --- Snapshot-interface compatibility (0.8.5) ---
     prefix: str = ""
     time_format: str | None = None
@@ -171,27 +199,52 @@ class RawSnapshot:
         return None
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialize snapshot metadata to a dictionary."""
+        """Serialize snapshot metadata to the v2 sidecar dict.
+
+        v2 is additive over v1: the nested ``pipeline`` block gains
+        ``openssl_cipher``, and ``checksum``/``provenance`` blocks are added. A v1
+        reader ignores the new keys; ``from_dict`` reads either version. ``created``
+        is ISO-8601 in UTC. ``checksum.value`` is reserved (null on the write path;
+        populated later by ``raw verify``).
+        """
         return {
-            "version": 1,
+            "version": 2,
             "name": self.name,
             "uuid": self.uuid,
             "parent_uuid": self.parent_uuid,
             "parent_name": self.parent_name,
-            "created": self.created.isoformat(),
+            "created": _to_utc(self.created).isoformat(),
             "size": self.size,
             "pipeline": {
                 "compress": self.compress,
                 "encrypt": self.encrypt,
                 "gpg_recipient": self.gpg_recipient,
+                "openssl_cipher": self.openssl_cipher,
             },
+            "checksum": {"algorithm": "sha256", "value": self.checksum_value},
+            "provenance": {
+                "origin": self.provenance_origin,
+                "tool_version": __version__,
+            },
+            # Kept for backward compatibility with v1 readers.
             "btrfs_backup_ng_version": __version__,
         }
 
     def save_metadata(self) -> None:
-        """Save metadata to the metadata file."""
-        with open(self.metadata_path, "w", encoding="utf-8") as f:
-            json.dump(self.to_dict(), f, indent=2)
+        """Write the sidecar atomically (temp -> fsync -> rename -> dir fsync) at
+        mode 0600, so a crash never leaves a partial/half-written .meta and the
+        metadata dossier is not world-readable."""
+        meta = self.metadata_path
+        tmp = meta.with_name(meta.name + ".tmp")
+        payload = json.dumps(self.to_dict(), indent=2).encode("utf-8")
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            os.write(fd, payload)
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        os.replace(tmp, meta)
+        _fsync_directory(meta.parent)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any], stream_path: Path) -> RawSnapshot:
@@ -204,7 +257,11 @@ class RawSnapshot:
         Returns:
             RawSnapshot instance
         """
-        pipeline = data.get("pipeline", {})
+        # `or {}` (not a default arg) so an explicit JSON null for a block does
+        # not become None and crash the .get() calls below.
+        pipeline = data.get("pipeline") or {}
+        checksum = data.get("checksum") or {}
+        provenance = data.get("provenance") or {}
         created_str = data.get("created")
 
         if created_str:
@@ -224,6 +281,10 @@ class RawSnapshot:
             compress=pipeline.get("compress"),
             encrypt=pipeline.get("encrypt"),
             gpg_recipient=pipeline.get("gpg_recipient"),
+            # v2 fields (absent in v1 -> defaults):
+            openssl_cipher=pipeline.get("openssl_cipher"),
+            checksum_value=checksum.get("value"),
+            provenance_origin=provenance.get("origin", "native-write"),
         )
 
     @classmethod
@@ -353,8 +414,9 @@ def discover_raw_snapshots(
             snapshot = RawSnapshot.load_metadata(meta_path)
             if not prefix or snapshot.name.startswith(prefix):
                 snapshots.append(snapshot)
-        except (json.JSONDecodeError, OSError):
-            # Skip invalid metadata files
+        except (json.JSONDecodeError, OSError, ValueError, TypeError, AttributeError):
+            # Skip a single malformed sidecar rather than aborting the whole
+            # directory listing (bad JSON, wrong types, unexpected structure).
             continue
 
     # Second pass: find stream files without metadata
@@ -363,10 +425,11 @@ def discover_raw_snapshots(
         if not item.is_file() or item.suffix == ".meta":
             continue
 
-        # Skip in-progress stream files: a ".part" file is a transfer that has
-        # not been committed (renamed to its final name), so it must NEVER be
-        # listed as a complete backup.
-        if item.name.endswith(".part"):
+        # Skip in-progress artifacts: a ".part" file is an uncommitted stream and
+        # a ".tmp" file is an uncommitted sidecar (save_metadata writes
+        # "<name>.meta.tmp"). Both contain ".btrfs" in their name, so without this
+        # they would be parsed as phantom complete backups.
+        if item.name.endswith((".part", ".tmp")):
             continue
 
         # Check if it's a btrfs stream file

--- a/tests/test_raw_atomic_write.py
+++ b/tests/test_raw_atomic_write.py
@@ -91,9 +91,10 @@ def test_commit_without_receive_is_noop(tmp_path):
 
 
 def test_ssh_commit_builds_sync_mv_sync_script_and_publishes():
-    """SSH commit runs exactly 'sync && mv -f <part> <final> && sync' remotely
-    (leading sync flushes bytes before rename; trailing sync makes the rename
-    durable). Mocked -- runs without any real SSH."""
+    """SSH commit's FIRST remote call publishes the stream with exactly
+    'sync && mv -f <part> <final> && sync' (leading sync flushes bytes before the
+    rename; trailing sync makes the rename durable); it then stats + writes the
+    sidecar remotely. Mocked -- runs without any real SSH."""
     ep = SSHRawEndpoint.__new__(SSHRawEndpoint)
     ep._pending_metadata = {
         "name": "snap",
@@ -101,17 +102,20 @@ def test_ssh_commit_builds_sync_mv_sync_script_and_publishes():
         "part_path": "/remote/snap.btrfs.part",
     }
     ep._exec_remote_command = MagicMock(
-        return_value=MagicMock(returncode=0, stderr=b"")
+        return_value=MagicMock(returncode=0, stderr=b"", stdout=b"1")
     )
     ep.commit_receive()
 
-    ep._exec_remote_command.assert_called_once()
-    argv = ep._exec_remote_command.call_args[0][0]
-    assert argv[0] == "sh"
-    assert argv[1] == "-c"
-    assert argv[2] == (
+    calls = ep._exec_remote_command.call_args_list
+    first_argv = calls[0][0][0]
+    assert first_argv[0] == "sh" and first_argv[1] == "-c"
+    assert first_argv[2] == (
         "sync && mv -f /remote/snap.btrfs.part /remote/snap.btrfs && sync"
     )
+    # The sidecar is published remotely and atomically (temp -> mv -> chmod 600).
+    sh_scripts = " ".join(c[0][0][2] for c in calls if c[0][0][0] == "sh")
+    assert "/remote/snap.btrfs.meta" in sh_scripts
+    assert "chmod 600" in sh_scripts
 
 
 def test_ssh_commit_raises_on_remote_failure():
@@ -143,14 +147,14 @@ def test_ssh_commit_wraps_in_sudo_when_configured():
         "part_path": "/backup/snap.btrfs.part",
     }
     with patch("btrfs_backup_ng.endpoint.raw.subprocess.run") as mrun:
-        mrun.return_value = MagicMock(returncode=0, stderr=b"")
+        mrun.return_value = MagicMock(returncode=0, stderr=b"", stdout=b"1")
         ep.commit_receive()
 
-    mrun.assert_called_once()
-    remote = mrun.call_args[0][0][-1]  # last element of the ssh argv
+    # First remote call is the sudoed mv; the sidecar stat/write calls follow.
+    remote = mrun.call_args_list[0][0][0][-1]  # last element of the ssh argv
     assert remote.startswith("sudo ")
     assert "sync && mv -f" in remote
-    assert remote.rstrip().endswith("&& sync") or "&& sync" in remote
+    assert "&& sync" in remote
 
 
 def test_commit_never_overwrites_a_committed_final(tmp_path):

--- a/tests/test_raw_endpoint.py
+++ b/tests/test_raw_endpoint.py
@@ -1086,6 +1086,19 @@ class TestSSHRawEndpointMethods:
             snapshots = endpoint.list_snapshots()
         assert snapshots == []
 
+    def test_list_snapshots_second_pass_skips_meta_tmp(self):
+        """An uncommitted remote sidecar (<name>.meta.tmp, left by a crash mid
+        sidecar-write) contains '.btrfs' and matches find '*.btrfs*'; it must NOT
+        be listed as a phantom backup."""
+        endpoint = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout=""),  # find *.meta -> none
+                MagicMock(returncode=0, stdout="/backup/good.btrfs.gz.meta.tmp\n"),
+            ]
+            snapshots = endpoint.list_snapshots()
+        assert snapshots == []
+
     def test_list_snapshots_skips_unstatable_stream(self):
         """A stream that cannot be stat'd is skipped, not surfaced with a
         fabricated created=now that would sort as newest."""

--- a/tests/test_raw_endpoint_integration.py
+++ b/tests/test_raw_endpoint_integration.py
@@ -750,13 +750,19 @@ class TestMetadataIntegration:
         with open(snapshot.metadata_path) as f:
             data = json.load(f)
 
-        # Check structure
-        assert data["version"] == 1
+        # Check structure (v2)
+        assert data["version"] == 2
         assert data["name"] == "root.20240115T120000"
         assert data["uuid"] == "test-uuid"
         assert "pipeline" in data
         assert data["pipeline"]["compress"] == "gzip"
+        assert data["checksum"] == {"algorithm": "sha256", "value": None}
+        assert data["provenance"]["origin"] == "native-write"
         assert "btrfs_backup_ng_version" in data
+        # Atomic write leaves no temp file behind.
+        assert not snapshot.metadata_path.with_name(
+            snapshot.metadata_path.name + ".tmp"
+        ).exists()
 
     def test_discover_snapshots_from_metadata(self, tmp_path):
         """Test discovering snapshots from metadata files."""

--- a/tests/test_raw_metadata.py
+++ b/tests/test_raw_metadata.py
@@ -95,7 +95,7 @@ class TestRawSnapshot:
 
         data = snapshot.to_dict()
 
-        assert data["version"] == 1
+        assert data["version"] == 2
         assert data["name"] == "root.20240115T120000"
         assert data["uuid"] == "abc123"
         assert data["parent_uuid"] == "def456"
@@ -104,7 +104,14 @@ class TestRawSnapshot:
         assert data["pipeline"]["compress"] == "zstd"
         assert data["pipeline"]["encrypt"] == "gpg"
         assert data["pipeline"]["gpg_recipient"] == "backup@example.com"
-        assert "btrfs_backup_ng_version" in data
+        # v2 additions
+        assert data["pipeline"]["openssl_cipher"] is None
+        assert data["checksum"] == {"algorithm": "sha256", "value": None}
+        assert data["provenance"]["origin"] == "native-write"
+        assert "tool_version" in data["provenance"]
+        # created is ISO-8601 UTC
+        assert data["created"].endswith("+00:00")
+        assert "btrfs_backup_ng_version" in data  # kept for v1 readers
 
     def test_from_dict(self):
         """Test deserialization from dictionary."""

--- a/tests/test_raw_sidecar.py
+++ b/tests/test_raw_sidecar.py
@@ -1,0 +1,201 @@
+"""Auto-written authoritative .meta sidecar (0.8.5 PR3).
+
+Every raw backup writes a v2 sidecar in commit_receive (after the stream is
+durable). The v2 schema is additive over v1 (adds pipeline.openssl_cipher, a
+reserved checksum block, provenance); from_dict reads either version. Written to
+FAIL if the sidecar auto-write is removed or the schema regresses.
+"""
+
+import json
+from pathlib import Path
+
+from btrfs_backup_ng.endpoint.raw import RawEndpoint
+from btrfs_backup_ng.endpoint.raw_metadata import RawSnapshot, discover_raw_snapshots
+
+
+def _receive_and_commit(ep, tmp_path, name="snap1", parent_name=None):
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"payload-bytes-1234567890")
+    with open(src, "rb") as stdin:
+        proc = ep.receive(stdin, snapshot_name=name, parent_name=parent_name)
+        proc.communicate()
+    assert proc.returncode == 0
+    ep.commit_receive()
+
+
+def test_commit_writes_authoritative_v2_sidecar(tmp_path):
+    ep = RawEndpoint(config={"path": str(tmp_path), "compress": "gzip"})
+    _receive_and_commit(ep, tmp_path, name="snap1", parent_name="snap0")
+
+    stream = tmp_path / "snap1.btrfs.gz"
+    meta = tmp_path / "snap1.btrfs.gz.meta"
+    assert stream.exists()
+    assert meta.exists()
+
+    data = json.loads(meta.read_text())
+    assert data["version"] == 2
+    assert data["name"] == "snap1"
+    assert data["parent_name"] == "snap0"
+    assert data["size"] == stream.stat().st_size
+    assert data["pipeline"]["compress"] == "gzip"
+    assert data["pipeline"]["encrypt"] is None
+    assert data["pipeline"]["openssl_cipher"] is None  # gated: only for openssl_enc
+    assert data["checksum"] == {"algorithm": "sha256", "value": None}  # reserved
+    assert data["provenance"]["origin"] == "native-write"
+    assert data["created"].endswith("+00:00")  # ISO-8601 UTC
+
+
+def test_sidecar_written_atomically_at_0600(tmp_path):
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    _receive_and_commit(ep, tmp_path, name="snap1")
+    meta = tmp_path / "snap1.btrfs.meta"
+    assert meta.exists()
+    assert (meta.stat().st_mode & 0o777) == 0o600  # not world-readable
+    assert not (tmp_path / "snap1.btrfs.meta.tmp").exists()  # temp cleaned
+
+
+def test_committed_sidecar_is_discovered_with_authoritative_metadata(tmp_path):
+    """After commit, a fresh endpoint lists the snapshot from the SIDECAR (not
+    filename inference), so restore/prune get authoritative metadata."""
+    ep = RawEndpoint(config={"path": str(tmp_path), "compress": "gzip"})
+    _receive_and_commit(ep, tmp_path, name="snap1", parent_name="snap0")
+
+    lister = RawEndpoint(config={"path": str(tmp_path)})
+    snaps = lister.list_snapshots()
+    assert len(snaps) == 1
+    s = snaps[0]
+    assert s.name == "snap1"
+    assert s.compress == "gzip"
+    assert s.parent_name == "snap0"  # only the sidecar carries this; filenames don't
+    assert s.provenance_origin == "native-write"
+
+
+def test_sidecar_records_openssl_cipher(tmp_path):
+    """openssl_cipher must be recorded (restore reads it in a later PR instead of
+    guessing aes-256-cbc)."""
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    ep._pending_metadata = {
+        "name": "s",
+        "stream_path": tmp_path / "s.btrfs.enc",
+        "part_path": tmp_path / "s.btrfs.enc.part",
+        "parent_name": None,
+        "compress": None,
+        "encrypt": "openssl_enc",
+        "gpg_recipient": None,
+        "openssl_cipher": "aes-128-cbc",
+    }
+    snap = ep._sidecar_snapshot(tmp_path / "s.btrfs.enc", 42)
+    assert snap.encrypt == "openssl_enc"
+    assert snap.openssl_cipher == "aes-128-cbc"
+    assert snap.to_dict()["pipeline"]["openssl_cipher"] == "aes-128-cbc"
+
+
+def test_receive_gates_openssl_cipher_to_openssl_only(tmp_path):
+    """A plaintext (or gpg) target must not record an openssl cipher."""
+    ep = RawEndpoint(config={"path": str(tmp_path)})  # encrypt=None
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"x")
+    with open(src, "rb") as stdin:
+        proc = ep.receive(stdin, snapshot_name="s")
+        proc.communicate()
+    assert ep._pending_metadata["openssl_cipher"] is None
+
+
+def test_sidecar_write_failure_does_not_fail_the_backup(tmp_path):
+    """PR3 headline invariant: the stream is durable BEFORE the sidecar, so a
+    sidecar-write error must NOT flip an already-successful backup into a failure
+    (it degrades to filename inference). commit_receive must not raise, and the
+    committed stream must exist."""
+    from unittest.mock import patch
+
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"payload")
+    with open(src, "rb") as stdin:
+        proc = ep.receive(stdin, snapshot_name="snap1")
+        proc.communicate()
+    with patch.object(RawSnapshot, "save_metadata", side_effect=OSError("disk full")):
+        ep.commit_receive()  # must NOT raise
+    # The backup itself succeeded (stream published); only the sidecar is missing.
+    assert (tmp_path / "snap1.btrfs").exists()
+    assert not (tmp_path / "snap1.btrfs.meta").exists()
+
+
+def test_snapper_raw_meta_and_snapper_meta_coexist_without_double_count(tmp_path):
+    """A snapper-raw backup has BOTH a .meta (stream) and a .snapper-meta.json
+    (snapper context). Discovery must list exactly one snapshot -- the .json is
+    neither a .meta sidecar nor a .btrfs stream."""
+    (tmp_path / "root-5-20240115.btrfs").write_bytes(b"stream")
+    RawSnapshot(
+        name="root-5-20240115",
+        stream_path=tmp_path / "root-5-20240115.btrfs",
+    ).save_metadata()
+    (tmp_path / "root-5-20240115.snapper-meta.json").write_text('{"snapper": 1}')
+
+    snaps = discover_raw_snapshots(tmp_path)
+    assert [s.name for s in snaps] == ["root-5-20240115"]
+
+
+def test_from_dict_tolerates_explicit_null_blocks(tmp_path):
+    """A sidecar with explicit JSON null for pipeline/checksum/provenance must not
+    crash from_dict (nulls are coalesced), so one odd file can't abort a listing."""
+    data = {
+        "version": 2,
+        "name": "s",
+        "created": "2024-01-15T12:00:00+00:00",
+        "pipeline": None,
+        "checksum": None,
+        "provenance": None,
+    }
+    snap = RawSnapshot.from_dict(data, Path("/b/s.btrfs"))
+    assert snap.name == "s"
+    assert snap.compress is None
+    assert snap.checksum_value is None
+    assert snap.provenance_origin == "native-write"
+
+
+def test_leftover_meta_tmp_is_not_discovered(tmp_path):
+    """A crash mid-sidecar-write can leave <name>.meta.tmp; discovery must ignore
+    it (it contains '.btrfs' and would otherwise be listed as a phantom backup)."""
+    (tmp_path / "good.btrfs").write_bytes(b"stream")
+    (tmp_path / "good.btrfs.meta.tmp").write_bytes(b"{partial json")
+    names = [s.name for s in discover_raw_snapshots(tmp_path)]
+    assert names == ["good"]
+
+
+def test_v1_sidecar_loads_with_defaults(tmp_path):
+    """A v1 sidecar (no openssl_cipher/checksum/provenance) loads via from_dict
+    without error, defaulting the new fields."""
+    v1 = {
+        "version": 1,
+        "name": "root.20240115T120000",
+        "uuid": "u",
+        "parent_uuid": None,
+        "parent_name": None,
+        "created": "2024-01-15T12:00:00+00:00",
+        "size": 10,
+        "pipeline": {"compress": "zstd", "encrypt": "gpg", "gpg_recipient": "a@b"},
+        "btrfs_backup_ng_version": "0.8.3",
+    }
+    snap = RawSnapshot.from_dict(v1, Path("/b/root.20240115T120000.btrfs.zst.gpg"))
+    assert snap.compress == "zstd"
+    assert snap.encrypt == "gpg"
+    assert snap.openssl_cipher is None
+    assert snap.checksum_value is None
+    assert snap.provenance_origin == "native-write"
+
+
+def test_v2_round_trip_preserves_new_fields(tmp_path):
+    snap = RawSnapshot(
+        name="s",
+        stream_path=Path("/b/s.btrfs.enc"),
+        encrypt="openssl_enc",
+        openssl_cipher="aes-256-gcm",
+        checksum_value="deadbeef",
+        provenance_origin="backfill",
+    )
+    restored = RawSnapshot.from_dict(snap.to_dict(), snap.stream_path)
+    assert restored.encrypt == "openssl_enc"
+    assert restored.openssl_cipher == "aes-256-gcm"
+    assert restored.checksum_value == "deadbeef"
+    assert restored.provenance_origin == "backfill"


### PR DESCRIPTION
## Problem
Raw backups only ever had metadata *inferred from the filename*, and it was never written on the backup path (`finalize_receive` was dead code). So the OpenSSL cipher, the incremental parent, and provenance were lost — restore/prune had to guess (audit root R5, raw write-only).

## Fix
Every raw backup now auto-writes an **authoritative `.meta` sidecar** in `commit_receive` (the PR1 success hook — the transfer engine is **untouched**), after the stream is durable:
- **Atomic** (temp → fsync → `os.replace` → dir fsync) at mode **0600**; `SSHRawEndpoint` writes it remotely and atomically (`cat > tmp && sync && mv && chmod 600`).
- **Best-effort:** an already-durable backup is never failed by a sidecar error — it degrades to filename inference.

### Schema v1 → v2 (additive, backward-compatible)
- `pipeline.openssl_cipher` (so restore can use the exact cipher — the read side is a follow-up)
- a reserved `checksum{algorithm, value}` block (value filled later by a verify pass; not computed here, to avoid a second read over the zero-copy stream pipeline)
- `provenance{origin, tool_version}`; `created` is ISO-8601 UTC
- `from_dict` reads v1 **and** v2 and tolerates explicit-null blocks; discovery skips a single malformed sidecar instead of aborting the listing, and ignores `.meta.tmp` like it ignores `.part`.

### Portability
The remote size uses a portable stat (`stat -c` → `stat -f` → `wc -c`), so a non-Linux `raw+ssh` target (NAS, macOS) records a real size instead of `0`.

## Testing
- New `test_raw_sidecar.py` + updates: auto-write, v1/v2 round-trip + explicit-null tolerance, atomic 0600 + no leftover temp, `.meta.tmp` exclusion (local **and** SSH), the **best-effort invariant**, snapper-raw coexistence, openssl-cipher gating.
- **Mutation-verified:** removing the auto-write, the SSH `.tmp` skip, or the best-effort swallow each fails specific tests.
- ruff/mypy clean, **2128 passed**.
- **Hardware-validated:** local `raw://` backup auto-writes a correct v2 sidecar → discovered authoritatively → restore **byte-identical**; **and a real `btrfs send` over the LAN to a macOS/APFS Mac mini** wrote a correct v2 sidecar, size verified against real BSD `stat` — the portable-stat fix proven on real Darwin.

Third of the 0.8.5 "raw backups become first-class" series. Next: `raw+ssh` restore.
