### PR TITLE
feat: raw+ssh restore + preflight + portable remote stat

### DIFF
--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -598,9 +598,10 @@ class RawEndpoint(Endpoint):
                 )
             return proc
 
-        # Chain commands with shell
-        cmd_strs = [" ".join(cmd) for cmd in pipeline]
-        shell_cmd = f"cat {input_path} | " + " | ".join(cmd_strs)
+        # Chain commands with shell; quote every argv element and the input path
+        # so a gpg keyring / stream path containing spaces does not word-split.
+        cmd_strs = [" ".join(shlex.quote(a) for a in cmd) for cmd in pipeline]
+        shell_cmd = f"cat {shlex.quote(str(input_path))} | " + " | ".join(cmd_strs)
 
         logger.debug("Executing restore pipeline: %s", shell_cmd)
 
@@ -844,6 +845,29 @@ class SSHRawEndpoint(RawEndpoint):
             logger.error("Failed to create remote directory: %s", e.stderr.decode())
             raise
 
+        # Preflight: raw+ssh runs POSIX shell commands on the remote (cat/mv/chmod
+        # + a size tool). The mkdir above already proved connectivity + a POSIX-ish
+        # shell, so a missing tool here means the remote can't host raw+ssh (e.g. a
+        # bare Windows/cmd box) -- fail loud with actionable guidance rather than
+        # failing cryptically mid-transfer.
+        # `stat` (not just wc) is required: listing sidecar-less streams needs the
+        # mtime only stat can give, so the preflight must promise what enumeration
+        # actually depends on.
+        check = (
+            'for t in cat mv chmod stat; do command -v "$t" >/dev/null 2>&1 '
+            "|| exit 1; done; echo RAWSSHOK"
+        )
+        res = self._exec_remote_command(["sh", "-c", check], check=False)
+        out = res.stdout
+        if isinstance(out, (bytes, bytearray)):
+            out = out.decode(errors="replace")
+        if "RAWSSHOK" not in (out or ""):
+            raise RuntimeError(
+                f"Remote host {self.hostname} does not provide the POSIX tools "
+                "raw+ssh needs (sh, cat, mv, chmod, stat). For a non-POSIX or "
+                "SMB/NFS/cloud target, mount it locally and use a raw:// path."
+            )
+
         # Check local tools
         self._check_tools()
 
@@ -876,10 +900,13 @@ class SSHRawEndpoint(RawEndpoint):
             )
             return proc
 
-        # Local processing then SSH
+        # Local processing then SSH. Quote ssh_cmd elements (operator config may
+        # contain spaces) since this is composed into a local shell string.
         cmd_strs = [" ".join(cmd) for cmd in pipeline]
         local_pipeline = " | ".join(cmd_strs)
-        ssh_part = " ".join(ssh_cmd) + " " + shlex.quote(remote_cmd)
+        ssh_part = (
+            " ".join(shlex.quote(c) for c in ssh_cmd) + " " + shlex.quote(remote_cmd)
+        )
         shell_cmd = f"{local_pipeline} | {ssh_part}"
 
         logger.debug("Executing SSH pipeline: %s", shell_cmd)
@@ -983,6 +1010,57 @@ class SSHRawEndpoint(RawEndpoint):
                 "Failed to write remote sidecar %s: %s", meta, (stderr or "").strip()
             )
 
