### PR TITLE
feat(cli): add raw command family with raw list

### DIFF
--- a/completions/btrfs-backup-ng.bash
+++ b/completions/btrfs-backup-ng.bash
@@ -5,12 +5,13 @@ _btrfs_backup_ng() {
     local cur prev words cword split
     _init_completion -s || return
 
-    local commands="run snapshot transfer prune list status config install uninstall restore verify estimate doctor completions manpages transfers snapper"
+    local commands="run snapshot transfer prune list status config install uninstall restore verify estimate doctor completions manpages transfers snapper raw"
     local config_subcommands="validate init import detect"
     local completions_subcommands="install path"
     local manpages_subcommands="install path"
     local transfers_subcommands="list show resume pause cleanup operations"
     local snapper_subcommands="detect list backup status restore generate-config"
+    local raw_subcommands="list"
 
     # Global options
     local global_opts="-h --help -v --verbose -q --quiet --debug -V --version -c --config"
@@ -45,6 +46,7 @@ _btrfs_backup_ng() {
     local snapper_status_opts="--json"
     local snapper_restore_opts="--snapshot --dry-run --ssh-sudo --ssh-key"
     local snapper_generate_config_opts="-o --output"
+    local raw_list_opts="--json --ssh-sudo"
     local snapper_types="single pre post"
     local verify_levels="metadata stream full"
     local shell_types="bash zsh fish"
@@ -62,15 +64,26 @@ _btrfs_backup_ng() {
     local i
     for ((i=1; i < cword; i++)); do
         case "${words[i]}" in
-            run|snapshot|transfer|prune|list|status|config|install|uninstall|restore|verify|estimate|doctor|completions|manpages|transfers|snapper)
+            run|snapshot|transfer|prune|status|config|install|uninstall|restore|verify|estimate|doctor|completions|manpages|transfers|snapper|raw)
                 cmd="${words[i]}"
+                ;;
+            list)
+                # `list` is both a top-level command and a subcommand of
+                # transfers/raw: only treat it as the command when none is set yet,
+                # otherwise it is the subcommand (a plain command list first, then
+                # the combined-arm check, would let it overwrite $cmd to "list").
+                if [[ -z "$cmd" ]]; then
+                    cmd="list"
+                elif [[ "$cmd" == "transfers" || "$cmd" == "raw" ]]; then
+                    subcmd="list"
+                fi
                 ;;
             validate|init|import|detect)
                 if [[ "$cmd" == "config" ]]; then
                     subcmd="${words[i]}"
                 fi
                 ;;
-            list|show|resume|pause|cleanup|operations)
+            show|resume|pause|cleanup|operations)
                 if [[ "$cmd" == "transfers" ]]; then
                     subcmd="${words[i]}"
                 fi
@@ -345,6 +358,25 @@ _btrfs_backup_ng() {
                         ;;
                     generate-config)
                         COMPREPLY=($(compgen -W "$snapper_generate_config_opts" -- "$cur"))
+                        ;;
+                esac
+            fi
+            ;;
+        raw)
+            if [[ -z "$subcmd" ]]; then
+                if [[ "$cur" == -* ]]; then
+                    COMPREPLY=($(compgen -W "-h --help" -- "$cur"))
+                else
+                    COMPREPLY=($(compgen -W "$raw_subcommands" -- "$cur"))
+                fi
+            else
+                case "$subcmd" in
+                    list)
+                        if [[ "$cur" == -* ]]; then
+                            COMPREPLY=($(compgen -W "$raw_list_opts" -- "$cur"))
+                        else
+                            _filedir -d
+                        fi
                         ;;
                 esac
             fi

--- a/completions/btrfs-backup-ng.fish
+++ b/completions/btrfs-backup-ng.fish
@@ -10,7 +10,7 @@ function __fish_btrfs_backup_ng_no_subcommand
     set -e cmd[1]
     for c in $cmd
         switch $c
-            case run snapshot transfer prune list status config install uninstall restore verify estimate doctor completions manpages transfers snapper
+            case run snapshot transfer prune list status config install uninstall restore verify estimate doctor completions manpages transfers snapper raw
                 return 1
         end
     end
