### PR TITLE
feat(cli): add raw verify to check backups against their recorded checksums

### DIFF
--- a/completions/btrfs-backup-ng.bash
+++ b/completions/btrfs-backup-ng.bash
@@ -11,7 +11,7 @@ _btrfs_backup_ng() {
     local manpages_subcommands="install path"
     local transfers_subcommands="list show resume pause cleanup operations"
     local snapper_subcommands="detect list backup status restore generate-config"
-    local raw_subcommands="list"
+    local raw_subcommands="list verify"
 
     # Global options
     local global_opts="-h --help -v --verbose -q --quiet --debug -V --version -c --config"
@@ -47,6 +47,7 @@ _btrfs_backup_ng() {
     local snapper_restore_opts="--snapshot --dry-run --ssh-sudo --ssh-key"
     local snapper_generate_config_opts="-o --output"
     local raw_list_opts="--json --ssh-sudo"
+    local raw_verify_opts="--snapshot --json --ssh-sudo"
     local snapper_types="single pre post"
     local verify_levels="metadata stream full"
     local shell_types="bash zsh fish"
@@ -64,7 +65,7 @@ _btrfs_backup_ng() {
     local i
     for ((i=1; i < cword; i++)); do
         case "${words[i]}" in
-            run|snapshot|transfer|prune|status|config|install|uninstall|restore|verify|estimate|doctor|completions|manpages|transfers|snapper|raw)
+            run|snapshot|transfer|prune|status|config|install|uninstall|restore|estimate|doctor|completions|manpages|transfers|snapper|raw)
                 cmd="${words[i]}"
                 ;;
             list)
@@ -76,6 +77,15 @@ _btrfs_backup_ng() {
                     cmd="list"
                 elif [[ "$cmd" == "transfers" || "$cmd" == "raw" ]]; then
                     subcmd="list"
+                fi
+                ;;
+            verify)
+                # `verify` is both a top-level command and a raw subcommand (same
+                # reasoning as `list` above).
+                if [[ -z "$cmd" ]]; then
+                    cmd="verify"
+                elif [[ "$cmd" == "raw" ]]; then
+                    subcmd="verify"
                 fi
                 ;;
             validate|init|import|detect)
@@ -374,6 +384,13 @@ _btrfs_backup_ng() {
                     list)
                         if [[ "$cur" == -* ]]; then
                             COMPREPLY=($(compgen -W "$raw_list_opts" -- "$cur"))
+                        else
+                            _filedir -d
+                        fi
+                        ;;
+                    verify)
+                        if [[ "$cur" == -* ]]; then
+                            COMPREPLY=($(compgen -W "$raw_verify_opts" -- "$cur"))
                         else
                             _filedir -d
                         fi

--- a/completions/btrfs-backup-ng.fish
+++ b/completions/btrfs-backup-ng.fish
@@ -352,6 +352,7 @@ complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_snapper_using_subcommand 
 
 # raw command subcommands
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_using_command raw' -a list -d 'List the backups a raw target holds'
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_using_command raw' -a verify -d 'Verify raw backups against their recorded checksums'
 
 # Helper for raw subcommand
 function __fish_btrfs_backup_ng_raw_using_subcommand
@@ -371,3 +372,9 @@ end
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand list' -l json -d 'Output in JSON format'
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand list' -l ssh-sudo -d 'Use sudo for remote commands on a raw+ssh target'
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand list' -a '(__fish_complete_directories)' -d 'Raw target path'
+
+# raw verify
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand verify' -l snapshot -d 'Verify only the named snapshot' -x
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand verify' -l json -d 'Output in JSON format'
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand verify' -l ssh-sudo -d 'Use sudo for remote commands on a raw+ssh target'
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand verify' -a '(__fish_complete_directories)' -d 'Raw target path'

