### PR TITLE
feat(cli): add raw backfill-metadata for legacy streams without a sidecar

### DIFF
--- a/completions/btrfs-backup-ng.bash
+++ b/completions/btrfs-backup-ng.bash
@@ -11,7 +11,7 @@ _btrfs_backup_ng() {
     local manpages_subcommands="install path"
     local transfers_subcommands="list show resume pause cleanup operations"
     local snapper_subcommands="detect list backup status restore generate-config"
-    local raw_subcommands="list verify"
+    local raw_subcommands="list verify backfill-metadata"
 
     # Global options
     local global_opts="-h --help -v --verbose -q --quiet --debug -V --version -c --config"
@@ -48,6 +48,7 @@ _btrfs_backup_ng() {
     local snapper_generate_config_opts="-o --output"
     local raw_list_opts="--json --ssh-sudo"
     local raw_verify_opts="--snapshot --json --ssh-sudo"
+    local raw_backfill_opts="--dry-run --json --ssh-sudo"
     local snapper_types="single pre post"
     local verify_levels="metadata stream full"
     local shell_types="bash zsh fish"
@@ -86,6 +87,11 @@ _btrfs_backup_ng() {
                     cmd="verify"
                 elif [[ "$cmd" == "raw" ]]; then
                     subcmd="verify"
+                fi
+                ;;
+            backfill-metadata)
+                if [[ "$cmd" == "raw" ]]; then
+                    subcmd="backfill-metadata"
                 fi
                 ;;
             validate|init|import|detect)
@@ -391,6 +397,13 @@ _btrfs_backup_ng() {
                     verify)
                         if [[ "$cur" == -* ]]; then
                             COMPREPLY=($(compgen -W "$raw_verify_opts" -- "$cur"))
+                        else
+                            _filedir -d
+                        fi
+                        ;;
+                    backfill-metadata)
+                        if [[ "$cur" == -* ]]; then
+                            COMPREPLY=($(compgen -W "$raw_backfill_opts" -- "$cur"))
                         else
                             _filedir -d
                         fi

--- a/completions/btrfs-backup-ng.fish
+++ b/completions/btrfs-backup-ng.fish
@@ -353,6 +353,7 @@ complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_snapper_using_subcommand 
 # raw command subcommands
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_using_command raw' -a list -d 'List the backups a raw target holds'
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_using_command raw' -a verify -d 'Verify raw backups against their recorded checksums'
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_using_command raw' -a backfill-metadata -d 'Write .meta sidecars for legacy streams that have none'
 
 # Helper for raw subcommand
 function __fish_btrfs_backup_ng_raw_using_subcommand
@@ -378,3 +379,9 @@ complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand veri
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand verify' -l json -d 'Output in JSON format'
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand verify' -l ssh-sudo -d 'Use sudo for remote commands on a raw+ssh target'
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand verify' -a '(__fish_complete_directories)' -d 'Raw target path'
+
+# raw backfill-metadata
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand backfill-metadata' -l dry-run -d 'Show what would be backfilled without writing'
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand backfill-metadata' -l json -d 'Output in JSON format'
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand backfill-metadata' -l ssh-sudo -d 'Use sudo for remote commands on a raw+ssh target'
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand backfill-metadata' -a '(__fish_complete_directories)' -d 'Raw target path'

--- a/completions/btrfs-backup-ng.zsh
+++ b/completions/btrfs-backup-ng.zsh
@@ -398,6 +398,7 @@ _btrfs-backup-ng() {
                     raw_commands=(
                         'list:List the backups a raw target holds'
                         'verify:Verify raw backups against their recorded checksums'
+                        'backfill-metadata:Write .meta sidecars for legacy streams'
                     )
                     _arguments \
                         '1: :->raw_cmd' \
@@ -418,6 +419,13 @@ _btrfs-backup-ng() {
                                 verify)
                                     _arguments \
                                         '--snapshot[Verify only the named snapshot]:snapshot name:' \
+                                        '--json[Output in JSON format]' \
+                                        '--ssh-sudo[Use sudo for remote commands on a raw+ssh target]' \
+                                        '1:raw target:_files -/'
+                                    ;;
+                                backfill-metadata)
+                                    _arguments \
+                                        '--dry-run[Show what would be backfilled without writing]' \
                                         '--json[Output in JSON format]' \
                                         '--ssh-sudo[Use sudo for remote commands on a raw+ssh target]' \
                                         '1:raw target:_files -/'