@@ -67,6 +67,7 @@ complete -c btrfs-backup-ng -n __fish_btrfs_backup_ng_no_subcommand -a completio
 complete -c btrfs-backup-ng -n __fish_btrfs_backup_ng_no_subcommand -a manpages -d 'Install man pages'
 complete -c btrfs-backup-ng -n __fish_btrfs_backup_ng_no_subcommand -a transfers -d 'Manage chunked and resumable transfers (experimental)'
 complete -c btrfs-backup-ng -n __fish_btrfs_backup_ng_no_subcommand -a snapper -d 'Manage snapper-managed snapshots'
+complete -c btrfs-backup-ng -n __fish_btrfs_backup_ng_no_subcommand -a raw -d 'Inspect and maintain raw-target backups'
 
 # Compression methods (including raw target compression algorithms)
 set -l compress_methods none zstd gzip lz4 pigz lzop xz bzip2 pbzip2 lzo
@@ -348,3 +349,25 @@ complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_snapper_using_subcommand 
 
 # snapper generate-config
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_snapper_using_subcommand generate-config' -s o -l output -d 'Output file' -r -F
+
+# raw command subcommands
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_using_command raw' -a list -d 'List the backups a raw target holds'
+
+# Helper for raw subcommand
+function __fish_btrfs_backup_ng_raw_using_subcommand
+    set -l cmd (commandline -opc)
+    set -e cmd[1]
+    if test (count $cmd) -gt 1
+        if test $cmd[1] = raw
+            if test $argv[1] = $cmd[2]
+                return 0
+            end
+        end
+    end
+    return 1
+end
+
+# raw list
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand list' -l json -d 'Output in JSON format'
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand list' -l ssh-sudo -d 'Use sudo for remote commands on a raw+ssh target'
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand list' -a '(__fish_complete_directories)' -d 'Raw target path'

--- a/completions/btrfs-backup-ng.zsh
+++ b/completions/btrfs-backup-ng.zsh
@@ -26,6 +26,7 @@ _btrfs-backup-ng() {
         'manpages:Install man pages'
         'transfers:Manage chunked and resumable transfers (experimental)'
         'snapper:Manage snapper-managed snapshots'
+        'raw:Inspect and maintain raw-target backups'
     )
 
     local -a global_opts
@@ -387,6 +388,31 @@ _btrfs-backup-ng() {
                                 generate-config)
                                     _arguments \
                                         '(-o --output)'{-o,--output}'[Output file]:file:_files'
+                                    ;;
+                            esac
+                            ;;
+                    esac
+                    ;;
+                raw)
+                    local -a raw_commands
+                    raw_commands=(
+                        'list:List the backups a raw target holds'
+                    )
+                    _arguments \
+                        '1: :->raw_cmd' \
+                        '*:: :->raw_args'
+
+                    case $state in
+                        raw_cmd)
+                            _describe -t commands 'raw command' raw_commands
+                            ;;
+                        raw_args)
+                            case $line[1] in
+                                list)
+                                    _arguments \
+                                        '--json[Output in JSON format]' \
+                                        '--ssh-sudo[Use sudo for remote commands on a raw+ssh target]' \
+                                        '1:raw target:_files -/'
                                     ;;
                             esac
                             ;;

--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -929,6 +929,49 @@ ssh_sudo = true
 
 ---
 