--- a/completions/btrfs-backup-ng.zsh
+++ b/completions/btrfs-backup-ng.zsh
@@ -397,6 +397,7 @@ _btrfs-backup-ng() {
                     local -a raw_commands
                     raw_commands=(
                         'list:List the backups a raw target holds'
+                        'verify:Verify raw backups against their recorded checksums'
                     )
                     _arguments \
                         '1: :->raw_cmd' \
@@ -410,6 +411,13 @@ _btrfs-backup-ng() {
                             case $line[1] in
                                 list)
                                     _arguments \
+                                        '--json[Output in JSON format]' \
+                                        '--ssh-sudo[Use sudo for remote commands on a raw+ssh target]' \
+                                        '1:raw target:_files -/'
+                                    ;;
+                                verify)
+                                    _arguments \
+                                        '--snapshot[Verify only the named snapshot]:snapshot name:' \
                                         '--json[Output in JSON format]' \
                                         '--ssh-sudo[Use sudo for remote commands on a raw+ssh target]' \
                                         '1:raw target:_files -/'

--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -970,6 +970,38 @@ Raw target: raw:///mnt/usb/backups  (2 snapshots)
   home.20260101T120000             2026-01-01T12:00:00Z  340 MiB  -           -        -            native-write
 ```
 
+#### raw verify
+
+Verify raw backups by recomputing each stream's sha256 and comparing it to the checksum recorded in its `.meta` sidecar. For a `raw+ssh://` target the hash is computed on the remote host, so streams are not re-downloaded.
+
+```bash
+btrfs-backup-ng raw verify TARGET [OPTIONS]
+```
+
+**Arguments:**
+| Argument | Description |
+|----------|-------------|
+| `TARGET` | Raw target: `raw://PATH`, `raw+ssh://[USER@]HOST/PATH`, or a plain path |
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--snapshot NAME` | Verify only the named snapshot |
+| `--json` | Output per-snapshot results as JSON |
+| `--ssh-sudo` | Use `sudo` for remote commands on a `raw+ssh://` target |
+
+Per-snapshot status: **ok** (matches), **corrupt** (the stored stream differs from what was backed up), **error** (the stream could not be read/hashed), or **unverifiable** (no checksum was recorded — a legacy backup, or a best-effort write-time seal that failed). Exit status is `1` if any snapshot is corrupt or errored, else `0`.
+
+`raw verify` confirms a stream still matches the checksum recorded in its own `.meta` sidecar — an **integrity/consistency** check, not an authenticity one: an attacker who can rewrite both the stream and its sidecar can make a corrupted backup report `ok`. For a `raw+ssh://` target the hash is recomputed **on the (untrusted) remote host**, so an `ok` verdict only confirms the recorded checksum and cannot detect corruption or tampering introduced by a compromised target. For tamper-evident verification, verify a locally-mounted copy (`raw://`), where the stream is hashed with your own host's kernel after dropping its page cache.
+
+**Example Output:**
+```
+Raw target: raw:///mnt/usb/backups  (verifying 2 snapshots)
+  OK            root.20260101T120000
+  CORRUPT       home.20260101T120000
+  1 ok, 1 corrupt, 0 error, 0 unverifiable
+```
+
 ---
 
 ## Filesystem Checks

--- a/man/man1/btrfs-backup-ng-raw.1
+++ b/man/man1/btrfs-backup-ng-raw.1
@@ -5,6 +5,9 @@ btrfs-backup-ng-raw \- inspect and maintain raw-target backups
 .SH SYNOPSIS
 .B btrfs-backup-ng raw list
 \fITARGET\fR [\fB\-\-json\fR] [\fB\-\-ssh-sudo\fR]