--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -1002,6 +1002,39 @@ Raw target: raw:///mnt/usb/backups  (verifying 2 snapshots)
   1 ok, 1 corrupt, 0 error, 0 unverifiable
 ```
 
+#### raw backfill-metadata
+
+Write authoritative `.meta` sidecars for **legacy** raw streams that have none — backups written before sidecars existed (or by another tool such as btrbk). New backups already write their sidecar automatically; this is only for pre-existing streams.
+
+```bash
+btrfs-backup-ng raw backfill-metadata TARGET [OPTIONS]
+```
+
+**Arguments:**
+| Argument | Description |
+|----------|-------------|
+| `TARGET` | Raw target: `raw://PATH`, `raw+ssh://[USER@]HOST/PATH`, or a plain path |
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--dry-run` | Show which streams would be backfilled without writing anything |
+| `--json` | Output per-stream results as JSON |
+| `--ssh-sudo` | Use `sudo` for remote commands on a `raw+ssh://` target |
+
+Each backfilled sidecar records the pipeline inferred from the filename (compression/encryption) and a sha256 of the stream as it exists now, and is stamped `provenance_origin=backfill` with `stream_completeness=unknown`. A legacy stream's completeness cannot be proven (it might have been truncated), so a backfilled sidecar is marked as a **reconstructed, non-authoritative** record — the checksum lets `raw verify` detect later corruption, but does not confirm the original backup was complete. Exit status is `1` if any sidecar write failed, else `0`.
+
+Run `backfill-metadata` when no backup or prune is in flight against the same target: it re-checks for a sidecar immediately before writing (so a concurrently-committed backup is not overwritten), but a per-target lock is not yet in place.
+
+**Example Output:**
+```
+Raw target: raw:///mnt/usb/backups  (2 legacy streams without a sidecar)
+  BACKFILLED      root.20240115T120000
+  BACKFILLED      home.20240115T120000
+  2 backfilled, 0 error
+  Note: backfilled sidecars are marked stream_completeness=unknown -- a legacy stream cannot be proven complete.
+```
+
 ---
 
 ## Filesystem Checks

--- a/man/man1/btrfs-backup-ng-raw.1
+++ b/man/man1/btrfs-backup-ng-raw.1
@@ -8,6 +8,9 @@ btrfs-backup-ng-raw \- inspect and maintain raw-target backups
 .br
 .B btrfs-backup-ng raw verify
 \fITARGET\fR [\fB\-\-snapshot\fR \fINAME\fR] [\fB\-\-json\fR] [\fB\-\-ssh-sudo\fR]
+.br
+.B btrfs-backup-ng raw backfill-metadata
+\fITARGET\fR [\fB\-\-dry-run\fR] [\fB\-\-json\fR] [\fB\-\-ssh-sudo\fR]
 .SH DESCRIPTION
 Operate directly on a raw backup target. Raw targets (\fBraw://\fR and
 \fBraw+ssh://\fR) store btrfs send streams as files for backing up to non-btrfs
@@ -81,6 +84,35 @@ Output per-snapshot results in JSON format.
 .TP
 .B \-\-ssh-sudo
 Use \fBsudo\fR for the remote commands on a \fBraw+ssh://\fR target.
+.SS backfill-metadata
+Write authoritative \fB.meta\fR sidecars for LEGACY streams that have none.
+.PP
+.RS
+.B btrfs-backup-ng raw backfill-metadata
+\fITARGET\fR [\fB\-\-dry-run\fR] [\fB\-\-json\fR] [\fB\-\-ssh-sudo\fR]
+.RE
+.PP
+For backups written before sidecars existed (or by another tool such as btrbk).
+New backups already write their sidecar automatically; this is only for
+pre-existing streams. Each backfilled sidecar records the pipeline inferred from
+the filename and a sha256 of the stream as it exists now, and is stamped
+.B provenance_origin=backfill
+with
+.BR stream_completeness=unknown :
+a legacy stream's completeness cannot be proven, so a backfilled sidecar is a
+reconstructed, non-authoritative record. The checksum lets
+.B raw verify
+detect later corruption, not confirm the original backup was complete. Run this
+command when no backup or prune is in flight against the same target.
+.TP
+.B \-\-dry-run
+Show which streams would be backfilled without writing anything.
+.TP
+.B \-\-json
+Output per-stream results in JSON format.
+.TP
+.B \-\-ssh-sudo
+Use \fBsudo\fR for the remote commands on a \fBraw+ssh://\fR target.
 .SH EXIT STATUS
 .TP
 .B 0
@@ -89,6 +121,8 @@ printed for a missing local path). For \fBverify\fR, all backups are
 .B ok
 or
 .BR unverifiable .
+For \fBbackfill-metadata\fR, all candidate sidecars were written (or none were
+needed).
 .TP
 .B 1
 For \fBlist\fR, the target could not be listed. For \fBverify\fR, at least one
@@ -96,6 +130,7 @@ backup is
 .B corrupt
 or
 .BR error .
+For \fBbackfill-metadata\fR, at least one sidecar could not be written.
 .TP
 .B 2
 Invalid target (for example a non-raw URL scheme), or a
@@ -120,6 +155,12 @@ Verify every backup a target holds:
 .TP
 Verify a single backup on a remote target:
 .B btrfs-backup-ng raw verify raw+ssh://backup@nas/backups --snapshot root.20260101T120000
+.TP
+Preview backfilling sidecars for legacy streams:
+.B btrfs-backup-ng raw backfill-metadata raw:///mnt/usb/backups --dry-run
+.TP
+Backfill sidecars for legacy streams:
+.B btrfs-backup-ng raw backfill-metadata raw:///mnt/usb/backups
 .SH SEE ALSO
 .BR btrfs-backup-ng (1),
 .BR btrfs-backup-ng-restore (1),

--- a/src/btrfs_backup_ng/cli/dispatcher.py
+++ b/src/btrfs_backup_ng/cli/dispatcher.py
@@ -402,6 +402,31 @@ def create_subcommand_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Use sudo for remote commands on a raw+ssh target",
     )