+### raw
+
+Inspect and maintain [raw-target](#raw-targets) backups directly. Raw targets hold btrfs send streams as files, each with an authoritative `.meta` sidecar.
+
+```bash
+btrfs-backup-ng raw SUBCOMMAND [OPTIONS]
+```
+
+#### raw list
+
+List the backups a raw target holds, read from each stream's `.meta` sidecar (falling back to filename inference for legacy streams written before sidecars existed).
+
+```bash
+btrfs-backup-ng raw list TARGET [OPTIONS]
+```
+
+**Arguments:**
+| Argument | Description |
+|----------|-------------|
+| `TARGET` | Raw target: `raw://PATH`, `raw+ssh://[USER@]HOST/PATH`, or a plain path (treated as `raw://`) |
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--json` | Output the authoritative sidecar documents as JSON for scripting |
+| `--ssh-sudo` | Use `sudo` for remote commands on a `raw+ssh://` target |
+
+**Example:**
+```bash
+btrfs-backup-ng raw list raw:///mnt/usb/backups
+btrfs-backup-ng raw list raw+ssh://backup@nas/backups --ssh-sudo
+```
+
+**Example Output:**
+```
+Raw target: raw:///mnt/usb/backups  (2 snapshots)
+  NAME                             CREATED               SIZE  ENC         COMPRESS CIPHER       ORIGIN
+  root.20260101T120000             2026-01-01T12:00:00Z  1.2 GiB  openssl_enc zstd     aes-256-cbc  native-write
+  home.20260101T120000             2026-01-01T12:00:00Z  340 MiB  -           -        -            native-write
+```
+
+---
+
 ## Filesystem Checks
 
 The `--fs-checks` option controls how btrfs-backup-ng validates source and destination paths:

--- a/man/man1/btrfs-backup-ng-raw.1
+++ b/man/man1/btrfs-backup-ng-raw.1
@@ -1,0 +1,74 @@
+.\" Man page for btrfs-backup-ng raw
+.TH BTRFS-BACKUP-NG-RAW 1 "July 2026" "btrfs-backup-ng" "User Commands"
+.SH NAME
+btrfs-backup-ng-raw \- inspect and maintain raw-target backups
+.SH SYNOPSIS
+.B btrfs-backup-ng raw list
+\fITARGET\fR [\fB\-\-json\fR] [\fB\-\-ssh-sudo\fR]
+.SH DESCRIPTION
+Operate directly on a raw backup target. Raw targets (\fBraw://\fR and
+\fBraw+ssh://\fR) store btrfs send streams as files for backing up to non-btrfs
+storage (NFS, SMB, cloud, another OS). Each stream is written with an
+authoritative \fB.meta\fR sidecar recording its pipeline (compression, encryption,
+cipher), size, provenance, and creation time.
+.PP
+These subcommands read and maintain such a target directly, independently of any
+configured backup job.
+.SH SUBCOMMANDS
+.SS list
+List the backups a raw target holds.
+.PP
+.RS
+.B btrfs-backup-ng raw list
+\fITARGET\fR [\fB\-\-json\fR] [\fB\-\-ssh-sudo\fR]
+.RE
+.PP
+Enumerates the target's backups from each stream's \fB.meta\fR sidecar, falling
+back to filename inference for legacy streams written before sidecars existed.
+The human-readable output lists each backup's name, creation time, size, and
+pipeline (encryption method, compression, openssl cipher, and metadata origin).
+.TP
+.I TARGET
+Raw target to inspect: \fBraw://\fIPATH\fR (local),
+\fBraw+ssh://\fR[\fIUSER\fR@]\fIHOST\fR/\fIPATH\fR (remote over SSH), or a plain
+path (treated as \fBraw://\fR).
+.TP
+.B \-\-json
+Output the authoritative sidecar documents as JSON for scripting.
+.TP
+.B \-\-ssh-sudo
+Use \fBsudo\fR for the remote commands on a \fBraw+ssh://\fR target.
+.SH EXIT STATUS
+.TP
+.B 0
+Success (including an empty or nonexistent target; a warning is printed for a
+missing local path).
+.TP
+.B 1
+The target could not be listed.
+.TP
+.B 2
+Invalid target (for example a non-raw URL scheme).
+.SH EXAMPLES
+.TP
+List a local raw target:
+.B btrfs-backup-ng raw list raw:///mnt/usb/backups
+.TP
+List a plain path (treated as raw://):
+.B btrfs-backup-ng raw list /mnt/usb/backups
+.TP
+List a remote raw+ssh target with sudo:
+.B btrfs-backup-ng raw list raw+ssh://backup@nas/backups --ssh-sudo
+.TP
+Machine-readable output:
+.B btrfs-backup-ng raw list raw:///mnt/usb/backups --json
+.SH SEE ALSO
+.BR btrfs-backup-ng (1),
+.BR btrfs-backup-ng-restore (1),
+.BR btrfs-send (8),
+.BR btrfs-receive (8)
+.SH NOTES
+A \fBraw+ssh://\fR target is a POSIX-shell-remote model: btrfs-backup-ng runs
+\fBsh\fR, \fBcat\fR, \fBmv\fR, and \fBstat\fR over SSH on the remote host. For a
+non-POSIX or SMB/NFS/cloud destination, mount it locally and use a \fBraw://\fR
+path instead.

--- a/src/btrfs_backup_ng/cli/dispatcher.py
+++ b/src/btrfs_backup_ng/cli/dispatcher.py
@@ -30,6 +30,7 @@ SUBCOMMANDS = frozenset(
         "manpages",
         "doctor",
         "snapper",
+        "raw",
     }
 )
 
@@ -347,6 +348,34 @@ def create_subcommand_parser() -> argparse.ArgumentParser:
         "--dry-run",
         action="store_true",
         help="Show what would be done without making changes",
+    )
+
+    # raw command with subcommands (inspect/maintain raw:// and raw+ssh:// targets)
+    raw_parser = subparsers.add_parser(
+        "raw",
+        help="Inspect and maintain raw-target backups",
+        description="Operate directly on a raw:// or raw+ssh:// backup target",
+    )
+    raw_subs = raw_parser.add_subparsers(dest="raw_action")
+    raw_list_parser = raw_subs.add_parser(
+        "list",
+        help="List the backups a raw target holds",
+        description="Enumerate a raw target's backups via their .meta sidecars",
+    )
+    raw_list_parser.add_argument(
+        "target",
+        metavar="TARGET",
+        help="Raw target: raw://PATH, raw+ssh://[USER@]HOST/PATH, or a plain path",
+    )
+    raw_list_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output in JSON format for scripting",
+    )
+    raw_list_parser.add_argument(
+        "--ssh-sudo",
+        action="store_true",
+        help="Use sudo for remote commands on a raw+ssh target",
     )
 
     # install command
@@ -1432,6 +1461,7 @@ def run_subcommand(args: argparse.Namespace) -> int:
         "manpages": cmd_manpages,
         "doctor": cmd_doctor,
         "snapper": cmd_snapper,
+        "raw": cmd_raw,
     }
 
     handler = handlers.get(args.command)