+.br
+.B btrfs-backup-ng raw verify
+\fITARGET\fR [\fB\-\-snapshot\fR \fINAME\fR] [\fB\-\-json\fR] [\fB\-\-ssh-sudo\fR]
 .SH DESCRIPTION
 Operate directly on a raw backup target. Raw targets (\fBraw://\fR and
 \fBraw+ssh://\fR) store btrfs send streams as files for backing up to non-btrfs
@@ -38,17 +41,66 @@ Output the authoritative sidecar documents as JSON for scripting.
 .TP
 .B \-\-ssh-sudo
 Use \fBsudo\fR for the remote commands on a \fBraw+ssh://\fR target.
+.SS verify
+Verify raw backups against their recorded checksums.
+.PP
+.RS
+.B btrfs-backup-ng raw verify
+\fITARGET\fR [\fB\-\-snapshot\fR \fINAME\fR] [\fB\-\-json\fR] [\fB\-\-ssh-sudo\fR]
+.RE
+.PP
+Recomputes each stream's sha256 and compares it to the value recorded in its
+\fB.meta\fR sidecar. For a \fBraw+ssh://\fR target the hash is computed on the
+remote host, so streams are not re-downloaded. Each backup is reported as
+.B ok
+(matches),
+.B corrupt
+(the stored stream differs from what was backed up),
+.B error
+(the stream could not be read or hashed), or
+.B unverifiable
+(no checksum was recorded -- a legacy backup, or a best-effort write-time seal
+that failed).
+.PP
+verify confirms a stream still matches the checksum in its own sidecar -- an
+integrity/consistency check, not authenticity: an attacker who can rewrite both
+the stream and its sidecar can make a corrupted backup report
+.BR ok .
+For a \fBraw+ssh://\fR target the hash is recomputed ON the (untrusted) remote
+host, so an
+.B ok
+verdict only confirms the recorded checksum and cannot detect corruption or
+tampering introduced by a compromised target. For tamper-evident verification,
+verify a locally-mounted copy (\fBraw://\fR).
+.TP
+.BI \-\-snapshot " NAME"
+Verify only the named snapshot.
+.TP
+.B \-\-json
+Output per-snapshot results in JSON format.
+.TP
+.B \-\-ssh-sudo
+Use \fBsudo\fR for the remote commands on a \fBraw+ssh://\fR target.
 .SH EXIT STATUS
 .TP
 .B 0
-Success (including an empty or nonexistent target; a warning is printed for a
-missing local path).
+Success. For \fBlist\fR, includes an empty or nonexistent target (a warning is
+printed for a missing local path). For \fBverify\fR, all backups are
+.B ok
+or
+.BR unverifiable .
 .TP
 .B 1
-The target could not be listed.
+For \fBlist\fR, the target could not be listed. For \fBverify\fR, at least one
+backup is
+.B corrupt
+or
+.BR error .
 .TP
 .B 2
-Invalid target (for example a non-raw URL scheme).
+Invalid target (for example a non-raw URL scheme), or a
+.B \-\-snapshot
+name that is not present.
 .SH EXAMPLES
 .TP
 List a local raw target:
@@ -62,6 +114,12 @@ List a remote raw+ssh target with sudo:
 .TP
 Machine-readable output:
 .B btrfs-backup-ng raw list raw:///mnt/usb/backups --json
+.TP
+Verify every backup a target holds:
+.B btrfs-backup-ng raw verify raw:///mnt/usb/backups
+.TP
+Verify a single backup on a remote target:
+.B btrfs-backup-ng raw verify raw+ssh://backup@nas/backups --snapshot root.20260101T120000
 .SH SEE ALSO
 .BR btrfs-backup-ng (1),
 .BR btrfs-backup-ng-restore (1),

--- a/src/btrfs_backup_ng/cli/dispatcher.py
+++ b/src/btrfs_backup_ng/cli/dispatcher.py
@@ -377,6 +377,31 @@ def create_subcommand_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Use sudo for remote commands on a raw+ssh target",
     )
+    raw_verify_parser = raw_subs.add_parser(
+        "verify",
+        help="Verify raw backups against their recorded checksums",
+        description="Recompute each stream's sha256 and compare to its .meta sidecar",
+    )
+    raw_verify_parser.add_argument(
+        "target",
+        metavar="TARGET",
+        help="Raw target: raw://PATH, raw+ssh://[USER@]HOST/PATH, or a plain path",
+    )
+    raw_verify_parser.add_argument(
+        "--snapshot",
+        metavar="NAME",
+        help="Verify only the named snapshot",
+    )
+    raw_verify_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output in JSON format for scripting",
+    )
+    raw_verify_parser.add_argument(
+        "--ssh-sudo",
+        action="store_true",
+        help="Use sudo for remote commands on a raw+ssh target",
+    )
 
     # install command
     install_parser = subparsers.add_parser(

--- a/src/btrfs_backup_ng/cli/raw_cmd.py
+++ b/src/btrfs_backup_ng/cli/raw_cmd.py
@@ -23,6 +23,8 @@ def execute_raw(args: argparse.Namespace) -> int:
     action = getattr(args, "raw_action", None)
     if action == "list":
         return _raw_list(args)
+    if action == "verify":
+        return _raw_verify(args)
     # No/unknown action: argparse allows a bare `raw`, so guide the user.
     print("No raw action specified. Try: btrfs-backup-ng raw list <target>")
     return 1
@@ -54,27 +56,23 @@ def _human_size(n: int) -> str:
     return f"{size:.1f} EiB"
 
 
-def _raw_list(args: argparse.Namespace) -> int:
-    """List the backups a raw target holds (via their ``.meta`` sidecars)."""
-    try:
-        spec = _coerce_raw_spec(args.target)
-    except ValueError as e:
-        print(str(e))
-        return 2
+def _open_target(args: argparse.Namespace):
+    """Coerce ``args.target`` to a raw spec and open the endpoint.
 
+    Returns ``(endpoint, spec)``. Raises ValueError on a non-raw scheme or an
+    endpoint that cannot be built. Warns (on stderr, so ``--json`` stays clean)
+    when a local target does not exist -- a typo/unmounted path should not read as
+    an empty target."""
+    spec = _coerce_raw_spec(args.target)
     common: dict = {}
     if getattr(args, "ssh_sudo", False):
         common["ssh_sudo"] = True
-
     try:
         ep = endpoint.choose_endpoint(spec, common_config=common)
     except ValueError as e:
-        print(f"Cannot open raw target: {e}")
-        return 2
-
-    # A local target that does not exist is almost always a typo or an unmounted
-    # path; warn (on stderr, so --json stays clean) rather than let the resulting
-    # empty list look like "this target holds no backups".
+        # Preserve the historical framing so a construction failure (e.g. a
+        # hostname-less raw+ssh spec) reads differently from a coercion error.
+        raise ValueError(f"Cannot open raw target: {e}") from e
     if spec.startswith("raw://"):
         local_path = Path(spec[len("raw://") :])
         if not local_path.exists():
@@ -82,6 +80,16 @@ def _raw_list(args: argparse.Namespace) -> int:
                 f"warning: {local_path} does not exist or is not mounted",
                 file=sys.stderr,
             )