+    raw_backfill_parser = raw_subs.add_parser(
+        "backfill-metadata",
+        help="Write .meta sidecars for legacy streams that have none",
+        description="Reconstruct sidecars for pre-0.8.5 raw streams without one",
+    )
+    raw_backfill_parser.add_argument(
+        "target",
+        metavar="TARGET",
+        help="Raw target: raw://PATH, raw+ssh://[USER@]HOST/PATH, or a plain path",
+    )
+    raw_backfill_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show which streams would be backfilled without writing sidecars",
+    )
+    raw_backfill_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output in JSON format for scripting",
+    )
+    raw_backfill_parser.add_argument(
+        "--ssh-sudo",
+        action="store_true",
+        help="Use sudo for remote commands on a raw+ssh target",
+    )
 
     # install command
     install_parser = subparsers.add_parser(

--- a/src/btrfs_backup_ng/cli/raw_cmd.py
+++ b/src/btrfs_backup_ng/cli/raw_cmd.py
@@ -25,6 +25,8 @@ def execute_raw(args: argparse.Namespace) -> int:
         return _raw_list(args)
     if action == "verify":
         return _raw_verify(args)
+    if action == "backfill-metadata":
+        return _raw_backfill(args)
     # No/unknown action: argparse allows a bare `raw`, so guide the user.
     print("No raw action specified. Try: btrfs-backup-ng raw list <target>")
     return 1
@@ -200,4 +202,87 @@ def _raw_verify(args: argparse.Namespace) -> int:
 
     # Fail if any backup is corrupt or its stream could not be read.
     bad = any(r["status"] in ("corrupt", "error") for r in results)
+    return 1 if bad else 0
+
+
+def _raw_backfill(args: argparse.Namespace) -> int:
+    """Write authoritative ``.meta`` sidecars for LEGACY streams that have none
+    (backups written before sidecars existed).
+
+    Each backfilled sidecar records the pipeline inferred from the filename and a
+    sha256 of the stream as it exists now, but is stamped
+    ``provenance_origin=backfill`` and ``stream_completeness=unknown``: a legacy
+    stream's completeness cannot be verified, so a backfilled sidecar is marked as a
+    reconstructed, non-authoritative record (callers should not assume it is a
+    verified complete backup). ``--dry-run`` reports the candidates without writing.
+    Exit 1 if any sidecar write failed."""
+    try:
+        ep, spec = _open_target(args)
+    except ValueError as e:
+        print(str(e))
+        return 2
+
+    try:
+        candidates = ep.streams_without_sidecar()
+    except Exception as e:  # pragma: no cover - defensive; endpoint errors vary
+        logger.debug("raw backfill-metadata failed", exc_info=True)
+        print(f"Failed to scan {spec}: {e}")
+        return 1
+
+    dry = getattr(args, "dry_run", False)
+    results = []
+    for snap in candidates:
+        entry = {
+            "name": snap.name,
+            "stream": str(snap.stream_path),
+            "compress": snap.compress,
+            "encrypt": snap.encrypt,
+        }
+        if dry:
+            entry["action"] = "would-backfill"
+        else:
+            # Seal a checksum of the stream as it is now (detects later corruption);
+            # completeness stays "unknown" -- this does not prove the legacy stream
+            # is a complete btrfs send.
+            snap.checksum_value = ep.compute_stream_checksum(snap)
+            # Re-check immediately before writing: if a sidecar appeared since the
+            # scan (a backup committed concurrently -- commit publishes the stream
+            # then writes its sidecar as two steps), do NOT overwrite the
+            # authoritative sidecar with a backfill record. (A full per-target lock
+            # covering backup/prune/backfill lands with the raw maintenance lock;
+            # this re-check closes the practical window.)
+            if ep.sidecar_exists(snap):
+                entry["action"] = "skipped"
+                results.append(entry)
+                continue
+            try:
+                ep.write_sidecar(snap)
+                entry["action"] = "backfilled"
+                entry["checksum"] = snap.checksum_value
+            except Exception as e:
+                logger.debug("backfill sidecar write failed", exc_info=True)
+                entry["action"] = "error"
+                entry["error"] = str(e)
+        results.append(entry)
+
+    if getattr(args, "json", False):
+        print(json.dumps(results, indent=2))
+    else:
+        plural = "" if len(results) == 1 else "s"
+        print(
+            f"Raw target: {spec}  "
+            f"({len(results)} legacy stream{plural} without a sidecar)"
+        )
+        for r in results:
+            print(f"  {r['action'].upper():<15} {r['name']}")
+        if not dry and results:
+            n_ok = sum(1 for r in results if r["action"] == "backfilled")
+            n_err = sum(1 for r in results if r["action"] == "error")
+            print(f"  {n_ok} backfilled, {n_err} error")
+            print(
+                "  Note: backfilled sidecars are marked stream_completeness=unknown "
+                "-- a legacy stream cannot be proven complete."
+            )
+
+    bad = any(r["action"] == "error" for r in results)
     return 1 if bad else 0

--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -156,7 +156,12 @@ def _sha256_file(path: Path) -> str | None:
     miss) -- without evicting other data from the cache."""
     try:
         h = hashlib.sha256()
-        with open(path, "rb") as f:
+        # O_NOFOLLOW: never hash through a symlink at the final path component --
+        # a backfill walking an untrusted directory must not be tricked into
+        # hashing (and, with --json, disclosing the digest of) an arbitrary file
+        # via a planted <name>.btrfs symlink.
+        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+        with os.fdopen(fd, "rb") as f:
             fadvise = getattr(os, "posix_fadvise", None)
             dontneed = getattr(os, "POSIX_FADV_DONTNEED", None)
             if fadvise is not None and dontneed is not None:
@@ -586,6 +591,56 @@ class RawEndpoint(Endpoint):
         sidecar's recorded ``checksum_value`` to detect corruption. The raw+ssh
         subclass overrides this to hash on the remote host (no re-download)."""
         return _sha256_file(snapshot.stream_path)