+    def send(
+        self,
+        snapshot: Any,
+        parent: Any | None = None,
+        clones: list[Any] | None = None,
+    ) -> subprocess.Popen[bytes]:
+        """Read a raw stream back from the REMOTE host for restore.
+
+        The base RawEndpoint.send() opens a local file; for raw+ssh the stream
+        lives on the remote, so we stream it down over ssh and decrypt/decompress
+        it LOCALLY -- ``ssh host 'cat <remote>' | <decrypt> | <decompress>``. The
+        gpg key / openssl passphrase stay on the restore host; secrets are never
+        sent to the (untrusted) remote.
+        """
+        if not isinstance(snapshot, RawSnapshot):
+            raise TypeError(f"Expected RawSnapshot, got {type(snapshot)}")
+        remote = str(snapshot.stream_path)
+        # Clear error if the stream is not on the remote (vs a cryptic pipe fail).
+        test = self._exec_remote_command(
+            ["sh", "-c", f"test -f {shlex.quote(remote)}"], check=False
+        )
+        if test.returncode != 0:
+            raise FileNotFoundError(
+                f"Remote stream not found: {self.hostname}:{remote}"
+            )
+
+        pipeline = self._build_restore_pipeline(snapshot)  # LOCAL decrypt/decompress
+        ssh_cmd = self._build_ssh_command()
+        remote_cat = f"cat {shlex.quote(remote)}"
+        if self.ssh_sudo:
+            remote_cat = f"sudo sh -c {shlex.quote(remote_cat)}"
+        # Quote every argv element: this string is run by a local bash. ssh_cmd
+        # carries operator config (ssh_opts, key path) that may contain spaces.
+        ssh_part = (
+            " ".join(shlex.quote(c) for c in ssh_cmd) + " " + shlex.quote(remote_cat)
+        )
+        if pipeline and pipeline != [["cat"]]:
+            local_stages = " | ".join(
+                " ".join(shlex.quote(a) for a in cmd) for cmd in pipeline
+            )
+            shell_cmd = f"{ssh_part} | {local_stages}"
+        else:
+            shell_cmd = ssh_part
+        logger.debug("Executing remote restore pipeline: %s", shell_cmd)
+        return _popen_pipeline_pipefail(
+            shell_cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
     def list_snapshots(self, flush_cache: bool = False) -> list[RawSnapshot]:
         """List raw snapshots on the remote host.
 
@@ -1084,9 +1162,11 @@ class SSHRawEndpoint(RawEndpoint):
                 continue
             if prefix and not name.startswith(prefix):
                 continue
-            stat_cmd = f"stat -c '%Y %s' {shlex.quote(stream_path_str)}"
+            # Portable mtime+size: GNU/busybox `stat -c`, else BSD/macOS `stat -f`.
+            q = shlex.quote(stream_path_str)
+            stat_cmd = f"stat -c '%Y %s' {q} 2>/dev/null || stat -f '%m %z' {q}"
             if self.ssh_sudo:
-                stat_cmd = f"sudo {stat_cmd}"
+                stat_cmd = f"sudo sh -c {shlex.quote(stat_cmd)}"
             try:
                 stat_result = subprocess.run(
                     ssh_cmd + [stat_cmd],

--- a/tests/test_raw_endpoint.py
+++ b/tests/test_raw_endpoint.py
@@ -878,12 +878,12 @@ class TestSSHRawEndpointMethods:
         )
 
         with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
+            mock_run.return_value = MagicMock(returncode=0, stdout=b"RAWSSHOK\n")
             with patch.object(endpoint, "_check_tools", return_value=[]):
                 endpoint._prepare()
 
-        mock_run.assert_called_once()
-        call_args = mock_run.call_args[0][0]
+        # First remote call is mkdir; a POSIX-tools preflight follows.
+        call_args = mock_run.call_args_list[0][0][0]
         assert "ssh" in call_args
         assert "backup@nas" in call_args
         assert "mkdir -p /backup/data" in call_args
@@ -899,11 +899,11 @@ class TestSSHRawEndpointMethods:
         )
 
         with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
+            mock_run.return_value = MagicMock(returncode=0, stdout=b"RAWSSHOK\n")
             with patch.object(endpoint, "_check_tools", return_value=[]):
                 endpoint._prepare()
 
-        call_args = mock_run.call_args[0][0]
+        call_args = mock_run.call_args_list[0][0][0]  # first call = mkdir
         assert "sudo mkdir" in call_args[-1]
 
     def test_prepare_failure(self):

--- a/tests/test_raw_ssh_restore.py
+++ b/tests/test_raw_ssh_restore.py
@@ -1,0 +1,157 @@
+"""raw+ssh restore + preflight (0.8.5 Stage 2).
+
+SSHRawEndpoint.send() reads the stream back from the REMOTE host over ssh and
+decrypts/decompresses it LOCALLY. prepare() preflights the remote for the POSIX
+tools raw+ssh needs. Written to FAIL if the remote-read or preflight regress.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from btrfs_backup_ng.endpoint.raw import SSHRawEndpoint
+from btrfs_backup_ng.endpoint.raw_metadata import RawSnapshot
+
+
+def _ep():
+    return SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+
+
+def test_send_reads_remote_stream_and_decompresses_locally():
+    """send() must stream `ssh host 'cat <remote>'` and pipe it through LOCAL
+    decompression -- not open a local file (the base RawEndpoint behavior)."""
+    ep = _ep()
+    ep._exec_remote_command = MagicMock(return_value=MagicMock(returncode=0))  # test -f
+    snap = RawSnapshot(
+        name="s", stream_path=Path("/backup/s.btrfs.gz"), compress="gzip"
+    )
+    with patch("btrfs_backup_ng.endpoint.raw._popen_pipeline_pipefail") as pp:
+        pp.return_value = MagicMock()
+        ep.send(snap)
+    shell_cmd = pp.call_args[0][0]
+    assert "ssh" in shell_cmd
+    assert "/backup/s.btrfs.gz" in shell_cmd  # reads the REMOTE path
+    assert "cat" in shell_cmd
+    assert "gzip -d" in shell_cmd  # decompression runs locally, after the ssh cat
+
+
+def test_send_plaintext_is_just_remote_cat():
+    ep = _ep()
+    ep._exec_remote_command = MagicMock(return_value=MagicMock(returncode=0))
+    snap = RawSnapshot(name="s", stream_path=Path("/backup/s.btrfs"))  # no comp/enc
+    with patch("btrfs_backup_ng.endpoint.raw._popen_pipeline_pipefail") as pp:
+        pp.return_value = MagicMock()
+        ep.send(snap)
+    shell_cmd = pp.call_args[0][0]
+    assert "ssh" in shell_cmd and "/backup/s.btrfs" in shell_cmd
+    # Structural invariant: plaintext is a single remote cat with NO local stage
+    # (catches any unexpected local staging, not just gpg/gzip).
+    assert "|" not in shell_cmd
+
+
+def test_send_missing_remote_stream_raises_clearly():
+    ep = _ep()
+    ep._exec_remote_command = MagicMock(
+        return_value=MagicMock(returncode=1)
+    )  # test -f fails
+    snap = RawSnapshot(name="nope", stream_path=Path("/backup/nope.btrfs"))
+    with pytest.raises(FileNotFoundError, match="Remote stream not found"):
+        ep.send(snap)
+
+
+def test_prepare_preflight_fails_loud_when_remote_lacks_posix_tools():
+    """A remote missing the POSIX tools (no RAWSSHOK) must fail with actionable
+    guidance, not a cryptic mid-transfer error."""
+    ep = _ep()
+    with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout=b"")):
+        with patch.object(ep, "_check_tools", return_value=[]):
+            with pytest.raises(RuntimeError, match="does not provide the POSIX tools"):
+                ep._prepare()
+
+
+def test_prepare_preflight_passes_when_tools_present():
+    ep = _ep()
+    with patch(
+        "subprocess.run", return_value=MagicMock(returncode=0, stdout=b"RAWSSHOK\n")
+    ):
+        with patch.object(ep, "_check_tools", return_value=[]):
+            ep._prepare()  # must not raise
+
+
+def test_send_encrypted_decrypts_locally_after_ssh_cat():
+    """Security invariant: gpg decrypt runs LOCALLY, downstream of the ssh cat --
+    the key/passphrase are never shipped to the (untrusted) remote."""
+    ep = _ep()
+    ep._exec_remote_command = MagicMock(return_value=MagicMock(returncode=0))
+    snap = RawSnapshot(
+        name="s",
+        stream_path=Path("/backup/s.btrfs.gz.gpg"),
+        encrypt="gpg",
+        compress="gzip",
+    )
+    with patch("btrfs_backup_ng.endpoint.raw._popen_pipeline_pipefail") as pp:
+        pp.return_value = MagicMock()
+        ep.send(snap)
+    shell_cmd = pp.call_args[0][0]
+    # Order proves decrypt is a LOCAL downstream stage: ssh cat | gpg | gzip -d.
+    assert shell_cmd.index("ssh") < shell_cmd.index("gpg") < shell_cmd.index("gzip")
+    assert "--decrypt" in shell_cmd
+
+
+def test_send_ssh_sudo_wraps_remote_cat_in_sudo_sh_c():
+    """With ssh_sudo the WHOLE remote cat is wrapped in `sudo sh -c`, not a bare
+    `sudo cat` (which would mis-scope under a shell)."""
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas", "ssh_sudo": True})
+    ep._exec_remote_command = MagicMock(return_value=MagicMock(returncode=0))
+    snap = RawSnapshot(name="s", stream_path=Path("/backup/s.btrfs"))
+    with patch("btrfs_backup_ng.endpoint.raw._popen_pipeline_pipefail") as pp:
+        pp.return_value = MagicMock()
+        ep.send(snap)
+    shell_cmd = pp.call_args[0][0]
+    assert "sudo sh -c" in shell_cmd
+
+
+def test_list_second_pass_stat_is_portable_and_sudo_scoped():
+    """The sidecar-less list stat tries GNU then BSD, and under ssh_sudo the WHOLE
+    fallback runs inside one `sudo sh -c` (not just the first stat)."""
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas", "ssh_sudo": True})
+    with patch("subprocess.run") as mrun:
+        mrun.side_effect = [
+            MagicMock(returncode=0, stdout=""),  # find *.meta -> none
+            MagicMock(returncode=0, stdout="/backup/x.btrfs\n"),  # find stream
+            MagicMock(returncode=0, stdout="1700000000 4096\n"),  # stat
+        ]
+        ep.list_snapshots()
+    stat_str = " ".join(mrun.call_args_list[2][0][0])  # the stat call's argv
+    # Quote-insensitive (the sudo wrapping shlex-escapes the inner quotes):
+    assert "stat -c" in stat_str and "%Y %s" in stat_str  # GNU branch
+    assert "stat -f" in stat_str and "%m %z" in stat_str  # BSD/macOS fallback
+    assert "sudo sh -c" in stat_str  # whole fallback under one sudo
+
+
+def test_remote_sidecar_size_cmd_is_portable():
+    """The remote sidecar size uses GNU -> BSD -> wc, so a macOS/NAS target records
+    a real size (GNU `stat -c` is unsupported on BSD)."""
+    ep = SSHRawEndpoint.__new__(SSHRawEndpoint)
+    ep._pending_metadata = {
+        "name": "s",
+        "stream_path": "/backup/s.btrfs",
+        "part_path": "/backup/s.btrfs.part",
+        "parent_name": None,
+        "compress": None,
+        "encrypt": None,
+        "gpg_recipient": None,
+        "openssl_cipher": None,
+    }
+    seen = []
+    ep._exec_remote_command = MagicMock(
+        side_effect=lambda argv, **kw: (
+            seen.append(argv) or MagicMock(returncode=0, stdout=b"10")
+        )
+    )
+    ep._write_remote_sidecar(Path("/backup/s.btrfs"))
+    size_script = " ".join(seen[0])  # first remote call is the size command
+    assert "stat -c %s" in size_script
+    assert "stat -f %z" in size_script
+    assert "wc -c" in size_script