+    return ep, spec
+
+
+def _raw_list(args: argparse.Namespace) -> int:
+    """List the backups a raw target holds (via their ``.meta`` sidecars)."""
+    try:
+        ep, spec = _open_target(args)
+    except ValueError as e:
+        print(str(e))
+        return 2
 
     try:
         snapshots = ep.list_snapshots(flush_cache=True)
@@ -111,3 +119,85 @@ def _raw_list(args: argparse.Namespace) -> int:
             f"{(s.openssl_cipher or '-'):<12} {s.provenance_origin or '-'}"
         )
     return 0
+
+
+def _raw_verify(args: argparse.Namespace) -> int:
+    """Verify raw backups by recomputing each stream's sha256 and comparing it to
+    the checksum recorded in its ``.meta`` sidecar.
+
+    Per-snapshot status: ``ok`` (matches), ``corrupt`` (mismatch -> the stored
+    stream differs from what was backed up), ``error`` (the stream could not be
+    read/hashed), or ``unverifiable`` (no checksum was recorded -- a legacy backup
+    or a best-effort write-time seal that failed). Exit 1 if any snapshot is corrupt
+    or errored, else 0."""
+    try:
+        ep, spec = _open_target(args)
+    except ValueError as e:
+        print(str(e))
+        return 2
+
+    try:
+        snapshots = ep.list_snapshots(flush_cache=True)
+    except Exception as e:  # pragma: no cover - defensive; endpoint errors vary
+        logger.debug("raw verify failed", exc_info=True)
+        print(f"Failed to list {spec}: {e}")
+        return 1
+
+    want = getattr(args, "snapshot", None)
+    if want:
+        snapshots = [s for s in snapshots if s.name == want]
+        if not snapshots:
+            print(f"No snapshot named {want!r} at {spec}")
+            return 2
+
+    results = []
+    for s in snapshots:
+        recorded = s.checksum_value
+        algorithm = getattr(s, "checksum_algorithm", "sha256")
+        if not recorded:
+            status, computed = "unverifiable", None
+        elif algorithm != "sha256":
+            # We only compute sha256; comparing it to a digest of another algorithm
+            # would false-flag an intact stream as corrupt. Cannot check -> unverifiable.
+            status, computed = "unverifiable", None
+        else:
+            computed = ep.compute_stream_checksum(s)
+            if computed is None:
+                status = "error"
+            elif computed == recorded:
+                status = "ok"
+            else:
+                status = "corrupt"
+        results.append(
+            {
+                "name": s.name,
+                "status": status,
+                "recorded": recorded,
+                "computed": computed,
+            }
+        )
+
+    if getattr(args, "json", False):
+        print(json.dumps(results, indent=2))
+    else:
+        plural = "" if len(results) == 1 else "s"
+        print(f"Raw target: {spec}  (verifying {len(results)} snapshot{plural})")
+        for r in results:
+            line = f"  {r['status'].upper():<13} {r['name']}"
+            if r["status"] == "corrupt":
+                # Show the mismatch on the one status an operator must investigate.
+                rec = (r["recorded"] or "-")[:12]
+                comp = (r["computed"] or "-")[:12]
+                line += f"  recorded={rec}... computed={comp}..."
+            print(line)
+        counts = {k: 0 for k in ("ok", "corrupt", "error", "unverifiable")}
+        for r in results:
+            counts[r["status"]] += 1
+        print(
+            f"  {counts['ok']} ok, {counts['corrupt']} corrupt, "
+            f"{counts['error']} error, {counts['unverifiable']} unverifiable"
+        )
+
+    # Fail if any backup is corrupt or its stream could not be read.
+    bad = any(r["status"] in ("corrupt", "error") for r in results)
+    return 1 if bad else 0

