### PR TITLE
fix(raw): honor recorded openssl cipher on restore; harden cipher/passphrase handling

### DIFF
--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -1019,8 +1019,20 @@ def _do_rich_progress_transfer(
     """
     logger.debug("Using Rich progress bar for transfer")
 
-    # Start receive process (stderr is suppressed at the endpoint level)
-    receive_process = destination_endpoint.receive(subprocess.PIPE, snapshot_name)
+    # Start receive process (stderr is suppressed at the endpoint level). Building
+    # the receive pipeline can raise (e.g. a raw openssl target with no passphrase
+    # env now fails loud at build time); convert that to a SnapshotTransferError so
+    # this path reports a clean failure with the failed-transaction audit log,
+    # exactly like the non-rich transfer path.
+    try:
+        receive_process = destination_endpoint.receive(subprocess.PIPE, snapshot_name)
+    except Exception as e:
+        logger.error("Failed to start receive process: %s", e)
+        try:
+            send_process.kill()
+        except Exception:
+            pass
+        raise __util__.SnapshotTransferError(f"Receive process failed to start: {e}")
     if receive_process is None:
         logger.error("Failed to start receive process")
         if is_ssh_endpoint and not destination_endpoint.config.get("ssh_sudo", False):

--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -50,6 +51,91 @@ class PendingMetadata(TypedDict):
 # Environment variable for OpenSSL passphrase (compatible with btrbk)
 OPENSSL_PASSPHRASE_ENV = "BTRFS_BACKUP_PASSPHRASE"
 BTRBK_PASSPHRASE_ENV = "BTRBK_PASSPHRASE"
+
+# OpenSSL cipher names are alphanumerics and hyphens (aes-256-cbc, chacha20,
+# aes-128-ctr, ...). Restrict to that grammar so a cipher value -- which may come
+# from an on-disk .meta sidecar (semi-trusted) or from operator config -- can
+# never carry a shell metacharacter, space, or quote into a pipeline. Anchored
+# with \A ... \Z (not ^...$, which would match around a trailing newline) so a
+# newline cannot slip through the structural guard regardless of downstream
+# quoting.
+_CIPHER_RE = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9-]*\Z")
+
+# Substrings marking an AEAD mode. `openssl enc` cannot use AEAD ciphers (it errors
+# "AEAD ciphers not supported"), so accepting one only defers a cryptic failure to
+# mid-transfer. No non-AEAD cipher name contains these tokens.
+_AEAD_MARKERS = ("gcm", "ccm", "ocb", "poly1305")
+
+
+def _validate_cipher(cipher: str) -> str:
+    """Return ``cipher`` if it is a usable ``openssl enc`` cipher name, else raise
+    ValueError.
+
+    Structural check first (see ``_CIPHER_RE``: leading alphanumeric, then
+    ``[A-Za-z0-9-]``, no metacharacters/whitespace/newline). Then two SEMANTIC
+    rejections of values that are syntactically valid but unsafe or unusable:
+
+      * ``none`` -- openssl's NULL cipher performs NO encryption, so accepting it
+        would silently write a PLAINTEXT backup labelled as encrypted (the
+        CWE-311/312 class fixed in 0.8.4 / GHSA-vr25-6vrh-869j). Refused.
+      * AEAD modes (``*-gcm``/``*-ccm``/``*-ocb``/``*poly1305``) -- ``openssl enc``
+        cannot use them; refuse up front with a clear message instead of a cryptic
+        mid-transfer error.
+    """
+    if not isinstance(cipher, str) or not _CIPHER_RE.match(cipher):
+        raise ValueError(
+            f"Invalid openssl cipher name: {cipher!r}. Expected a name like "
+            "'aes-256-cbc' (letters, digits, hyphens only)."
+        )
+    lowered = cipher.lower()
+    if lowered == "none":
+        raise ValueError(
+            "Refusing openssl cipher 'none': it performs NO encryption and would "
+            "write a plaintext backup labelled as encrypted. Use a real cipher "
+            "such as aes-256-cbc, or set encrypt=none for an explicit plaintext "
+            "target."
+        )
+    if any(marker in lowered for marker in _AEAD_MARKERS):
+        raise ValueError(
+            f"openssl cipher {cipher!r} is an AEAD mode that 'openssl enc' cannot "
+            "use. Choose a non-AEAD cipher such as aes-256-cbc, aes-256-ctr, or "
+            "chacha20."
+        )
+    return cipher
+
+
+def _selected_passphrase_env() -> str | None:
+    """Return the NAME of the passphrase environment variable that is set (primary
+    ``BTRFS_BACKUP_PASSPHRASE`` preferred, then ``BTRBK_PASSPHRASE`` for btrbk
+    compatibility), or None if neither is set.
+
+    Single source of truth so the construction-time warning
+    (``_get_openssl_passphrase``) and the pipeline ``-pass`` argument
+    (``_openssl_pass_arg``) can never disagree about which variable is used."""
+    if os.environ.get(OPENSSL_PASSPHRASE_ENV):
+        return OPENSSL_PASSPHRASE_ENV
+    if os.environ.get(BTRBK_PASSPHRASE_ENV):
+        return BTRBK_PASSPHRASE_ENV
+    return None
+
+
+def _openssl_pass_arg() -> str:
+    """Return the openssl ``-pass`` argument (``env:<NAME>``) for whichever
+    passphrase env var is set.
+
+    openssl reads the passphrase from the named environment variable itself, so
+    the secret never appears on the command line. Raises ValueError if neither
+    variable is set -- the caller must not run openssl with an empty passphrase,
+    which silently produces an unreadable stream on encrypt and garbage on
+    decrypt."""
+    name = _selected_passphrase_env()
+    if name is None:
+        raise ValueError(
+            f"openssl_enc requires a passphrase in {OPENSSL_PASSPHRASE_ENV} or "
+            f"{BTRBK_PASSPHRASE_ENV}, but neither is set."
+        )
+    return f"env:{name}"
+
 
 # Suffix for the in-progress stream file. A raw receive writes here and the
 # transfer engine renames it to the final name only after the pipeline is
@@ -127,7 +213,13 @@ class RawEndpoint(Endpoint):
             self.encrypt = None
         self.gpg_recipient = config.get("gpg_recipient")
         self.gpg_keyring = config.get("gpg_keyring")
-        self.openssl_cipher = config.get("openssl_cipher", "aes-256-cbc")
+        # Validated at construction so a bad cipher fails fast rather than
+        # surfacing as a cryptic openssl error mid-transfer. An explicit None or
+        # "" (the CLI threads openssl_cipher=None for gpg/plaintext targets) means
+        # "unset" -> the aes-256-cbc default, exactly as an absent key would.
+        self.openssl_cipher = _validate_cipher(
+            config.get("openssl_cipher") or "aes-256-cbc"
+        )
 
         # Validate encryption config
         if self.encrypt == "gpg" and not self.gpg_recipient:
@@ -176,14 +268,14 @@ class RawEndpoint(Endpoint):
         """Get OpenSSL passphrase from environment.
 
         Checks BTRFS_BACKUP_PASSPHRASE first, then BTRBK_PASSPHRASE for
-        btrbk compatibility.
+        btrbk compatibility. Shares ``_selected_passphrase_env`` with the pipeline
+        ``-pass`` argument so the two never disagree about which variable is used.
 
         Returns:
             Passphrase string or None if not set
         """
-        return os.environ.get(OPENSSL_PASSPHRASE_ENV) or os.environ.get(
-            BTRBK_PASSPHRASE_ENV
-        )
+        name = _selected_passphrase_env()
+        return os.environ.get(name) if name else None
 
     def __repr__(self) -> str:
         parts = [f"raw://{self.config['path']}"]
@@ -325,7 +417,7 @@ class RawEndpoint(Endpoint):
                 "-salt",
                 "-pbkdf2",
                 "-pass",
-                "env:BTRFS_BACKUP_PASSPHRASE",
+                _openssl_pass_arg(),
             ]
             pipeline.append(openssl_cmd)
 
@@ -366,9 +458,11 @@ class RawEndpoint(Endpoint):
             return proc
 
         # For multiple commands, chain them together
-        # We use shell to handle the pipeline and file output
+        # We use shell to handle the pipeline and file output. Quote every argv
+        # element (a gpg recipient/keyring or cipher may contain spaces or shell
+        # metacharacters) so nothing word-splits or injects into the shell string.
         output_path = self._pending_metadata["part_path"]
-        cmd_strs = [" ".join(cmd) for cmd in pipeline]
+        cmd_strs = [" ".join(shlex.quote(a) for a in cmd) for cmd in pipeline]
         shell_cmd = " | ".join(cmd_strs) + f" > {shlex.quote(str(output_path))}"
 
         logger.debug("Executing pipeline: %s", shell_cmd)
@@ -551,15 +645,27 @@ class RawEndpoint(Endpoint):
                 gpg_cmd.extend(["--keyring", self.gpg_keyring])
             pipeline.append(gpg_cmd)
         elif snapshot.encrypt == "openssl_enc":
-            # OpenSSL symmetric decryption
+            # Restore with the cipher RECORDED in the sidecar so a backup made
+            # with a non-default cipher decrypts correctly. Fall back to this
+            # endpoint's configured cipher only for legacy backups that recorded
+            # none (every pre-sidecar backup used the aes-256-cbc default), and
+            # log it so the assumption is never silent. Validate whichever we use:
+            # the sidecar is on-disk and only semi-trusted.
+            cipher = _validate_cipher(snapshot.openssl_cipher or self.openssl_cipher)
+            if not snapshot.openssl_cipher:
+                logger.info(
+                    "No cipher recorded for %s; restoring with endpoint cipher %s",
+                    snapshot.name,
+                    cipher,
+                )
             openssl_cmd = [
                 "openssl",
                 "enc",
                 "-d",
-                f"-{self.openssl_cipher}",
+                f"-{cipher}",
                 "-pbkdf2",
                 "-pass",
-                "env:BTRFS_BACKUP_PASSPHRASE",
+                _openssl_pass_arg(),
             ]
             pipeline.append(openssl_cmd)
 
@@ -832,7 +938,7 @@ class SSHRawEndpoint(RawEndpoint):
         path = self.config["path"]
         ssh_cmd = self._build_ssh_command()
 
-        mkdir_cmd = f"mkdir -p {path}"
+        mkdir_cmd = f"mkdir -p {shlex.quote(str(path))}"
         if self.ssh_sudo:
             mkdir_cmd = f"sudo {mkdir_cmd}"
 
@@ -900,9 +1006,10 @@ class SSHRawEndpoint(RawEndpoint):
             )
             return proc
 
-        # Local processing then SSH. Quote ssh_cmd elements (operator config may
-        # contain spaces) since this is composed into a local shell string.
-        cmd_strs = [" ".join(cmd) for cmd in pipeline]
+        # Local processing then SSH. Quote every argv element (a gpg
+        # recipient/keyring or cipher may contain spaces or shell metacharacters)
+        # and ssh_cmd elements, since this is composed into a local shell string.
+        cmd_strs = [" ".join(shlex.quote(a) for a in cmd) for cmd in pipeline]
         local_pipeline = " | ".join(cmd_strs)
         ssh_part = (
             " ".join(shlex.quote(c) for c in ssh_cmd) + " " + shlex.quote(remote_cmd)
@@ -1080,7 +1187,7 @@ class SSHRawEndpoint(RawEndpoint):
         ssh_cmd = self._build_ssh_command()
 
         # List .meta files
-        find_cmd = f"find {path} -name '*.meta' -type f 2>/dev/null"
+        find_cmd = f"find {shlex.quote(str(path))} -name '*.meta' -type f 2>/dev/null"
         if self.ssh_sudo:
             find_cmd = f"sudo {find_cmd}"
 
@@ -1102,7 +1209,7 @@ class SSHRawEndpoint(RawEndpoint):
             if not meta_path:
                 continue
             try:
-                cat_cmd = f"cat {meta_path}"
+                cat_cmd = f"cat {shlex.quote(meta_path)}"
                 if self.ssh_sudo:
                     cat_cmd = f"sudo {cat_cmd}"
                 result = subprocess.run(
@@ -1210,7 +1317,10 @@ class SSHRawEndpoint(RawEndpoint):
         for snapshot in snapshots:
             try:
                 # Build rm command for stream and metadata
-                rm_cmd = f"rm -f {snapshot.stream_path} {snapshot.metadata_path}"
+                rm_cmd = (
+                    f"rm -f {shlex.quote(str(snapshot.stream_path))} "
+                    f"{shlex.quote(str(snapshot.metadata_path))}"
+                )
                 if self.ssh_sudo:
                     rm_cmd = f"sudo {rm_cmd}"
 

--- a/tests/test_r6_raw_encryption.py
+++ b/tests/test_r6_raw_encryption.py
@@ -380,7 +380,11 @@ class TestSSHRawEndpointEncryption:
         assert gpg, "raw+ssh gpg config must build a gpg encryption stage"
         assert "--encrypt" in gpg[0] and "KEYID" in gpg[0]
 
-    def test_ssh_raw_pipeline_includes_openssl_stage(self):
+    def test_ssh_raw_pipeline_includes_openssl_stage(self, monkeypatch):
+        # openssl_enc now hard-fails if no passphrase is available (an encrypt
+        # pipeline that could not decrypt is never built); set one so this
+        # structural check exercises a realistic encrypting configuration.
+        monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "test-pass")
         pipeline = self._ssh_raw(encrypt="openssl_enc")
         enc = [s for s in pipeline if s and s[0] == "openssl"]
         assert enc, "raw+ssh openssl config must build an openssl encryption stage"

--- a/tests/test_raw_openssl_cipher.py
+++ b/tests/test_raw_openssl_cipher.py
@@ -1,0 +1,327 @@
+"""OpenSSL cipher/passphrase restore+send contract (0.8.5 PR4).
+
+The raw endpoint records the openssl cipher used for a backup in its ``.meta``
+sidecar (PR3). These tests pin the contract that PR4 establishes around that
+value:
+
+  * restore decrypts with the cipher RECORDED in the sidecar, not this
+    endpoint's configured default (else a non-default-cipher backup decrypts to
+    garbage);
+  * ``BTRBK_PASSPHRASE`` is actually usable end to end (it was advertised in
+    __init__ but the pipelines hardcoded ``env:BTRFS_BACKUP_PASSPHRASE``, so a
+    btrbk migrant silently produced an unreadable backup);
+  * an unknown/tampered cipher is rejected up front rather than reaching a shell;
+  * restore without any passphrase fails loud instead of running openssl empty;
+  * a legacy backup that recorded no cipher still restores (endpoint default);
+  * the send-side pipelines quote every argv element (no shell injection via a
+    gpg recipient/keyring or cipher), matching the already-quoted restore side.
+
+Each test is written to FAIL if its guard is reverted (mutation-verified).
+"""
+
+import shutil
+import subprocess
+
+import pytest
+
+from btrfs_backup_ng.endpoint import raw as raw_mod
+from btrfs_backup_ng.endpoint.raw import RawEndpoint, SSHRawEndpoint
+from btrfs_backup_ng.endpoint.raw_metadata import RawSnapshot
+
+requires_openssl = pytest.mark.skipif(
+    shutil.which("openssl") is None, reason="openssl not installed"
+)
+
+
+def _write_encrypted_backup(tmp_path, cipher, payload, name="snap"):
+    """Encrypt ``payload`` into a committed raw backup under ``tmp_path`` using
+    ``cipher``, returning nothing (the sidecar records the cipher)."""
+    ep = RawEndpoint(
+        config={
+            "path": str(tmp_path),
+            "encrypt": "openssl_enc",
+            "openssl_cipher": cipher,
+        }
+    )
+    src = tmp_path / "src.bin"
+    src.write_bytes(payload)
+    with open(src, "rb") as stdin:
+        proc = ep.receive(stdin, snapshot_name=name)
+        proc.communicate()
+    assert proc.returncode == 0, "encrypt receive failed"
+    ep.commit_receive()
+    src.unlink()
+
+
+# --------------------------------------------------------------------------- #
+# (1) restore uses the RECORDED cipher, not the endpoint default
+# --------------------------------------------------------------------------- #
+@requires_openssl
+def test_restore_uses_recorded_cipher_not_endpoint_default(tmp_path, monkeypatch):
+    """A backup encrypted with a non-default cipher must decrypt correctly on an
+    endpoint left at the aes-256-cbc default. Reverting restore to
+    ``self.openssl_cipher`` makes the decrypt fail -> this test fails."""
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "correct horse battery staple")
+    payload = b"REAL-SNAPSHOT-BYTES-" * 200
+    _write_encrypted_backup(tmp_path, "aes-128-cbc", payload)
+
+    # A restore endpoint configured with the DEFAULT cipher (aes-256-cbc).
+    restore_ep = RawEndpoint(config={"path": str(tmp_path)})
+    snaps = restore_ep.list_snapshots()
+    assert len(snaps) == 1
+    # The sidecar carries the real cipher, so restore has the information it needs.
+    assert snaps[0].openssl_cipher == "aes-128-cbc"
+
+    proc = restore_ep.send(snaps[0])
+    out, err = proc.communicate()
+    assert proc.returncode == 0, err.decode(errors="replace")
+    assert out == payload
+
+
+# --------------------------------------------------------------------------- #
+# (2) BTRBK_PASSPHRASE is usable end to end
+# --------------------------------------------------------------------------- #
+@requires_openssl
+def test_btrbk_passphrase_only_round_trips(tmp_path, monkeypatch):
+    """With ONLY BTRBK_PASSPHRASE set, encrypt+decrypt must round-trip. Reverting
+    the pipelines to hardcoded ``env:BTRFS_BACKUP_PASSPHRASE`` makes openssl read
+    an unset variable -> the encrypt receive fails -> this test fails."""
+    monkeypatch.delenv("BTRFS_BACKUP_PASSPHRASE", raising=False)
+    monkeypatch.setenv("BTRBK_PASSPHRASE", "btrbk-migrant-secret")
+    payload = b"MIGRANT-STREAM-" * 128
+    _write_encrypted_backup(tmp_path, "aes-256-cbc", payload)
+
+    restore_ep = RawEndpoint(config={"path": str(tmp_path)})
+    (snap,) = restore_ep.list_snapshots()
+    proc = restore_ep.send(snap)
+    out, err = proc.communicate()
+    assert proc.returncode == 0, err.decode(errors="replace")
+    assert out == payload
+
+
+# --------------------------------------------------------------------------- #
+# (3a) an invalid configured cipher is rejected at construction
+# --------------------------------------------------------------------------- #
+def test_invalid_cipher_rejected_at_construction(tmp_path):
+    """A cipher carrying shell metacharacters must be rejected when the endpoint
+    is built. Removing the __init__ _validate_cipher call -> no raise -> fails."""
+    with pytest.raises(ValueError, match="Invalid openssl cipher"):
+        RawEndpoint(
+            config={"path": str(tmp_path), "openssl_cipher": "aes-256-cbc; touch pwned"}
+        )
+
+
+@pytest.mark.parametrize("cipher", [None, ""])
+def test_explicit_unset_cipher_defaults_and_is_valid(tmp_path, cipher):
+    """An explicit ``openssl_cipher=None`` or ``""`` (the CLI threads None for
+    gpg/plaintext targets) means "unset" and must default to aes-256-cbc, NOT be
+    rejected by construction validation. Regression guard: validating the raw
+    ``.get()`` result instead of coalescing empties rejects every gpg/plaintext
+    raw target -> this test fails."""
+    ep = RawEndpoint(config={"path": str(tmp_path), "openssl_cipher": cipher})
+    assert ep.openssl_cipher == "aes-256-cbc"
+
+
+# --------------------------------------------------------------------------- #
+# (3c) the NULL cipher "none" must be refused -- it writes plaintext
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("cipher", ["none", "NONE", "None"])
+def test_null_cipher_none_is_refused(tmp_path, cipher):
+    """``openssl enc -none`` performs NO encryption, so accepting openssl_cipher=
+    'none' would write a PLAINTEXT backup labelled as encrypted (the CWE-311/312
+    class fixed in 0.8.4). Dropping the semantic 'none' rejection -> the value is
+    accepted -> this test fails. Rejected both directly and at construction of an
+    encrypting endpoint."""
+    with pytest.raises(ValueError, match="performs NO encryption"):
+        raw_mod._validate_cipher(cipher)
+    with pytest.raises(ValueError, match="performs NO encryption"):
+        RawEndpoint(
+            config={
+                "path": str(tmp_path),
+                "encrypt": "openssl_enc",
+                "openssl_cipher": cipher,
+            }
+        )
+
+
+# --------------------------------------------------------------------------- #
+# (3d) AEAD ciphers are refused -- `openssl enc` cannot use them
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "cipher", ["aes-256-gcm", "aes-128-ccm", "aes-256-ocb", "chacha20-poly1305"]
+)
+def test_aead_cipher_is_refused(cipher):
+    """`openssl enc` errors 'AEAD ciphers not supported', so an AEAD cipher must be
+    rejected up front rather than failing cryptically mid-transfer. Removing the
+    AEAD rejection -> accepted -> this test fails."""
+    with pytest.raises(ValueError, match="AEAD"):
+        raw_mod._validate_cipher(cipher)
+
+
+# --------------------------------------------------------------------------- #
+# (3e) a trailing newline must not slip through the structural guard
+# --------------------------------------------------------------------------- #
+def test_trailing_newline_cipher_is_rejected():
+    """Python's ``$`` matches before a trailing newline, so ``^...$`` would accept
+    'aes-256-cbc\\n' -- a shell metacharacter defeating the guard if any downstream
+    quote is ever dropped. The ``\\A...\\Z`` anchors reject it. Reverting to
+    ``^...$`` -> accepted -> this test fails."""
+    with pytest.raises(ValueError, match="Invalid openssl cipher"):
+        raw_mod._validate_cipher("aes-256-cbc\n")
+
+
+# --------------------------------------------------------------------------- #
+# (positive) a legitimate non-AEAD stream cipher still round-trips
+# --------------------------------------------------------------------------- #
+@requires_openssl
+def test_chacha20_round_trips(tmp_path, monkeypatch):
+    """chacha20 is a legitimate non-AEAD openssl cipher; the allowlist must not be
+    over-tightened into rejecting it. Encrypt with chacha20, restore, and get the
+    bytes back unchanged."""
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "chacha-secret")
+    payload = b"CHACHA-STREAM-" * 300
+    _write_encrypted_backup(tmp_path, "chacha20", payload)
+
+    restore_ep = RawEndpoint(config={"path": str(tmp_path)})
+    (snap,) = restore_ep.list_snapshots()
+    assert snap.openssl_cipher == "chacha20"
+    proc = restore_ep.send(snap)
+    out, err = proc.communicate()
+    assert proc.returncode == 0, err.decode(errors="replace")
+    assert out == payload
+
+
+# --------------------------------------------------------------------------- #
+# (3b) a tampered sidecar cipher is rejected before reaching a shell
+# --------------------------------------------------------------------------- #
+def test_malicious_sidecar_cipher_rejected_at_restore(tmp_path, monkeypatch):
+    """A cipher read from a hostile/corrupt sidecar must be rejected when the
+    restore pipeline is built. Removing the restore-side _validate_cipher ->
+    no raise -> this test fails."""
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "x")
+    restore_ep = RawEndpoint(config={"path": str(tmp_path)})
+    snap = RawSnapshot(
+        name="evil",
+        stream_path=tmp_path / "evil.btrfs",
+        encrypt="openssl_enc",
+        openssl_cipher="aes-256-cbc; touch pwned",
+    )
+    with pytest.raises(ValueError, match="Invalid openssl cipher"):
+        restore_ep._build_restore_pipeline(snap)
+
+
+# --------------------------------------------------------------------------- #
+# (2/5) restore without any passphrase fails loud
+# --------------------------------------------------------------------------- #
+def test_restore_without_passphrase_fails_loud(tmp_path, monkeypatch):
+    """Building an openssl restore pipeline with no passphrase env set must
+    raise, not silently run openssl with an empty password. Reverting to the
+    hardcoded ``env:BTRFS_BACKUP_PASSPHRASE`` arg removes the raise -> fails."""
+    monkeypatch.delenv("BTRFS_BACKUP_PASSPHRASE", raising=False)
+    monkeypatch.delenv("BTRBK_PASSPHRASE", raising=False)
+    restore_ep = RawEndpoint(config={"path": str(tmp_path)})
+    snap = RawSnapshot(
+        name="s",
+        stream_path=tmp_path / "s.btrfs",
+        encrypt="openssl_enc",
+        openssl_cipher="aes-256-cbc",
+    )
+    with pytest.raises(ValueError, match="requires a passphrase"):
+        restore_ep._build_restore_pipeline(snap)
+
+
+# --------------------------------------------------------------------------- #
+# (legacy) a backup that recorded no cipher still restores (endpoint default)
+# --------------------------------------------------------------------------- #
+def test_legacy_snapshot_without_recorded_cipher_uses_endpoint_default(
+    tmp_path, monkeypatch
+):
+    """A pre-sidecar backup records no cipher; restore must fall back to the
+    endpoint default (aes-256-cbc, what every such backup used) rather than
+    hard-failing. If the fallback is dropped, _validate_cipher(None) raises ->
+    this test fails."""
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "x")
+    restore_ep = RawEndpoint(config={"path": str(tmp_path)})
+    snap = RawSnapshot(
+        name="legacy",
+        stream_path=tmp_path / "legacy.btrfs",
+        encrypt="openssl_enc",
+        openssl_cipher=None,
+    )
+    pipeline = restore_ep._build_restore_pipeline(snap)
+    openssl_cmd = next(c for c in pipeline if c and c[0] == "openssl")
+    assert "-aes-256-cbc" in openssl_cmd
+
+
+# --------------------------------------------------------------------------- #
+# (4) send-side pipelines quote every argv element (no injection)
+# --------------------------------------------------------------------------- #
+def test_send_pipeline_quotes_argv_local(tmp_path, monkeypatch):
+    """The local multi-stage send pipeline must quote each argv element so a gpg
+    recipient with shell metacharacters is passed as ONE argument. Reverting the
+    quote in _execute_pipeline lets the shell split/execute it -> fails."""
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    ep._pending_metadata["part_path"] = tmp_path / "out.part"
+    pipeline = [["gzip"], ["gpg", "--recipient", "evil; touch pwned"]]
+
+    captured = {}
+
+    def fake_popen(shell_cmd, **kw):
+        captured["cmd"] = shell_cmd
+        from unittest.mock import MagicMock
+
+        return MagicMock()
+
+    monkeypatch.setattr(raw_mod, "_popen_pipeline_pipefail", fake_popen)
+    ep._execute_pipeline(pipeline, subprocess.DEVNULL)
+    # The metacharacter-laden recipient survives as a single token only if quoted.
+    import shlex
+
+    assert "evil; touch pwned" in shlex.split(captured["cmd"])
+
+
+def test_send_pipeline_quotes_argv_ssh(monkeypatch):
+    """Same guarantee for the raw+ssh send pipeline (SSHRawEndpoint override).
+    Reverting its quote -> the recipient word-splits in the local shell -> fails."""
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+    ep._pending_metadata["part_path"] = "/backup/out.part"
+    pipeline = [["gzip"], ["gpg", "--recipient", "evil; touch pwned"]]
+
+    captured = {}
+
+    def fake_popen(shell_cmd, **kw):
+        captured["cmd"] = shell_cmd
+        from unittest.mock import MagicMock
+
+        return MagicMock()
+
+    monkeypatch.setattr(raw_mod, "_popen_pipeline_pipefail", fake_popen)
+    ep._execute_pipeline(pipeline, subprocess.DEVNULL)
+    import shlex
+
+    assert "evil; touch pwned" in shlex.split(captured["cmd"])
+
+
+# --------------------------------------------------------------------------- #
+# (regression) a build-time receive() error on the rich-progress path becomes a
+# clean SnapshotTransferError, not a bare ValueError that skips the audit log
+# --------------------------------------------------------------------------- #
+def test_rich_progress_receive_build_error_becomes_transfer_error():
+    """PR4 makes receive() fail loud at build time (e.g. openssl with no
+    passphrase). The rich-progress transfer path must convert that to a
+    SnapshotTransferError like the standard path. Dropping the try/except around
+    the rich-progress receive() -> the raw ValueError propagates -> this test
+    fails."""
+    from unittest.mock import MagicMock
+
+    from btrfs_backup_ng import __util__
+    from btrfs_backup_ng.core import operations
+
+    send_process = MagicMock()
+    dest = MagicMock()
+    dest.receive.side_effect = ValueError("openssl_enc requires a passphrase")
+
+    with pytest.raises(__util__.SnapshotTransferError):
+        operations._do_rich_progress_transfer(send_process, dest, False, "snap", None)
+    # The send process is torn down so it cannot linger after the failure.
+    send_process.kill.assert_called_once()


### PR DESCRIPTION
## 0.8.5 PR4 — openssl cipher/passphrase restore+send contract

This is where PR3's recorded `openssl_cipher` sidecar value gets consumed. It fixes a data-loss + security cluster on the raw openssl path.

### Fixes
- **Restore honors the recorded cipher.** `_build_restore_pipeline` used the endpoint's configured cipher (default `aes-256-cbc`) instead of the cipher recorded in the `.meta` sidecar — a backup made with any other cipher decrypted to garbage. Restore now reads the recorded cipher, falling back to the endpoint cipher only for legacy backups that recorded none (logged, never silent).
- **`BTRBK_PASSPHRASE` now actually works.** It was accepted at construction but both openssl pipelines hardcoded `env:BTRFS_BACKUP_PASSPHRASE`, so a btrbk migrant who set only `BTRBK_PASSPHRASE` silently produced an **unreadable** backup. Both pipelines now name whichever variable is set (single source of truth), and openssl never runs with an empty passphrase — it fails loud.
- **Cipher validation** (the value can come from a semi-trusted sidecar or operator config):
  - structural allowlist anchored `\A..\Z` — no shell metacharacters, no trailing newline;
  - **the NULL cipher `none` is refused** — `openssl enc -none` performs *no* encryption and would write a plaintext backup labelled encrypted (CWE-311/312, the same class as GHSA-vr25-6vrh-869j / 0.8.4);
  - AEAD ciphers (which `openssl enc` cannot use) are refused up front instead of failing cryptically mid-transfer.
- **Send-side pipelines shlex-quote every argv element**, matching the already-quoted restore side; the raw+ssh `find`/`cat`/`mkdir`/`rm` commands are quoted too, closing the shell-injection class across the file.
- **Rich-progress transfer path** converts a build-time `receive()` failure to a `SnapshotTransferError` (clean failure + audit log), like the standard path.

### Quality
- Adversarial 4-lens review (correctness / regression / completeness / security) — it surfaced the critical `none`-plaintext and the newline-anchor issues, both fixed and verified live.
- 20 mutation-verified test cases in `tests/test_raw_openssl_cipher.py`; every enforcement guard was reverted and confirmed to fail its test.
- Full suite `2157 passed, 1 skipped`; ruff / ruff-format@0.15.22 / mypy clean; real openssl round-trips (incl. `chacha20`).

Part of the 0.8.5 "raw backups become first-class" release. Follows #21 #22 #23 #24.