### PR DESCRIPTION
## Problem
`raw+ssh` backups were **not restorable** (audit root R5): `SSHRawEndpoint` inherited `RawEndpoint.send()`, which opens a **local** file — so restoring a stream that lives on the remote failed with `FileNotFoundError`. Backup-only is not a backup.

## Fix
- **`SSHRawEndpoint.send()` reads the stream back over ssh** and decrypts/decompresses **locally**: `ssh host 'cat <remote>' | <decrypt> | <decompress>`. The gpg key / openssl passphrase **never leave the restore host**. A `test -f` preflight yields a clear "not found"; `pipefail` propagates an ssh/cat or decrypt failure to the return code so a failed restore can't masquerade as success.
- **`_prepare()` preflight:** verifies the remote has the POSIX tools raw+ssh needs (`cat`/`mv`/`chmod`/`stat`) and **fails loud** — pointing users to `raw://` on a local mount for a non-POSIX / SMB / cloud target — instead of a cryptic mid-transfer error.
- **Portable list-fallback stat:** GNU `stat -c`, else BSD/macOS `stat -f`; under `ssh_sudo` the whole fallback runs inside one `sudo sh -c` (the old form left the fallback `stat` un-sudoed — a real bug on root-owned NAS dirs).
- **Quoting hardening:** ssh command elements and local pipeline stages (incl. a gpg-keyring path) are `shlex.quote`d, so a config value containing spaces no longer word-splits.

## Testing
- New `test_raw_ssh_restore.py`: remote-read pipeline shape, plaintext-single-cat, missing-stream `FileNotFoundError`, preflight fail/pass, **decrypt-runs-locally order**, **`ssh_sudo` wrapping**, **portable + sudo-scoped list stat**, portable sidecar size.
- **Mutation-verified:** dropping the BSD stat fallback, or reverting the `sudo sh -c` scoping, each now fails a test (both were untested before this review pass).
- ruff/mypy clean, **2137 passed**.
- **Real hardware:** on a macOS/APFS Mac mini over the LAN — plaintext + gzip remote-read round-trips byte-identical; and a full **cross-machine round-trip**: real `btrfs send` here → `raw+ssh://` Mac → **restore *from* the Mac** → `btrfs receive` here → **byte-identical**.

Completes the `raw+ssh` restore gap in the 0.8.5 "raw backups become first-class" series. Next: PR4 (restore reads the exact `openssl_cipher` from the sidecar).