--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -580,6 +580,13 @@ class RawEndpoint(Endpoint):
         does)."""
         snapshot.save_metadata()
 
+    def compute_stream_checksum(self, snapshot: RawSnapshot) -> str | None:
+        """Return the CURRENT sha256 of ``snapshot``'s stream file, or None if it
+        cannot be read. ``raw verify`` recomputes this and compares it against the
+        sidecar's recorded ``checksum_value`` to detect corruption. The raw+ssh
+        subclass overrides this to hash on the remote host (no re-download)."""
+        return _sha256_file(snapshot.stream_path)
+
     def _sidecar_snapshot(
         self, final_path: Path, size: int, checksum_value: str | None = None
     ) -> RawSnapshot:
@@ -1105,6 +1112,12 @@ class SSHRawEndpoint(RawEndpoint):
             self.write_sidecar(self._sidecar_snapshot(final_path, size, checksum))
         except Exception as e:
             logger.warning("Failed to write remote sidecar for %s: %s", final_path, e)
+
+    def compute_stream_checksum(self, snapshot: RawSnapshot) -> str | None:
+        """Hash ``snapshot``'s stream ON the remote host (see ``_remote_sha256``),
+        so ``raw verify`` compares against the recorded checksum without
+        re-downloading the stream."""
+        return self._remote_sha256(snapshot.stream_path)
 
     def _remote_sha256(self, final_path: Path) -> str | None:
         """Compute the sha256 of the committed remote stream ON the remote host,

--- a/src/btrfs_backup_ng/endpoint/raw_metadata.py
+++ b/src/btrfs_backup_ng/endpoint/raw_metadata.py
@@ -125,6 +125,10 @@ class RawSnapshot:
     # by reading the file back after the atomic commit (so it reflects the bytes on
     # disk). None for legacy sidecars or when the read-back failed (best-effort).
     checksum_value: str | None = None
+    # The digest algorithm ``checksum_value`` was computed with. Always "sha256"
+    # today; carried so ``raw verify`` refuses to compare (reports "unverifiable")
+    # rather than false-flag corruption if a sidecar ever records another algorithm.
+    checksum_algorithm: str = "sha256"
     provenance_origin: str = "native-write"
     # --- Snapshot-interface compatibility (0.8.5) ---
     prefix: str = ""
@@ -221,7 +225,10 @@ class RawSnapshot:
                 "gpg_recipient": self.gpg_recipient,
                 "openssl_cipher": self.openssl_cipher,
             },
-            "checksum": {"algorithm": "sha256", "value": self.checksum_value},
+            "checksum": {
+                "algorithm": self.checksum_algorithm,
+                "value": self.checksum_value,
+            },
             "provenance": {
                 "origin": self.provenance_origin,
                 "tool_version": __version__,
@@ -292,6 +299,7 @@ class RawSnapshot:
             # v2 fields (absent in v1 -> defaults):
             openssl_cipher=pipeline.get("openssl_cipher"),
             checksum_value=checksum.get("value"),
+            checksum_algorithm=checksum.get("algorithm") or "sha256",
             provenance_origin=provenance.get("origin", "native-write"),
         )
 

