### PR TITLE
feat(raw): seal a ciphertext sha256 into every raw backup sidecar

### DIFF
--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -13,6 +13,7 @@ Encryption methods:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -143,6 +144,32 @@ def _openssl_pass_arg() -> str:
 # leaves at most a ``.part`` file, which discovery ignores -- so a partial
 # transfer can never be listed as a complete backup.
 PARTIAL_SUFFIX = ".part"
+
+
+def _sha256_file(path: Path) -> str | None:
+    """Return the hex sha256 of ``path``'s bytes, or None on any I/O error.
+
+    Best-effort: a checksum failure must never fail an already-durable backup. On
+    Linux, the file's page cache is dropped first (POSIX_FADV_DONTNEED) so the read
+    comes from the physical medium -- verifying the bytes that actually landed on
+    disk after fsync (catching write-side/media corruption a warm-cache read would
+    miss) -- without evicting other data from the cache."""
+    try:
+        h = hashlib.sha256()
+        with open(path, "rb") as f:
+            fadvise = getattr(os, "posix_fadvise", None)
+            dontneed = getattr(os, "POSIX_FADV_DONTNEED", None)
+            if fadvise is not None and dontneed is not None:
+                try:
+                    fadvise(f.fileno(), 0, 0, dontneed)
+                except OSError:
+                    pass
+            for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                h.update(chunk)
+        return h.hexdigest()
+    except OSError as e:
+        logger.warning("Could not checksum %s: %s", path, e)
+        return None
 
 
 def _popen_pipeline_pipefail(shell_cmd: str, **popen_kwargs: Any) -> subprocess.Popen:
@@ -526,9 +553,12 @@ class RawEndpoint(Endpoint):
         # never a sidecar describing a missing/partial stream. Best-effort: the
         # backup data already succeeded, so a sidecar error must not fail it.
         try:
-            self.write_sidecar(
-                self._sidecar_snapshot(final_path, final_path.stat().st_size)
-            )
+            size = final_path.stat().st_size
+            # sha256 of the committed ciphertext, read back from disk so it
+            # reflects the bytes that actually landed (raw verify recomputes and
+            # compares). Best-effort: on failure the checksum stays null.
+            checksum = _sha256_file(final_path)
+            self.write_sidecar(self._sidecar_snapshot(final_path, size, checksum))
         except Exception as e:
             # The backup data is already durable; a sidecar error must NEVER flip
             # an already-successful transfer into a reported failure (PR1 contract).
@@ -550,11 +580,13 @@ class RawEndpoint(Endpoint):
         does)."""
         snapshot.save_metadata()
 
-    def _sidecar_snapshot(self, final_path: Path, size: int) -> RawSnapshot:
+    def _sidecar_snapshot(
+        self, final_path: Path, size: int, checksum_value: str | None = None
+    ) -> RawSnapshot:
         """Build the authoritative RawSnapshot to persist for a just-committed
         stream, from the pending receive metadata. openssl_cipher is recorded so
-        restore uses the exact cipher; the checksum is reserved (filled later by
-        ``raw verify``)."""
+        restore uses the exact cipher; ``checksum_value`` is the sha256 of the
+        committed ciphertext (None if it could not be computed -- best-effort)."""
         pending = self._pending_metadata
         return RawSnapshot(
             name=pending["name"],
@@ -567,6 +599,7 @@ class RawEndpoint(Endpoint):
             gpg_recipient=pending.get("gpg_recipient"),
             openssl_cipher=pending.get("openssl_cipher"),
             provenance_origin="native-write",
+            checksum_value=checksum_value,
         )
 
     def send(
@@ -1063,13 +1096,65 @@ class SSHRawEndpoint(RawEndpoint):
                 final_path,
                 e,
             )
-        # Best-effort: the stream is already durable, so a sidecar write error must
-        # not fail the backup (mirrors the local commit path). write_sidecar raises
-        # on failure; catch and log rather than propagate.
+        # Best-effort: the stream is already durable, so a checksum or sidecar error
+        # must not fail the backup (mirrors the local commit path). Both the remote
+        # hash and write_sidecar are inside the try so neither can flip an
+        # already-successful transfer into a reported failure (the PR1/R1 contract).
         try:
-            self.write_sidecar(self._sidecar_snapshot(final_path, size))
+            checksum = self._remote_sha256(final_path)
+            self.write_sidecar(self._sidecar_snapshot(final_path, size, checksum))
         except Exception as e:
             logger.warning("Failed to write remote sidecar for %s: %s", final_path, e)
+
+    def _remote_sha256(self, final_path: Path) -> str | None:
+        """Compute the sha256 of the committed remote stream ON the remote host,
+        returning the 64-hex digest or None (best-effort).
+
+        Portable across a raw target that may be Linux, macOS/BSD, or a minimal
+        box: GNU ``sha256sum``, else BSD/macOS ``shasum -a 256``, else
+        ``openssl dgst``. The tool is chosen by EXISTENCE (``command -v``), not by a
+        pipeline's exit status -- a missing first tool must fall through to the next,
+        which a ``tool | awk || ...`` chain would not do (the ``||`` keys off awk's
+        exit, not the tool's). Hashing remotely keeps the bytes on the remote (no
+        re-download) and offloads the work to that host's kernel.
+
+        NOTE: because the digest is computed BY the (untrusted) target, it is only
+        as trustworthy as that host -- for raw+ssh the checksum detects passive/
+        accidental corruption noticed by an independent reader, but cannot catch
+        corruption introduced by a compromised target (unlike the local read-back,
+        which hashes honest bytes at write time). Corruption detection, not tamper
+        resistance."""
+        q = shlex.quote(str(final_path))
+        cmd = (
+            f"if command -v sha256sum >/dev/null 2>&1; then sha256sum {q} | awk '{{print $1}}'; "
+            f"elif command -v shasum >/dev/null 2>&1; then shasum -a 256 {q} | awk '{{print $1}}'; "
+            f"elif command -v openssl >/dev/null 2>&1; then openssl dgst -sha256 {q} | awk '{{print $NF}}'; "
+            f"else exit 1; fi"
+        )
+        try:
+            res = self._exec_remote_command(["sh", "-c", cmd], check=False)
+            out = res.stdout
+            if isinstance(out, (bytes, bytearray)):
+                out = out.decode(errors="replace")
+            digest = (str(out) or "").strip().lower()
+            if (
+                res.returncode == 0
+                and len(digest) == 64
+                and all(c in "0123456789abcdef" for c in digest)
+            ):
+                return digest
+            logger.warning(
+                "No usable sha256 tool (sha256sum/shasum/openssl) on %s or hashing "
+                "failed (rc=%s); sidecar checksum=null (corruption detection "
+                "disabled for this backup)",
+                getattr(self, "hostname", "remote"),
+                res.returncode,
+            )
+        except Exception as e:
+            # Fully best-effort: computing a checksum must NEVER raise out of here
+            # (and so can never fail a durable backup or skip the sidecar write).
+            logger.warning("Could not checksum remote %s: %s", final_path, e)
+        return None
 
     def write_sidecar(self, snapshot: RawSnapshot) -> None:
         """Write ``snapshot``'s ``.meta`` sidecar on the remote target atomically

--- a/src/btrfs_backup_ng/endpoint/raw_metadata.py
+++ b/src/btrfs_backup_ng/endpoint/raw_metadata.py
@@ -121,9 +121,9 @@ class RawSnapshot:
     gpg_recipient: str | None = None
     openssl_cipher: str | None = None
     # --- authoritative sidecar (0.8.5) ---
-    # checksum_value is RESERVED: the schema carries checksum{algorithm,value} but
-    # the value is populated later by `raw verify` (computed via a Python-native
-    # stream tee), so the zero-copy write pipeline is not taxed with a second read.
+    # checksum_value: hex sha256 of the committed ciphertext, sealed at write time
+    # by reading the file back after the atomic commit (so it reflects the bytes on
+    # disk). None for legacy sidecars or when the read-back failed (best-effort).
     checksum_value: str | None = None
     provenance_origin: str = "native-write"
     # --- Snapshot-interface compatibility (0.8.5) ---
@@ -204,8 +204,8 @@ class RawSnapshot:
         v2 is additive over v1: the nested ``pipeline`` block gains
         ``openssl_cipher``, and ``checksum``/``provenance`` blocks are added. A v1
         reader ignores the new keys; ``from_dict`` reads either version. ``created``
-        is ISO-8601 in UTC. ``checksum.value`` is reserved (null on the write path;
-        populated later by ``raw verify``).
+        is ISO-8601 in UTC. ``checksum.value`` is the sha256 of the committed
+        ciphertext (null for legacy sidecars or a best-effort read-back failure).
         """
         return {
             "version": 2,

--- a/tests/test_raw_checksum.py
+++ b/tests/test_raw_checksum.py
@@ -1,0 +1,213 @@
+"""Write-time ciphertext checksum (0.8.5 PR6b).
+
+Every raw backup records the sha256 of its committed stream in the ``.meta``
+sidecar (``checksum.value``), computed by reading the file back AFTER the atomic
+commit -- so it reflects the bytes that actually landed on disk (Option 1:
+post-commit read-back; see the design notes). raw verify (PR6c) recomputes and
+compares. The seal is best-effort: a checksum failure never fails a durable backup.
+"""
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from btrfs_backup_ng.endpoint import raw as raw_mod
+from btrfs_backup_ng.endpoint.raw import RawEndpoint, SSHRawEndpoint, _sha256_file
+from btrfs_backup_ng.endpoint.raw_metadata import discover_raw_snapshots
+
+
+def _commit_backup(path, name="root.20260101T120000", payload=b"stream-" * 500):
+    ep = RawEndpoint(config={"path": str(path)})
+    src = path / "src.bin"
+    src.write_bytes(payload)
+    with open(src, "rb") as stdin:
+        ep.receive(stdin, snapshot_name=name).communicate()
+    ep.commit_receive()
+    src.unlink()
+    return ep
+
+
+# --------------------------------------------------------------------------- #
+# _sha256_file helper
+# --------------------------------------------------------------------------- #
+def test_sha256_file_matches_hashlib(tmp_path):
+    f = tmp_path / "blob"
+    data = b"arbitrary-bytes-" * 1000
+    f.write_bytes(data)
+    assert _sha256_file(f) == hashlib.sha256(data).hexdigest()
+
+
+def test_sha256_file_missing_returns_none(tmp_path):
+    """Best-effort: a missing/unreadable file yields None, not an exception."""
+    assert _sha256_file(tmp_path / "nope") is None
+
+
+def test_sha256_file_without_posix_fadvise(tmp_path, monkeypatch):
+    """The POSIX_FADV_DONTNEED call is getattr-guarded for non-Linux; removing
+    posix_fadvise entirely must not break hashing (pins the guard)."""
+    monkeypatch.delattr(os, "posix_fadvise", raising=False)
+    f = tmp_path / "blob"
+    data = b"no-fadvise-" * 300
+    f.write_bytes(data)
+    assert _sha256_file(f) == hashlib.sha256(data).hexdigest()
+
+
+# --------------------------------------------------------------------------- #
+# local write-time seal
+# --------------------------------------------------------------------------- #
+def test_commit_records_checksum_of_committed_stream(tmp_path):
+    """The sidecar checksum equals the sha256 of the on-disk stream file. If the
+    commit stops passing the computed checksum into the sidecar, value is null and
+    this fails."""
+    _commit_backup(tmp_path)
+    (snap,) = discover_raw_snapshots(tmp_path)
+    assert snap.checksum_value is not None
+    on_disk = hashlib.sha256(snap.stream_path.read_bytes()).hexdigest()
+    assert snap.checksum_value == on_disk
+
+
+def test_checksum_seal_is_best_effort(tmp_path, monkeypatch):
+    """If the checksum cannot be computed, the backup still commits durably with a
+    null checksum (never fail a durable backup on a checksum error). Reverting the
+    best-effort wrapping would surface the failure instead."""
+    monkeypatch.setattr(raw_mod, "_sha256_file", lambda p: None)
+    _commit_backup(tmp_path)
+    (snap,) = discover_raw_snapshots(tmp_path)
+    # Stream is durable and discoverable; only the checksum is absent.
+    assert snap.stream_path.exists()
+    assert snap.checksum_value is None
+
+
+# --------------------------------------------------------------------------- #
+# remote (raw+ssh) seal
+# --------------------------------------------------------------------------- #
+def test_remote_sha256_parses_valid_digest():
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+    digest = "a" * 64
+    ep._exec_remote_command = MagicMock(
+        return_value=MagicMock(returncode=0, stdout=(digest + "\n").encode())
+    )
+    assert ep._remote_sha256(Path("/backup/x.btrfs")) == digest
+    # Uses a portable hash command.
+    script = ep._exec_remote_command.call_args[0][0][2]
+    assert "sha256sum" in script and "shasum -a 256" in script and "openssl" in script
+
+
+def test_remote_sha256_rejects_non_hex_output():
+    """A garbage/error line must not be recorded as a checksum."""
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+    ep._exec_remote_command = MagicMock(
+        return_value=MagicMock(returncode=0, stdout=b"stat: cannot stat\n")
+    )
+    assert ep._remote_sha256(Path("/backup/x.btrfs")) is None
+
+
+def test_remote_sha256_empty_output_returns_none():
+    """rc==0 with EMPTY stdout (the exact symptom of the old broken fallback on a
+    host without the first hash tool) must yield None, not an empty checksum."""
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+    ep._exec_remote_command = MagicMock(
+        return_value=MagicMock(returncode=0, stdout=b"")
+    )
+    assert ep._remote_sha256(Path("/backup/x.btrfs")) is None
+
+
+def test_remote_hash_script_falls_through_when_sha256sum_absent(tmp_path):
+    """Run the ACTUAL remote-hash shell string through a real /bin/sh with a PATH
+    that lacks sha256sum/shasum (simulating macOS's missing sha256sum), leaving only
+    openssl+awk. The tool must be selected by existence so the fallback fires and a
+    correct digest is emitted -- NOT mocked, so it catches the pipeline-exit-status
+    bug the mocked tests miss. Reverting to `tool | awk || ...` makes this fail."""
+    openssl = shutil.which("openssl")
+    awk = shutil.which("awk")
+    if not openssl or not awk:
+        pytest.skip("openssl/awk not available")
+
+    blob = tmp_path / "stream.btrfs"
+    data = b"remote-fallthrough-" * 500
+    blob.write_bytes(data)
+
+    # Capture the real shell string _remote_sha256 builds (SSH itself is stubbed).
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+    captured = {}
+
+    def capture(argv, **kw):
+        captured["script"] = argv[2]
+        return MagicMock(returncode=0, stdout=b"")
+
+    ep._exec_remote_command = capture
+    ep._remote_sha256(blob)
+    script = captured["script"]
+
+    # A PATH with ONLY openssl + awk: sha256sum and shasum are absent (like macOS,
+    # which actually ships shasum -- here we prove the deepest fallback, openssl).
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (bindir / "openssl").symlink_to(openssl)
+    (bindir / "awk").symlink_to(awk)
+    res = subprocess.run(
+        ["/bin/sh", "-c", script],
+        env={"PATH": str(bindir)},
+        capture_output=True,
+        text=True,
+    )
+    digest = res.stdout.strip().lower()
+    assert digest == hashlib.sha256(data).hexdigest()
+
+
+def test_remote_sidecar_records_checksum():
+    """_write_remote_sidecar seals the remote checksum into the sidecar it writes.
+    Mocks all three remote calls (size stat, checksum, sidecar write) and inspects
+    the JSON fed to the remote write."""
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+    digest = "b" * 64
+    ep._exec_remote_command = MagicMock(
+        side_effect=[
+            MagicMock(returncode=0, stdout=b"123", stderr=b""),  # size stat
+            MagicMock(returncode=0, stdout=(digest + "\n").encode()),  # checksum
+            MagicMock(returncode=0, stdout=b"", stderr=b""),  # sidecar write
+        ]
+    )
+    ep._pending_metadata = {
+        "name": "root.20260101T120000",
+        "stream_path": Path("/backup/root.20260101T120000.btrfs"),
+        "part_path": Path("/backup/root.20260101T120000.btrfs.part"),
+        "parent_name": None,
+        "compress": None,
+        "encrypt": None,
+        "gpg_recipient": None,
+        "openssl_cipher": None,
+    }
+    ep._write_remote_sidecar(Path("/backup/root.20260101T120000.btrfs"))
+    payload = ep._exec_remote_command.call_args_list[2].kwargs["input"]
+    doc = json.loads(payload)
+    assert doc["checksum"]["value"] == digest
+
+
+def test_remote_checksum_exception_stays_best_effort():
+    """An unexpected exception from the remote hash must NOT fail an already-durable
+    backup: _write_remote_sidecar wraps the checksum + sidecar write in one
+    best-effort try/except. With the remote hash outside the try this propagates."""
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+    ep._exec_remote_command = MagicMock(
+        return_value=MagicMock(returncode=0, stdout=b"123", stderr=b"")
+    )
+    ep._remote_sha256 = MagicMock(side_effect=RuntimeError("boom"))
+    ep._pending_metadata = {
+        "name": "snap",
+        "stream_path": Path("/backup/snap.btrfs"),
+        "part_path": Path("/backup/snap.btrfs.part"),
+        "parent_name": None,
+        "compress": None,
+        "encrypt": None,
+        "gpg_recipient": None,
+        "openssl_cipher": None,
+    }
+    # Must not raise.
+    ep._write_remote_sidecar(Path("/backup/snap.btrfs"))

--- a/tests/test_raw_sidecar.py
+++ b/tests/test_raw_sidecar.py
@@ -40,7 +40,11 @@ def test_commit_writes_authoritative_v2_sidecar(tmp_path):
     assert data["pipeline"]["compress"] == "gzip"
     assert data["pipeline"]["encrypt"] is None
     assert data["pipeline"]["openssl_cipher"] is None  # gated: only for openssl_enc
-    assert data["checksum"] == {"algorithm": "sha256", "value": None}  # reserved
+    # checksum is sealed at write time (PR6b): sha256 of the committed stream.
+    import hashlib
+
+    assert data["checksum"]["algorithm"] == "sha256"
+    assert data["checksum"]["value"] == hashlib.sha256(stream.read_bytes()).hexdigest()
     assert data["provenance"]["origin"] == "native-write"
     assert data["created"].endswith("+00:00")  # ISO-8601 UTC
 


### PR DESCRIPTION
## 0.8.5 PR6b — write-time ciphertext checksum

Populates the sidecar's reserved `checksum.value` (a sha256 of the committed stream) so `raw verify` (PR6c) can detect corruption. Design: **Option 1 — post-commit read-back** (approved after a sounding-board syscall analysis; Python-native tee was rejected because it would trade the kernel zero-copy pipe for per-chunk context-switch churn with no safety gain).

### How
- After the atomic commit, the committed file is read back and hashed; the zero-copy write pipeline (`btrfs send | compress | encrypt > file`) is **unchanged**.
- Hashing the file *after* `fsync` catches write-side/media corruption a pipeline hash would miss. On Linux the read-back first drops the page cache (`POSIX_FADV_DONTNEED`) so it reads from the physical medium.
- raw+ssh hashes **on the remote host** (`sha256sum` → `shasum -a 256` → `openssl dgst`, selected by `command -v` existence — not by a pipeline's exit status), so bytes aren't re-downloaded.
- **Best-effort** on both paths: a checksum failure leaves the value null and never fails a durable backup. The remote digest is corruption-detection only, not tamper-proof (documented — it's computed by the untrusted target).

### Quality
- **Full 4-lens adversarial review.** It caught a **HIGH** bug: the original `sha256sum|awk || shasum|awk` chain gated `||` on awk's exit (no pipefail), so on macOS (no `sha256sum`) the fallback never fired → silent-null checksum on every raw+ssh backup. Fixed via `command -v` selection; the mocked tests that missed it are joined by a **non-mocked** test that runs the real shell string with `sha256sum` shadowed off PATH (mutation-verified). All other findings (best-effort symmetry, trust-asymmetry doc, fadvise-guard test) addressed.
- **Hardware-proven** on a real macOS/APFS host: raw+ssh backup seals a checksum matching an independent `shasum` on the Mac; cross-machine restore byte-identical; artifacts torn down.
- 11 mutation-verified tests; full suite `2192 passed`; ruff/format@0.15.22/mypy clean. Both commit paths (streaming + chunked) seal.

Follows #21–#27. Next: PR6c `raw verify` (recompute + compare this checksum).