+
+    def sidecar_exists(self, snapshot: RawSnapshot) -> bool:
+        """Whether ``snapshot``'s ``.meta`` sidecar exists now. Used by
+        ``raw backfill-metadata`` to re-check just before writing, so a sidecar that
+        appeared since the scan (e.g. a backup committed concurrently) is not
+        overwritten with a backfill record. The raw+ssh subclass tests the remote."""
+        return snapshot.metadata_path.exists()
+
+    def streams_without_sidecar(self) -> list[RawSnapshot]:
+        """Return backfill candidates: RawSnapshots reconstructed from the filename
+        for streams under this target that have NO ``.meta`` sidecar (legacy
+        backups). Each is stamped ``provenance_origin=backfill`` and
+        ``stream_completeness=unknown`` -- a legacy stream could be truncated, so a
+        backfilled sidecar is never authoritative. The checksum is left None for the
+        caller (``raw backfill-metadata``) to seal by hashing the stream. The raw+ssh
+        subclass overrides this to scan the remote target."""
+        path = Path(self.config["path"])
+        if not path.exists():
+            return []
+        out: list[RawSnapshot] = []
+        for item in sorted(path.iterdir()):
+            # Skip symlinks: this scan writes a sidecar next to each candidate while
+            # walking a directory of foreign/legacy content, so a symlinked "stream"
+            # must not be treated as a real backup (defends the write + the hash).
+            if item.is_symlink() or not item.is_file() or item.suffix == ".meta":
+                continue
+            if item.name.endswith((".part", ".tmp")) or ".btrfs" not in item.name:
+                continue
+            if item.with_name(item.name + ".meta").exists():
+                continue  # already has an authoritative sidecar
+            parsed = parse_stream_filename(item.name)
+            try:
+                stat = item.stat()
+            except OSError:
+                # Raced away or unreadable: skip this one rather than abort the whole
+                # backfill (mirrors the SSH path's stat-failure -> skip).
+                continue
+            out.append(
+                RawSnapshot(
+                    name=parsed["name"],
+                    stream_path=item,
+                    created=datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc),
+                    size=stat.st_size,
+                    compress=parsed["compress"],
+                    encrypt=parsed["encrypt"],
+                    provenance_origin="backfill",
+                    stream_completeness="unknown",
+                )
+            )
+        return out
 
     def _sidecar_snapshot(
         self, final_path: Path, size: int, checksum_value: str | None = None
@@ -1119,6 +1174,104 @@ class SSHRawEndpoint(RawEndpoint):
         re-downloading the stream."""
         return self._remote_sha256(snapshot.stream_path)
 
+    def sidecar_exists(self, snapshot: RawSnapshot) -> bool:
+        """Whether ``snapshot``'s ``.meta`` sidecar exists on the remote now (a
+        pre-write re-check; see the base method)."""
+        meta = shlex.quote(str(snapshot.metadata_path))
+        cmd = f"test -f {meta}"
+        if self.ssh_sudo:
+            cmd = f"sudo sh -c {shlex.quote(cmd)}"
+        try:
+            res = self._exec_remote_command(["sh", "-c", cmd], check=False)
+            return res.returncode == 0
+        except Exception:
+            return False
+
+    def _remote_find(self, pattern: str) -> list[str]:
+        """Return remote file paths that are DIRECT CHILDREN of the target dir and
+        match ``pattern``.
+
+        ``-maxdepth 1`` keeps the scan flat (matching the local ``iterdir`` scan);
+        ``-print0`` (NUL-separated) so a filename containing a newline cannot inject
+        a second, out-of-target path into the result set; and each path is checked to
+        be a direct child of the target dir as defense in depth."""
+        base = str(self.config["path"]).rstrip("/") or "/"
+        find_cmd = (
+            f"find {shlex.quote(base)} -maxdepth 1 "
+            f"-name {shlex.quote(pattern)} -type f -print0 2>/dev/null"
+        )
+        if self.ssh_sudo:
+            find_cmd = f"sudo {find_cmd}"
+        try:
+            res = subprocess.run(
+                self._build_ssh_command() + [find_cmd],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError:
+            return []
+        out: list[str] = []
+        for p in res.stdout.split("\x00"):
+            if not p or "\n" in p:
+                continue
+            if os.path.dirname(p) != base:  # must stay inside the target dir
+                continue
+            out.append(p)
+        return out
+
+    def _remote_stat(self, remote_path: str) -> tuple[datetime | None, int]:
+        """Portable remote mtime+size (GNU ``stat -c``, else BSD/macOS ``stat -f``).
+        Returns ``(created_utc, size)`` or ``(None, 0)`` if it cannot be stat'd."""
+        q = shlex.quote(remote_path)
+        stat_cmd = f"stat -c '%Y %s' {q} 2>/dev/null || stat -f '%m %z' {q}"
+        if self.ssh_sudo:
+            stat_cmd = f"sudo sh -c {shlex.quote(stat_cmd)}"
+        try:
+            res = subprocess.run(
+                self._build_ssh_command() + [stat_cmd],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            mtime_str, size_str = res.stdout.strip().split()
+            return datetime.fromtimestamp(int(mtime_str), tz=timezone.utc), int(
+                size_str
+            )
+        except (subprocess.CalledProcessError, ValueError):
+            return None, 0
+
+    def streams_without_sidecar(self) -> list[RawSnapshot]:
+        """Remote backfill candidates: streams on the remote target with no ``.meta``
+        sidecar. Two remote finds (streams, sidecars) plus a portable stat per
+        candidate. Stamped ``backfill`` / ``unknown`` like the local scan; the
+        checksum is left None for the caller to seal on the remote."""
+        streams = self._remote_find("*.btrfs*")
+        metas = set(self._remote_find("*.meta"))
+        out: list[RawSnapshot] = []
+        for sp in streams:
+            if sp.endswith((".meta", ".part", ".tmp")):
+                continue
+            if sp + ".meta" in metas:
+                continue  # already has an authoritative sidecar
+            created, size = self._remote_stat(sp)
+            if created is None:
+                continue
+            parsed = parse_stream_filename(Path(sp).name)
+            out.append(
+                RawSnapshot(
+                    name=parsed["name"],
+                    stream_path=Path(sp),
+                    created=created,
+                    size=size,
+                    compress=parsed["compress"],
+                    encrypt=parsed["encrypt"],
+                    provenance_origin="backfill",
+                    stream_completeness="unknown",
+                )
+            )
+        return out
+
     def _remote_sha256(self, final_path: Path) -> str | None:
         """Compute the sha256 of the committed remote stream ON the remote host,
         returning the 64-hex digest or None (best-effort).
@@ -1366,6 +1519,8 @@ class SSHRawEndpoint(RawEndpoint):
                 # would sort as newest and distort prune / parent selection. Skip it.
                 logger.debug("Skipping un-stat-able remote stream %s", stream_path_str)
                 continue
+            # Reconstructed from the filename (no authoritative sidecar): mark it
+            # honestly so it is never presented as a native atomic backup.
             snapshots.append(
                 RawSnapshot(
                     name=name,
@@ -1374,6 +1529,8 @@ class SSHRawEndpoint(RawEndpoint):
                     size=size,
                     compress=parsed["compress"],
                     encrypt=parsed["encrypt"],
+                    provenance_origin="filename-inferred",
+                    stream_completeness="unknown",
                 )
             )
             loaded_names.add(name)

--- a/src/btrfs_backup_ng/endpoint/raw_metadata.py
+++ b/src/btrfs_backup_ng/endpoint/raw_metadata.py
@@ -130,6 +130,12 @@ class RawSnapshot:
     # rather than false-flag corruption if a sidecar ever records another algorithm.
     checksum_algorithm: str = "sha256"
     provenance_origin: str = "native-write"
+    # Whether the stream is known to be a COMPLETE btrfs send. "complete" for a
+    # native atomic commit (a failed transfer never commits); "unknown" for a
+    # backfilled or filename-inferred legacy stream, which could be truncated. This
+    # is a MARKER for callers to treat such a record conservatively (do not assume a
+    # verified complete backup); it is not itself an enforced prune guard.
+    stream_completeness: str = "complete"
     # --- Snapshot-interface compatibility (0.8.5) ---
     prefix: str = ""
     time_format: str | None = None
@@ -231,6 +237,7 @@ class RawSnapshot:
             },
             "provenance": {
                 "origin": self.provenance_origin,
+                "stream_completeness": self.stream_completeness,
                 "tool_version": __version__,
             },
             # Kept for backward compatibility with v1 readers.
@@ -248,11 +255,17 @@ class RawSnapshot:
     def save_metadata(self) -> None:
         """Write the sidecar atomically (temp -> fsync -> rename -> dir fsync) at
         mode 0600, so a crash never leaves a partial/half-written .meta and the
-        metadata dossier is not world-readable."""
+        metadata dossier is not world-readable.
+
+        O_NOFOLLOW on the temp open refuses to follow a symlink at the ``.meta.tmp``
+        path: writing while walking an untrusted directory (``raw backfill-metadata``
+        over a target with foreign/legacy content, typically as root) must not let a
+        pre-planted ``<name>.meta.tmp`` symlink redirect the O_CREAT|O_TRUNC write to
+        an arbitrary file."""
         meta = self.metadata_path
         tmp = meta.with_name(meta.name + ".tmp")
         payload = self.serialize()
-        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
         try:
             os.write(fd, payload)
             os.fsync(fd)
@@ -301,6 +314,7 @@ class RawSnapshot:
             checksum_value=checksum.get("value"),
             checksum_algorithm=checksum.get("algorithm") or "sha256",
             provenance_origin=provenance.get("origin", "native-write"),
+            stream_completeness=provenance.get("stream_completeness") or "complete",
         )
 
     @classmethod