@@ -1563,6 +1593,13 @@ def cmd_snapper(args: argparse.Namespace) -> int:
     from .snapper_cmd import execute_snapper
 
     return execute_snapper(args)
+
+
+def cmd_raw(args: argparse.Namespace) -> int:
+    """Execute raw command."""
+    from .raw_cmd import execute_raw
+
+    return execute_raw(args)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/btrfs_backup_ng/cli/raw_cmd.py
+++ b/src/btrfs_backup_ng/cli/raw_cmd.py
@@ -1,0 +1,113 @@
+"""The ``raw`` command family: inspect and maintain raw-target backups.
+
+Raw targets (``raw://`` and ``raw+ssh://``) hold btrfs send streams as files, each
+with an authoritative ``.meta`` sidecar. These subcommands operate directly on such
+a target. The family starts with ``raw list``, which enumerates a target's backups
+via their sidecars (falling back to filename inference for legacy streams); later
+0.8.5 additions (verify, backfill-metadata, encrypt) build on the same endpoint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from btrfs_backup_ng import endpoint
+from btrfs_backup_ng.__logger__ import logger
+
+
+def execute_raw(args: argparse.Namespace) -> int:
+    """Dispatch a ``raw <action>`` subcommand."""
+    action = getattr(args, "raw_action", None)
+    if action == "list":
+        return _raw_list(args)
+    # No/unknown action: argparse allows a bare `raw`, so guide the user.
+    print("No raw action specified. Try: btrfs-backup-ng raw list <target>")
+    return 1
+
+
+def _coerce_raw_spec(target: str) -> str:
+    """Return a ``choose_endpoint`` spec for a raw target.
+
+    A bare path is treated as a local ``raw://`` target; ``raw://`` and
+    ``raw+ssh://`` pass through unchanged; any other scheme is an error (the raw
+    commands operate only on raw targets)."""
+    if target.startswith(("raw://", "raw+ssh://")):
+        return target
+    if "://" in target:
+        raise ValueError(
+            f"{target!r} is not a raw target. Use a raw:// or raw+ssh:// URL "
+            "(a plain path is treated as raw://)."
+        )
+    return "raw://" + target
+
+
+def _human_size(n: int) -> str:
+    """Format a byte count with a binary unit (B, KiB, MiB, ...)."""
+    size = float(n)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB", "PiB"):
+        if size < 1024:
+            return f"{size:.0f} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} EiB"
+
+
+def _raw_list(args: argparse.Namespace) -> int:
+    """List the backups a raw target holds (via their ``.meta`` sidecars)."""
+    try:
+        spec = _coerce_raw_spec(args.target)
+    except ValueError as e:
+        print(str(e))
+        return 2
+
+    common: dict = {}
+    if getattr(args, "ssh_sudo", False):
+        common["ssh_sudo"] = True
+
+    try:
+        ep = endpoint.choose_endpoint(spec, common_config=common)
+    except ValueError as e:
+        print(f"Cannot open raw target: {e}")
+        return 2
+
+    # A local target that does not exist is almost always a typo or an unmounted
+    # path; warn (on stderr, so --json stays clean) rather than let the resulting
+    # empty list look like "this target holds no backups".
+    if spec.startswith("raw://"):
+        local_path = Path(spec[len("raw://") :])
+        if not local_path.exists():
+            print(
+                f"warning: {local_path} does not exist or is not mounted",
+                file=sys.stderr,
+            )
+
+    try:
+        snapshots = ep.list_snapshots(flush_cache=True)
+    except Exception as e:  # pragma: no cover - defensive; endpoint errors vary
+        logger.debug("raw list failed", exc_info=True)
+        print(f"Failed to list {spec}: {e}")
+        return 1
+
+    if getattr(args, "json", False):
+        print(json.dumps([s.to_dict() for s in snapshots], indent=2))
+        return 0
+
+    plural = "" if len(snapshots) == 1 else "s"
+    print(f"Raw target: {spec}  ({len(snapshots)} snapshot{plural})")
+    if not snapshots:
+        return 0
+
+    print(
+        f"  {'NAME':<32} {'CREATED':<20} {'SIZE':>10}  "
+        f"{'ENC':<11} {'COMPRESS':<8} {'CIPHER':<12} ORIGIN"
+    )
+    for s in snapshots:
+        created = s.created.strftime("%Y-%m-%dT%H:%M:%SZ")
+        print(
+            f"  {s.name:<32} {created:<20} {_human_size(s.size):>10}  "
+            f"{(s.encrypt or '-'):<11} {(s.compress or '-'):<8} "
+            f"{(s.openssl_cipher or '-'):<12} {s.provenance_origin or '-'}"
+        )
+    return 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -84,6 +84,7 @@ class TestSubcommands:
             "config",
             "install",
             "uninstall",
+            "raw",
         }
         for cmd in expected:
             assert cmd in SUBCOMMANDS, f"{cmd} not in SUBCOMMANDS"

--- a/tests/test_raw_cmd.py
+++ b/tests/test_raw_cmd.py
@@ -1,0 +1,175 @@
+"""The `raw` command family (0.8.5 PR6a).
+
+`raw list` enumerates a raw target's backups via their .meta sidecars. These tests
+cover the target-spec coercion, the human + JSON output, and the error paths.
+"""
+
+import argparse
+import json
+
+import pytest
+
+from btrfs_backup_ng.cli import raw_cmd
+from btrfs_backup_ng.endpoint.raw import RawEndpoint
+
+
+def _build_backup(path, name, *, encrypt=None, compress=None, cipher="aes-256-cbc"):
+    """Write one committed raw backup of a few bytes under ``path``."""
+    cfg = {"path": str(path)}
+    if encrypt:
+        cfg["encrypt"] = encrypt
+        cfg["openssl_cipher"] = cipher
+    if compress:
+        cfg["compress"] = compress
+    ep = RawEndpoint(config=cfg)
+    src = path / f"{name}.src"
+    src.write_bytes(b"payload-" * 64)
+    with open(src, "rb") as stdin:
+        ep.receive(stdin, snapshot_name=name).communicate()
+    ep.commit_receive()
+    src.unlink()
+
+
+def _args(**kw):
+    ns = argparse.Namespace()
+    for k, v in kw.items():
+        setattr(ns, k, v)
+    return ns
+
+
+# --------------------------------------------------------------------------- #
+# spec coercion
+# --------------------------------------------------------------------------- #
+def test_coerce_bare_path_becomes_raw_scheme():
+    assert raw_cmd._coerce_raw_spec("/backups/x") == "raw:///backups/x"
+
+
+@pytest.mark.parametrize("spec", ["raw:///backups/x", "raw+ssh://host/backups/x"])
+def test_coerce_raw_schemes_pass_through(spec):
+    assert raw_cmd._coerce_raw_spec(spec) == spec
+
+
+def test_coerce_rejects_non_raw_scheme():
+    with pytest.raises(ValueError, match="not a raw target"):
+        raw_cmd._coerce_raw_spec("ssh://host/path")
+
+
+def test_human_size():
+    assert raw_cmd._human_size(0) == "0 B"
+    assert raw_cmd._human_size(512) == "512 B"
+    assert raw_cmd._human_size(1024) == "1.0 KiB"
+    assert raw_cmd._human_size(1024 * 1024) == "1.0 MiB"
+
+
+# --------------------------------------------------------------------------- #
+# execute_raw dispatch
+# --------------------------------------------------------------------------- #
+def test_execute_raw_no_action_returns_1(capsys):
+    rc = raw_cmd.execute_raw(_args(raw_action=None))
+    assert rc == 1
+    assert "raw list" in capsys.readouterr().out
+
+
+def test_execute_raw_dispatches_list(tmp_path, capsys):
+    rc = raw_cmd.execute_raw(_args(raw_action="list", target=str(tmp_path), json=False))
+    assert rc == 0
+    assert "Raw target:" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# raw list output
+# --------------------------------------------------------------------------- #
+def test_raw_list_human_lists_backups(tmp_path, capsys, monkeypatch):
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "x")
+    _build_backup(
+        tmp_path, "root.20260101T120000", encrypt="openssl_enc", compress="gzip"
+    )
+    _build_backup(tmp_path, "home.20260102T120000")
+
+    rc = raw_cmd.execute_raw(_args(raw_action="list", target=str(tmp_path), json=False))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "(2 snapshots)" in out
+    assert "root.20260101T120000" in out
+    assert "home.20260102T120000" in out
+    # The encrypting backup shows its cipher and pipeline.
+    assert "aes-256-cbc" in out
+    assert "openssl_enc" in out
+    assert "gzip" in out
+
+
+def test_raw_list_json_is_valid_and_authoritative(tmp_path, capsys, monkeypatch):
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "x")
+    _build_backup(tmp_path, "root.20260101T120000", encrypt="openssl_enc")
+
+    rc = raw_cmd.execute_raw(_args(raw_action="list", target=str(tmp_path), json=True))
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert isinstance(data, list) and len(data) == 1
+    entry = data[0]
+    assert entry["name"] == "root.20260101T120000"
+    # The JSON is the authoritative v2 sidecar document.
+    assert entry["version"] == 2
+    assert entry["pipeline"]["encrypt"] == "openssl_enc"
+    assert entry["pipeline"]["openssl_cipher"] == "aes-256-cbc"
+
+
+def test_raw_list_empty_target_is_ok(tmp_path, capsys):
+    rc = raw_cmd.execute_raw(_args(raw_action="list", target=str(tmp_path), json=False))
+    assert rc == 0
+    assert "(0 snapshots)" in capsys.readouterr().out
+
+
+def test_raw_list_rejects_non_raw_scheme(capsys):
+    rc = raw_cmd.execute_raw(
+        _args(raw_action="list", target="ssh://host/path", json=False)
+    )
+    assert rc == 2
+    assert "not a raw target" in capsys.readouterr().out
+
+
+def test_raw_list_warns_on_missing_local_target(tmp_path, capsys):
+    """A nonexistent local target warns (on stderr) instead of silently reporting
+    an empty target as if it held no backups."""
+    missing = tmp_path / "no-such-dir"
+    rc = raw_cmd.execute_raw(_args(raw_action="list", target=str(missing), json=False))
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "does not exist or is not mounted" in captured.err
+
+
+# --------------------------------------------------------------------------- #
+# dispatcher wiring (the command is actually registered and routed)
+# --------------------------------------------------------------------------- #
+def test_dispatcher_parses_raw_list():
+    """The real parser recognizes `raw list TARGET --json --ssh-sudo` and sets the
+    expected namespace. A missing subparser registration would fail here."""
+    from btrfs_backup_ng.cli.dispatcher import create_subcommand_parser
+
+    parser = create_subcommand_parser()
+    args = parser.parse_args(["raw", "list", "/x", "--json", "--ssh-sudo"])
+    assert args.command == "raw"
+    assert args.raw_action == "list"
+    assert args.target == "/x"
+    assert args.json is True
+    assert args.ssh_sudo is True
+
+
+def test_dispatcher_routes_raw_to_execute_raw(monkeypatch):
+    """run_subcommand must dispatch command=='raw' to raw_cmd.execute_raw. Dropping
+    the "raw": cmd_raw handler entry would fail here (not caught by the unit tests
+    that call execute_raw directly)."""
+    from btrfs_backup_ng.cli import dispatcher
+
+    called = {}
+
+    def fake_execute_raw(a):
+        called["args"] = a
+        return 0
+
+    monkeypatch.setattr(raw_cmd, "execute_raw", fake_execute_raw)
+    rc = dispatcher.run_subcommand(
+        _args(command="raw", raw_action="list", target="/x", json=False, version=False)
+    )
+    assert rc == 0
+    assert called["args"].command == "raw"


### PR DESCRIPTION
## 0.8.5 PR6a — `raw` command family + `raw list`

First slice of the split `raw` command family (was a monolithic "PR6"). Adds a command group for operating directly on a `raw://` / `raw+ssh://` backup target, independent of any configured job.

### `raw list TARGET [--json] [--ssh-sudo]`
- Enumerates a target's backups from their authoritative `.meta` sidecars (filename-inference fallback for legacy streams).
- Human table (name, created, size, encryption, compression, cipher, provenance) or `--json` of the sidecar documents.
- A bare path is treated as `raw://`; a non-raw URL scheme is rejected (exit 2); a missing local target warns on stderr rather than silently reporting "0 snapshots".

### Wiring & docs
- Registered in the dispatcher (SUBCOMMANDS, nested subparser, handler).
- bash/zsh/fish completions — and the bash command/subcommand detection is **fixed** so `raw list` (and the latent `transfers list`) resolve to the subcommand instead of the top-level `list`.
- New CLI-REFERENCE `### raw` section + `man/man1/btrfs-backup-ng-raw.1`.

### Quality
- Adversarial 2-lens review (correctness/regression + completeness); its medium finding (bash completion routing) and the low/nit findings (dispatcher-wiring test, docs, manpage, missing-path UX, fish TARGET completion, dead guard) are all addressed.
- 14 tests incl. dispatcher parser + handler routing; the two bits of real logic mutation-checked.
- Full suite `2181 passed, 1 skipped`; ruff / ruff-format@0.15.22 / mypy / completion syntax all clean.

Splits from the former PR6. Next: PR6b (checksum infra) → PR6c (`raw verify`) → PR6d (`raw backfill-metadata`) → PR6e (`raw encrypt` remediation — security-sensitive, gated on explicit sign-off). Follows #21–#26.