--- a/tests/test_raw_cmd.py
+++ b/tests/test_raw_cmd.py
@@ -6,6 +6,7 @@ cover the target-spec coercion, the human + JSON output, and the error paths.
 
 import argparse
 import json
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -59,6 +60,29 @@ def test_human_size():
     assert raw_cmd._human_size(512) == "512 B"
     assert raw_cmd._human_size(1024) == "1.0 KiB"
     assert raw_cmd._human_size(1024 * 1024) == "1.0 MiB"
+    # Beyond PiB falls through to the final EiB unit.
+    assert raw_cmd._human_size(1024**6) == "1.0 EiB"
+
+
+def test_ssh_sudo_is_threaded_to_endpoint(monkeypatch):
+    """--ssh-sudo must reach the endpoint via choose_endpoint's common_config."""
+    captured = {}
+
+    def fake_choose(spec, common_config=None, **kw):
+        captured["common"] = common_config
+        return MagicMock(list_snapshots=lambda flush_cache=False: [])
+
+    monkeypatch.setattr(raw_cmd.endpoint, "choose_endpoint", fake_choose)
+    rc = raw_cmd.execute_raw(
+        _args(
+            raw_action="list",
+            target="raw+ssh://nas/backup",
+            json=True,
+            ssh_sudo=True,
+        )
+    )
+    assert rc == 0
+    assert captured["common"].get("ssh_sudo") is True
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_raw_verify.py
+++ b/tests/test_raw_verify.py
@@ -1,0 +1,245 @@
+"""raw verify (0.8.5 PR6c).
+
+`raw verify` recomputes each stream's sha256 and compares it to the checksum
+recorded in the sidecar (PR6b). Per-snapshot status: ok / corrupt / error /
+unverifiable; exit 1 if any snapshot is corrupt or errored.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from btrfs_backup_ng.cli import raw_cmd
+from btrfs_backup_ng.endpoint.raw import RawEndpoint, SSHRawEndpoint
+from btrfs_backup_ng.endpoint.raw_metadata import RawSnapshot
+
+
+def _build(path, name):
+    ep = RawEndpoint(config={"path": str(path)})
+    src = path / (name + ".src")
+    src.write_bytes(b"verify-payload-" * 300)
+    with open(src, "rb") as f:
+        ep.receive(f, snapshot_name=name).communicate()
+    ep.commit_receive()
+    src.unlink()
+
+
+def _args(**kw):
+    ns = argparse.Namespace()
+    for k, v in kw.items():
+        setattr(ns, k, v)
+    return ns
+
+
+def _verify(tmp_path, **kw):
+    base = {
+        "raw_action": "verify",
+        "target": str(tmp_path),
+        "snapshot": None,
+        "json": False,
+    }
+    base.update(kw)
+    return raw_cmd.execute_raw(_args(**base))
+
+
+# --------------------------------------------------------------------------- #
+# compute_stream_checksum
+# --------------------------------------------------------------------------- #
+def test_compute_stream_checksum_matches_sealed(tmp_path):
+    _build(tmp_path, "s1")
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    (snap,) = ep.list_snapshots(flush_cache=True)
+    current = ep.compute_stream_checksum(snap)
+    assert current == hashlib.sha256(snap.stream_path.read_bytes()).hexdigest()
+    assert current == snap.checksum_value  # a fresh backup verifies clean
+
+
+def test_ssh_compute_stream_checksum_delegates_to_remote():
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+    ep._remote_sha256 = MagicMock(return_value="c" * 64)
+    snap = RawSnapshot(name="s", stream_path=Path("/backup/s.btrfs"))
+    assert ep.compute_stream_checksum(snap) == "c" * 64
+    ep._remote_sha256.assert_called_once_with(Path("/backup/s.btrfs"))
+
+
+# --------------------------------------------------------------------------- #
+# raw verify outcomes
+# --------------------------------------------------------------------------- #
+def test_verify_all_ok(tmp_path, capsys):
+    _build(tmp_path, "good1")
+    _build(tmp_path, "good2")
+    rc = _verify(tmp_path)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "2 ok, 0 corrupt" in out
+
+
+def test_verify_detects_corruption(tmp_path, capsys):
+    """A stream whose bytes changed after backup (its recorded checksum no longer
+    matches) is reported corrupt with a nonzero exit. If verify stopped comparing
+    the recomputed checksum, this fails."""
+    _build(tmp_path, "good")
+    _build(tmp_path, "bad")
+    bad_stream = tmp_path / "bad.btrfs"
+    bad_stream.write_bytes(bad_stream.read_bytes() + b"CORRUPTION")
+    rc = _verify(tmp_path)
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "CORRUPT" in out and "bad" in out
+    assert "1 ok, 1 corrupt" in out
+    # The corrupt row shows the mismatch (recorded vs computed) for triage.
+    assert "recorded=" in out and "computed=" in out
+
+
+def test_verify_unverifiable_when_no_recorded_checksum(tmp_path, capsys):
+    """A backup whose sidecar recorded no checksum (legacy / best-effort null) is
+    'unverifiable', not a failure (exit 0)."""
+    _build(tmp_path, "legacy")
+    meta = tmp_path / "legacy.btrfs.meta"
+    doc = json.loads(meta.read_text())
+    doc["checksum"]["value"] = None
+    meta.write_text(json.dumps(doc))
+    rc = _verify(tmp_path)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "1 unverifiable" in out
+
+
+@pytest.mark.skipif(
+    os.geteuid() == 0, reason="root bypasses chmod 0o000, so the stream stays readable"
+)
+def test_verify_error_when_stream_unreadable(tmp_path, capsys):
+    """A recorded checksum but an unreadable stream is 'error' (exit 1) -- distinct
+    from corrupt."""
+    _build(tmp_path, "locked")
+    stream = tmp_path / "locked.btrfs"
+    stream.chmod(0o000)
+    try:
+        rc = _verify(tmp_path)
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "1 error" in out
+    finally:
+        stream.chmod(0o600)
+
+
+def test_verify_error_over_ssh_when_remote_hash_none(monkeypatch, tmp_path):
+    """For raw+ssh, a None remote hash (no hash tool / hashing failed) maps to
+    'error' with exit 1 -- not corrupt, not a crash."""
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+    snap = RawSnapshot(
+        name="s", stream_path=Path("/backup/s.btrfs"), checksum_value="a" * 64
+    )
+    ep.list_snapshots = lambda flush_cache=False: [snap]
+    ep._remote_sha256 = lambda p: None  # remote hashing failed
+    monkeypatch.setattr(raw_cmd.endpoint, "choose_endpoint", lambda *a, **k: ep)
+    rc = _verify(tmp_path, target="raw+ssh://nas/backup")
+    assert rc == 1
+
+
+def test_verify_snapshot_filter(tmp_path, capsys):
+    _build(tmp_path, "aaa")
+    _build(tmp_path, "bbb")
+    rc = _verify(tmp_path, snapshot="aaa")
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "verifying 1 snapshot" in out
+    assert "aaa" in out
+
+
+def test_verify_snapshot_not_found(tmp_path, capsys):
+    _build(tmp_path, "aaa")
+    rc = _verify(tmp_path, snapshot="nope")
+    assert rc == 2
+    assert "No snapshot named" in capsys.readouterr().out
+
+
+def test_verify_json(tmp_path, capsys):
+    _build(tmp_path, "jjj")
+    rc = _verify(tmp_path, json=True)
+    data = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert data[0]["name"] == "jjj"
+    assert data[0]["status"] == "ok"
+    assert data[0]["recorded"] == data[0]["computed"]
+
+
+def test_verify_rejects_non_raw_scheme(capsys):
+    rc = _verify_target("ssh://host/path")
+    assert rc == 2
+    assert "not a raw target" in capsys.readouterr().out
+
+
+def _verify_target(target):
+    return raw_cmd.execute_raw(
+        _args(raw_action="verify", target=target, snapshot=None, json=False)
+    )
+
+
+def test_verify_empty_target(tmp_path, capsys):
+    rc = _verify(tmp_path)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "verifying 0 snapshot" in out
+
+
+def test_verify_all_unverifiable_exits_zero(tmp_path, capsys):
+    """A target whose backups all lack a recorded checksum must exit 0, not 1
+    (unverifiable is not a failure). Folding unverifiable into the bad set fails."""
+    for n in ("a", "b"):
+        _build(tmp_path, n)
+        meta = tmp_path / f"{n}.btrfs.meta"
+        doc = json.loads(meta.read_text())
+        doc["checksum"]["value"] = None
+        meta.write_text(json.dumps(doc))
+    rc = _verify(tmp_path)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "2 unverifiable" in out
+
+
+def test_verify_unsupported_algorithm_is_unverifiable(tmp_path, capsys):
+    """A sidecar recording a non-sha256 algorithm (with a value) must NOT be
+    false-flagged corrupt -- we only compute sha256, so it is unverifiable."""
+    _build(tmp_path, "other")
+    meta = tmp_path / "other.btrfs.meta"
+    doc = json.loads(meta.read_text())
+    doc["checksum"]["algorithm"] = "blake2b"  # value stays (a real sha256 hex)
+    meta.write_text(json.dumps(doc))
+    rc = _verify(tmp_path)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "1 unverifiable" in out
+    assert "corrupt" not in out.lower().replace("0 corrupt", "")
+
+
+def test_open_target_construction_error_keeps_prefix(capsys):
+    """A choose_endpoint construction failure (e.g. a hostname-less raw+ssh spec)
+    keeps the 'Cannot open raw target:' framing; a bare coercion error does not."""
+    rc = raw_cmd.execute_raw(
+        _args(raw_action="list", target="raw+ssh:///backups/x", json=False)
+    )
+    assert rc == 2
+    assert "Cannot open raw target:" in capsys.readouterr().out
+
+
+def test_dispatcher_parses_raw_verify():
+    """The real parser recognizes `raw verify TARGET --snapshot ... --json
+    --ssh-sudo`. A missing subparser registration would fail here."""
+    from btrfs_backup_ng.cli.dispatcher import create_subcommand_parser
+
+    parser = create_subcommand_parser()
+    args = parser.parse_args(
+        ["raw", "verify", "/x", "--snapshot", "s1", "--json", "--ssh-sudo"]
+    )
+    assert args.command == "raw"
+    assert args.raw_action == "verify"
+    assert args.target == "/x"
+    assert args.snapshot == "s1"
+    assert args.json is True
+    assert args.ssh_sudo is True


### PR DESCRIPTION
## 0.8.5 PR6c — `raw verify`

Consumes the checksum PR6b seals: `raw verify TARGET [--snapshot NAME] [--json] [--ssh-sudo]` recomputes each stream's sha256 and compares it to the sidecar's recorded value.

### Behavior
- Per-snapshot status: **ok** / **corrupt** (stream differs from what was backed up) / **error** (unreadable/unhashable) / **unverifiable** (no usable recorded checksum). Exit **1** on any corrupt/error, else 0.
- Polymorphic `compute_stream_checksum` — local read-back, or raw+ssh hashing **on the remote** (no re-download).
- Corrupt rows show the recorded-vs-computed prefix for triage; `--json` gives `{name,status,recorded,computed}`.

### Quality — full 4-lens review, all findings addressed
- **medium:** the `_open_target` refactor had dropped `raw list`'s "Cannot open raw target:" message → restored + pinned by a test.
- **medium:** verify ignored the sidecar's checksum *algorithm* (a future non-sha256 would false-flag corrupt) → now carries `checksum_algorithm` and reports such a sidecar **unverifiable**, never corrupt (mutation-verified).
- **medium (security):** raw+ssh verify recomputes on the untrusted target — CLI-REFERENCE + man page now state verify is an integrity/consistency check (not authenticity), and raw+ssh `ok` can't detect corruption from a compromised target (verify a `raw://` copy for tamper-evidence).
- Fixed a root-fragile test (skip under euid 0 so Tier2 stays green); added empty-target, all-unverifiable, ssh-None→error, and boundary tests.
- Deferred (noted): symlink-following in enumeration is a pre-existing property of the shared raw discovery, out of PR6c scope.
- **Hardware-proven** on a real macOS/APFS host: raw+ssh backup verifies `ok`; corruption injected on the Mac is detected (exit 1); teardown clean.
- 21 tests (2 core + 2 medium-fix guards mutation-verified); full suite `2208 passed`; ruff/format@0.15.22/mypy/completions clean.

Follows #21–#28. Next: PR6d `raw backfill-metadata` (legacy sidecars), then PR6e `raw encrypt` (plaintext-shred — gated on explicit sign-off).