@@ -463,7 +477,10 @@ def discover_raw_snapshots(
         if prefix and not name.startswith(prefix):
             continue
 
-        # Create snapshot from filename parsing
+        # Create snapshot from filename parsing. Mark it honestly: this record was
+        # reconstructed from the filename (no authoritative sidecar), so its origin
+        # is "filename-inferred" and its completeness is unknown -- never present it
+        # as a native atomic backup.
         stat = item.stat()
         snapshot = RawSnapshot(
             name=name,
@@ -472,6 +489,8 @@ def discover_raw_snapshots(
             size=stat.st_size,
             compress=parsed["compress"],
             encrypt=parsed["encrypt"],
+            provenance_origin="filename-inferred",
+            stream_completeness="unknown",
         )
         snapshots.append(snapshot)
 

--- a/tests/test_raw_backfill.py
+++ b/tests/test_raw_backfill.py
@@ -1,0 +1,315 @@
+"""raw backfill-metadata (0.8.5 PR6d).
+
+Writes authoritative .meta sidecars for LEGACY streams that have none, stamped
+provenance_origin=backfill and stream_completeness=unknown -- a legacy stream's
+completeness cannot be proven, so a backfilled sidecar is never authoritative.
+"""
+
+import argparse
+import json
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+from btrfs_backup_ng.endpoint import raw as raw_mod
+from btrfs_backup_ng.cli import raw_cmd
+from btrfs_backup_ng.endpoint.raw import RawEndpoint, SSHRawEndpoint
+from btrfs_backup_ng.endpoint.raw_metadata import RawSnapshot, discover_raw_snapshots
+
+
+def _legacy_stream(path, name, *, compress=None, encrypt=None):
+    """Create a committed backup then remove its sidecar (a pre-0.8.5 stream)."""
+    cfg = {"path": str(path)}
+    if compress:
+        cfg["compress"] = compress
+    if encrypt:
+        cfg["encrypt"] = encrypt
+        cfg["openssl_cipher"] = "aes-256-cbc"
+    ep = RawEndpoint(config=cfg)
+    src = path / (name + ".src")
+    src.write_bytes(b"legacy-" * 300)
+    with open(src, "rb") as f:
+        ep.receive(f, snapshot_name=name).communicate()
+    ep.commit_receive()
+    src.unlink()
+    # Strip the sidecar to simulate a legacy backup written before sidecars.
+    for meta in path.glob(f"{name}.btrfs*.meta"):
+        meta.unlink()
+
+
+def _args(**kw):
+    ns = argparse.Namespace()
+    for k, v in kw.items():
+        setattr(ns, k, v)
+    return ns
+
+
+def _backfill(tmp_path, **kw):
+    base = {
+        "raw_action": "backfill-metadata",
+        "target": str(tmp_path),
+        "dry_run": False,
+        "json": False,
+    }
+    base.update(kw)
+    return raw_cmd.execute_raw(_args(**base))
+
+
+# --------------------------------------------------------------------------- #
+# candidate discovery
+# --------------------------------------------------------------------------- #
+def test_streams_without_sidecar_finds_only_sidecarless(tmp_path, monkeypatch):
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "x")
+    _legacy_stream(tmp_path, "legacy")  # no sidecar
+    # A backup WITH a sidecar (not a candidate).
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    src = tmp_path / "kept.src"
+    src.write_bytes(b"kept")
+    with open(src, "rb") as f:
+        ep.receive(f, snapshot_name="kept").communicate()
+    ep.commit_receive()
+    src.unlink()
+
+    cands = ep.streams_without_sidecar()
+    names = {c.name for c in cands}
+    assert "legacy" in names
+    assert "kept" not in names  # already has a sidecar
+    # Candidates are stamped honestly.
+    (leg,) = [c for c in cands if c.name == "legacy"]
+    assert leg.provenance_origin == "backfill"
+    assert leg.stream_completeness == "unknown"
+
+
+# --------------------------------------------------------------------------- #
+# honest labeling of sidecar-less streams (pre-backfill)
+# --------------------------------------------------------------------------- #
+def test_filename_inferred_snapshot_is_labeled_honestly(tmp_path):
+    _legacy_stream(tmp_path, "leg")
+    (snap,) = discover_raw_snapshots(tmp_path)
+    assert snap.provenance_origin == "filename-inferred"
+    assert snap.stream_completeness == "unknown"
+
+
+# --------------------------------------------------------------------------- #
+# backfill outcomes
+# --------------------------------------------------------------------------- #
+def test_backfill_writes_unknown_completeness_sidecar(tmp_path):
+    _legacy_stream(tmp_path, "root.20240101T120000", compress="gzip")
+    rc = _backfill(tmp_path)
+    assert rc == 0
+    meta = next(tmp_path.glob("*.meta"))
+    doc = json.loads(meta.read_text())
+    # A legacy stream must NEVER be blessed as complete/native.
+    assert doc["provenance"]["origin"] == "backfill"
+    assert doc["provenance"]["stream_completeness"] == "unknown"
+    assert doc["pipeline"]["compress"] == "gzip"
+    assert doc["checksum"]["value"] is not None  # sealed by hashing the stream
+
+
+def test_backfill_then_verify_is_ok(tmp_path):
+    _legacy_stream(tmp_path, "root.20240101T120000")
+    assert _backfill(tmp_path) == 0
+    rc = raw_cmd.execute_raw(
+        _args(
+            raw_action="verify",
+            target=str(tmp_path),
+            snapshot=None,
+            json=False,
+        )
+    )
+    assert rc == 0  # the sealed checksum matches the stream
+
+
+def test_backfill_dry_run_writes_nothing(tmp_path, capsys):
+    _legacy_stream(tmp_path, "root.20240101T120000")
+    rc = _backfill(tmp_path, dry_run=True)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "WOULD-BACKFILL" in out
+    assert list(tmp_path.glob("*.meta")) == []  # nothing written
+
+
+def test_backfill_no_candidates(tmp_path, capsys):
+    """A target with only sidecar-backed backups has nothing to backfill."""
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    src = tmp_path / "s.src"
+    src.write_bytes(b"data")
+    with open(src, "rb") as f:
+        ep.receive(f, snapshot_name="s").communicate()
+    ep.commit_receive()
+    src.unlink()
+    rc = _backfill(tmp_path)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "0 legacy stream" in out
+
+
+def test_backfill_json_output(tmp_path, capsys):
+    _legacy_stream(tmp_path, "root.20240101T120000", compress="gzip")
+    rc = _backfill(tmp_path, json=True)
+    data = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert data[0]["name"] == "root.20240101T120000"
+    assert data[0]["action"] == "backfilled"
+    assert data[0]["compress"] == "gzip"
+
+
+# --------------------------------------------------------------------------- #
+# remote (raw+ssh) candidate discovery
+# --------------------------------------------------------------------------- #
+def test_ssh_streams_without_sidecar(monkeypatch):
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+    # Two streams; one already has a sidecar.
+    ep._remote_find = lambda pattern: (
+        ["/backup/legacy.btrfs.gz", "/backup/kept.btrfs"]
+        if pattern == "*.btrfs*"
+        else ["/backup/kept.btrfs.meta"]
+    )
+    ep._remote_stat = lambda p: (datetime(2024, 1, 1, tzinfo=timezone.utc), 123)
+    cands = ep.streams_without_sidecar()
+    names = {c.name for c in cands}
+    assert names == {"legacy"}  # kept has a sidecar
+    (leg,) = cands
+    assert leg.provenance_origin == "backfill"
+    assert leg.stream_completeness == "unknown"
+    assert leg.compress == "gzip"
+
+
+# --------------------------------------------------------------------------- #
+# schema round-trip + dispatcher
+# --------------------------------------------------------------------------- #
+def test_stream_completeness_round_trips(tmp_path):
+    snap = RawSnapshot(
+        name="s",
+        stream_path=tmp_path / "s.btrfs",
+        provenance_origin="backfill",
+        stream_completeness="unknown",
+    )
+    doc = snap.to_dict()
+    assert doc["provenance"]["stream_completeness"] == "unknown"
+    restored = RawSnapshot.from_dict(doc, tmp_path / "s.btrfs")
+    assert restored.stream_completeness == "unknown"
+    # Legacy sidecar without the field defaults to "complete".
+    doc["provenance"].pop("stream_completeness")
+    assert (
+        RawSnapshot.from_dict(doc, tmp_path / "s.btrfs").stream_completeness
+        == "complete"
+    )
+
+
+def test_dispatcher_parses_raw_backfill():
+    from btrfs_backup_ng.cli.dispatcher import create_subcommand_parser
+
+    parser = create_subcommand_parser()
+    args = parser.parse_args(
+        ["raw", "backfill-metadata", "/x", "--dry-run", "--json", "--ssh-sudo"]
+    )
+    assert args.command == "raw"
+    assert args.raw_action == "backfill-metadata"
+    assert args.target == "/x"
+    assert args.dry_run is True
+    assert args.json is True
+    assert args.ssh_sudo is True
+
+
+def test_native_backup_stays_complete(tmp_path):
+    """A native atomic backup's sidecar must record stream_completeness=complete
+    (only legacy/backfill/filename-inferred are 'unknown')."""
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    src = tmp_path / "s.src"
+    src.write_bytes(b"data")
+    with open(src, "rb") as f:
+        ep.receive(f, snapshot_name="s").communicate()
+    ep.commit_receive()
+    (snap,) = discover_raw_snapshots(tmp_path)
+    assert snap.provenance_origin == "native-write"
+    assert snap.stream_completeness == "complete"
+
+
+# --------------------------------------------------------------------------- #
+# security: symlink handling (backfill writes while walking an untrusted dir)
+# --------------------------------------------------------------------------- #
+def test_backfill_symlinked_meta_tmp_cannot_truncate_outside_file(tmp_path):
+    """A pre-planted <name>.meta.tmp symlink must NOT let the O_CREAT|O_TRUNC write
+    redirect to an arbitrary file (O_NOFOLLOW in save_metadata). The outside file
+    stays intact and no sidecar is written for the malicious candidate."""
+    outside = tmp_path / "outside.secret"
+    outside.write_text("DO-NOT-TRUNCATE")
+    stream = tmp_path / "pwn.btrfs"
+    stream.write_bytes(b"payload")
+    (tmp_path / "pwn.btrfs.meta.tmp").symlink_to(outside)
+
+    _backfill(tmp_path)  # rc may be 1 (write errored); the point is no damage
+    assert outside.read_text() == "DO-NOT-TRUNCATE"  # never truncated
+    assert not (tmp_path / "pwn.btrfs.meta").exists()
+
+
+def test_backfill_skips_symlinked_stream(tmp_path):
+    """A symlinked 'stream' is not a backfill candidate (defends the write + hash
+    against a <name>.btrfs symlink pointing at an arbitrary file)."""
+    real = tmp_path / "real.dat"
+    real.write_bytes(b"x")
+    (tmp_path / "link.btrfs").symlink_to(real)
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    assert ep.streams_without_sidecar() == []
+
+
+# --------------------------------------------------------------------------- #
+# concurrency: re-check before write, so a racing commit is not overwritten
+# --------------------------------------------------------------------------- #
+def test_backfill_rechecks_and_skips_if_sidecar_appears(tmp_path, monkeypatch, capsys):
+    """If a sidecar appears between the scan and the write (a backup committed
+    concurrently), backfill must SKIP -- never overwrite an authoritative sidecar
+    with a backfill record. Dropping the re-check would clobber it."""
+    _legacy_stream(tmp_path, "root.20240101T120000")
+    monkeypatch.setattr(RawEndpoint, "sidecar_exists", lambda self, snap: True)
+    rc = _backfill(tmp_path)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "SKIPPED" in out
+    assert list(tmp_path.glob("*.meta")) == []  # nothing written
+
+
+# --------------------------------------------------------------------------- #
+# security: remote find output must stay inside the target dir
+# --------------------------------------------------------------------------- #
+def test_remote_find_rejects_out_of_target_paths(monkeypatch):
+    """A crafted remote filename containing a newline (or any path outside the
+    target dir) must not inject an out-of-target write target."""
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+    ep._build_ssh_command = lambda: ["ssh", "nas"]
+    fake = MagicMock(returncode=0, stdout="/backup/ok.btrfs\x00/etc/passwd\x00")
+    monkeypatch.setattr(raw_mod.subprocess, "run", lambda *a, **k: fake)
+    assert ep._remote_find("*.btrfs*") == ["/backup/ok.btrfs"]
+
+
+def test_ssh_list_snapshots_stamps_filename_inferred(monkeypatch):
+    """A remote sidecar-less stream comes back from list_snapshots stamped
+    filename-inferred/unknown (never native-write/complete)."""
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+    ep._build_ssh_command = lambda: ["ssh", "nas"]
+    seq = [
+        MagicMock(returncode=0, stdout=""),  # find *.meta -> none
+        MagicMock(returncode=0, stdout="/backup/legacy.btrfs.gz"),  # find *.btrfs*
+        MagicMock(returncode=0, stdout="1704067200 123"),  # stat mtime size
+    ]
+    monkeypatch.setattr(raw_mod.subprocess, "run", MagicMock(side_effect=seq))
+    snaps = ep.list_snapshots(flush_cache=True)
+    assert len(snaps) == 1
+    assert snaps[0].provenance_origin == "filename-inferred"
+    assert snaps[0].stream_completeness == "unknown"
+
+
+# --------------------------------------------------------------------------- #
+# empty / nonexistent target
+# --------------------------------------------------------------------------- #
+def test_backfill_nonexistent_target(tmp_path, capsys):
+    rc = _backfill(tmp_path, target=str(tmp_path / "nope"))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "0 legacy stream" in out
+
+
+def test_ssh_streams_without_sidecar_empty(monkeypatch):
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+    ep._remote_find = lambda pattern: []
+    assert ep.streams_without_sidecar() == []


### PR DESCRIPTION
## 0.8.5 PR6d — `raw backfill-metadata`

Writes authoritative `.meta` sidecars for **legacy** raw streams that have none (pre-sidecar backups, or btrbk-written). New backups already write their own sidecar; this is the migration path for pre-existing streams.

### Behavior
- `raw backfill-metadata TARGET [--dry-run] [--json] [--ssh-sudo]` — for each sidecar-less stream, records the filename-inferred pipeline + a sha256 of the stream, stamped `provenance_origin=backfill` / `stream_completeness=unknown` (a legacy stream can't be proven complete — reconstructed, not authoritative). `--dry-run` writes nothing.
- New `stream_completeness` field (additive: old sidecars read back `complete`; native atomic backups stay `complete`). The filename-inference passes now label sidecar-less streams **`filename-inferred` / `unknown`** instead of the misleading `native-write` — so `raw list`/`verify` are honest.
- Local + raw+ssh (remote hash, no re-download).

### Full 4-lens review — every finding fixed (all mutation-verified)
- 🟠 **HIGH (symlink write attack):** backfill writes while walking an untrusted dir as root; `save_metadata` opened `.meta.tmp` without `O_NOFOLLOW` → a planted `.meta.tmp` symlink could truncate an arbitrary root file. Fixed: `O_NOFOLLOW` on the sidecar tmp + `_sha256_file`, and the scan skips symlinks.
- 🟠 **HIGH (concurrency):** `commit_receive` publishes stream then sidecar in two steps; a racing backfill could mislabel a native backup. Fixed: re-check for a sidecar immediately before writing (skip if it appeared). The full per-target lock (backup/prune/backfill) lands in the raw maintenance lock (PR6e); documented run-when-idle until then.
- 🟡 **MEDIUM (remote path-injection):** `find` output split on `\n` let a crafted remote filename inject an out-of-target path. Fixed: `find -maxdepth 1 -print0` + reject any path not a direct child of the target.
- Robustness: guarded local `stat()`; softened the over-claimed "never auto-pruned" wording to "marker, not enforced guard"; added the SSH `list_snapshots` stamping test + empty/nonexistent-target tests.

### Proof
- 18 mutation-verified tests; full suite `2227 passed`; ruff/format@0.15.22/mypy/completions/man all clean.
- **Hardware-proven on a real macOS host** (both before and after the security hardening): legacy stream → backfill → sidecar `origin=backfill, completeness=unknown` → verify OK → teardown.

Follows #21–#29. Next: **PR6e `raw encrypt`** (plaintext-shred remediation + the per-target lock) — gated on explicit sign-off.
