### PR TITLE
feat(cli): add raw encrypt to remediate plaintext raw backups

### DIFF
--- a/completions/btrfs-backup-ng.bash
+++ b/completions/btrfs-backup-ng.bash
@@ -11,7 +11,7 @@ _btrfs_backup_ng() {
     local manpages_subcommands="install path"
     local transfers_subcommands="list show resume pause cleanup operations"
     local snapper_subcommands="detect list backup status restore generate-config"
-    local raw_subcommands="list verify backfill-metadata"
+    local raw_subcommands="list verify backfill-metadata encrypt"
 
     # Global options
     local global_opts="-h --help -v --verbose -q --quiet --debug -V --version -c --config"
@@ -49,6 +49,7 @@ _btrfs_backup_ng() {
     local raw_list_opts="--json --ssh-sudo"
     local raw_verify_opts="--snapshot --json --ssh-sudo"
     local raw_backfill_opts="--dry-run --json --ssh-sudo"
+    local raw_encrypt_opts="--encrypt --gpg-recipient --openssl-cipher --shred --yes --dry-run --json"
     local snapper_types="single pre post"
     local verify_levels="metadata stream full"
     local shell_types="bash zsh fish"
@@ -89,9 +90,9 @@ _btrfs_backup_ng() {
                     subcmd="verify"
                 fi
                 ;;
-            backfill-metadata)
+            backfill-metadata|encrypt)
                 if [[ "$cmd" == "raw" ]]; then
-                    subcmd="backfill-metadata"
+                    subcmd="${words[i]}"
                 fi
                 ;;
             validate|init|import|detect)
@@ -404,6 +405,15 @@ _btrfs_backup_ng() {
                     backfill-metadata)
                         if [[ "$cur" == -* ]]; then
                             COMPREPLY=($(compgen -W "$raw_backfill_opts" -- "$cur"))
+                        else
+                            _filedir -d
+                        fi
+                        ;;
+                    encrypt)
+                        if [[ "$prev" == "--encrypt" ]]; then
+                            COMPREPLY=($(compgen -W "gpg openssl_enc" -- "$cur"))
+                        elif [[ "$cur" == -* ]]; then
+                            COMPREPLY=($(compgen -W "$raw_encrypt_opts" -- "$cur"))
                         else
                             _filedir -d
                         fi

--- a/completions/btrfs-backup-ng.fish
+++ b/completions/btrfs-backup-ng.fish
@@ -354,6 +354,7 @@ complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_snapper_using_subcommand 
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_using_command raw' -a list -d 'List the backups a raw target holds'
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_using_command raw' -a verify -d 'Verify raw backups against their recorded checksums'
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_using_command raw' -a backfill-metadata -d 'Write .meta sidecars for legacy streams that have none'
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_using_command raw' -a encrypt -d 'Encrypt plaintext raw streams in place (remediation)'
 
 # Helper for raw subcommand
 function __fish_btrfs_backup_ng_raw_using_subcommand
@@ -385,3 +386,13 @@ complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand back
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand backfill-metadata' -l json -d 'Output in JSON format'
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand backfill-metadata' -l ssh-sudo -d 'Use sudo for remote commands on a raw+ssh target'
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand backfill-metadata' -a '(__fish_complete_directories)' -d 'Raw target path'
+
+# raw encrypt
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand encrypt' -l encrypt -d 'Encryption method' -xa 'gpg openssl_enc'
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand encrypt' -l gpg-recipient -d 'GPG recipient key' -x
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand encrypt' -l openssl-cipher -d 'OpenSSL cipher' -x
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand encrypt' -l shred -d 'Remove plaintext after a verified decrypt proof'
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand encrypt' -l yes -d 'Do not prompt before removing plaintext'
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand encrypt' -l dry-run -d 'Show what would be encrypted without changes'
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand encrypt' -l json -d 'Output in JSON format'
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_raw_using_subcommand encrypt' -a '(__fish_complete_directories)' -d 'Raw target path'

--- a/completions/btrfs-backup-ng.zsh
+++ b/completions/btrfs-backup-ng.zsh
@@ -399,6 +399,7 @@ _btrfs-backup-ng() {
                         'list:List the backups a raw target holds'
                         'verify:Verify raw backups against their recorded checksums'
                         'backfill-metadata:Write .meta sidecars for legacy streams'
+                        'encrypt:Encrypt plaintext raw streams in place (remediation)'
                     )
                     _arguments \
                         '1: :->raw_cmd' \
@@ -428,6 +429,17 @@ _btrfs-backup-ng() {
                                         '--dry-run[Show what would be backfilled without writing]' \
                                         '--json[Output in JSON format]' \
                                         '--ssh-sudo[Use sudo for remote commands on a raw+ssh target]' \
+                                        '1:raw target:_files -/'
+                                    ;;
+                                encrypt)
+                                    _arguments \
+                                        '--encrypt[Encryption method]:method:(gpg openssl_enc)' \
+                                        '--gpg-recipient[GPG recipient key]:keyid:' \
+                                        '--openssl-cipher[OpenSSL cipher]:cipher:' \
+                                        '--shred[Remove plaintext after a verified decrypt proof]' \
+                                        '--yes[Do not prompt before removing plaintext]' \
+                                        '--dry-run[Show what would be encrypted without changes]' \
+                                        '--json[Output in JSON format]' \
                                         '1:raw target:_files -/'
                                     ;;
                             esac

--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -1035,6 +1035,39 @@ Raw target: raw:///mnt/usb/backups  (2 legacy streams without a sidecar)
   Note: backfilled sidecars are marked stream_completeness=unknown -- a legacy stream cannot be proven complete.
 ```
 
+#### raw encrypt
+
+Encrypt raw streams that were written as **plaintext** — remediation for backups affected by [GHSA-vr25-6vrh-869j](https://github.com/berrym/btrfs-backup-ng/security/advisories/GHSA-vr25-6vrh-869j), where an `encrypt=` config on a raw target could silently write plaintext (fixed in 0.8.4). Runs **locally only** so the passphrase/keys never leave the host; for a remote target, mount it and use a `raw://` path.
+
+```bash
+btrfs-backup-ng raw encrypt TARGET --encrypt {gpg|openssl_enc} [OPTIONS]
+```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--encrypt {gpg,openssl_enc}` | Encryption method to apply (required) |
+| `--gpg-recipient KEYID` | GPG recipient (required with `--encrypt gpg`) |
+| `--openssl-cipher CIPHER` | OpenSSL cipher for `openssl_enc` (default `aes-256-cbc`) |
+| `--shred` | Remove each plaintext file after a verified decrypt proof |
+| `--yes` | Do not prompt before removing plaintext (for scripts; with `--shred`) |
+| `--dry-run` | Show which plaintext streams would be encrypted, without changes |
+| `--json` | Per-stream results as JSON |
+
+For each plaintext stream, `raw encrypt` writes an encrypted copy alongside it (a new authoritative sidecar with `provenance.origin=remediation` and `remediated_from`), then runs a **live decrypt-to-identical proof** — it decrypts the new stream and confirms it is byte-identical to the plaintext.
+
+The plaintext is removed **only** when that proof passes **and** `--shred` was given (by default the plaintext is kept). For `gpg`, the proof needs the secret key on this host; if it is absent, the encrypted copy is written but the plaintext is kept.
+
+> **Erasure caveat.** `--shred` removes the plaintext with a plain `unlink`. On copy-on-write filesystems (btrfs) and on SSDs, this does **not** securely erase the underlying blocks (btrfs writes new blocks; SSD controllers remap them). True physical erasure relies on device-level `trim`/`discard` or full-disk encryption at rest, which this tool cannot provide — and prior exposure (older backup media, indexes) cannot be undone.
+
+**Example:**
+```bash
+# encrypt plaintext backups with openssl (BTRFS_BACKUP_PASSPHRASE set), keep plaintext:
+btrfs-backup-ng raw encrypt raw:///mnt/usb/backups --encrypt openssl_enc
+# ...then remove the plaintext after the verified proof:
+btrfs-backup-ng raw encrypt raw:///mnt/usb/backups --encrypt openssl_enc --shred
+```
+
 ---
 
 ## Filesystem Checks

--- a/man/man1/btrfs-backup-ng-raw.1
+++ b/man/man1/btrfs-backup-ng-raw.1
@@ -11,6 +11,9 @@ btrfs-backup-ng-raw \- inspect and maintain raw-target backups
 .br
 .B btrfs-backup-ng raw backfill-metadata
 \fITARGET\fR [\fB\-\-dry-run\fR] [\fB\-\-json\fR] [\fB\-\-ssh-sudo\fR]
+.br
+.B btrfs-backup-ng raw encrypt
+\fITARGET\fR \fB\-\-encrypt\fR \fIMETHOD\fR [\fB\-\-shred\fR] [\fIOPTIONS\fR]
 .SH DESCRIPTION
 Operate directly on a raw backup target. Raw targets (\fBraw://\fR and
 \fBraw+ssh://\fR) store btrfs send streams as files for backing up to non-btrfs
@@ -113,6 +116,57 @@ Output per-stream results in JSON format.
 .TP
 .B \-\-ssh-sudo
 Use \fBsudo\fR for the remote commands on a \fBraw+ssh://\fR target.
+.SS encrypt
+Encrypt raw streams that were written as plaintext (remediation for
+GHSA-vr25-6vrh-869j).
+.PP
+.RS
+.B btrfs-backup-ng raw encrypt
+\fITARGET\fR \fB\-\-encrypt\fR \fIMETHOD\fR [\fB\-\-gpg-recipient\fR \fIKEYID\fR]
+[\fB\-\-openssl-cipher\fR \fICIPHER\fR] [\fB\-\-shred\fR] [\fB\-\-yes\fR]
+[\fB\-\-dry-run\fR] [\fB\-\-json\fR]
+.RE
+.PP
+Runs LOCALLY only so the passphrase/keys never leave this host; for a remote
+target, mount it and use a \fBraw://\fR path. For each plaintext stream, writes an
+encrypted copy alongside it (new sidecar, \fBprovenance.origin=remediation\fR), then
+runs a LIVE decrypt-to-identical proof (decrypts the new stream and confirms it is
+byte-identical to the plaintext). The plaintext is removed ONLY when that proof
+passes AND
+.B \-\-shred
+was given; by default it is kept. For gpg the proof needs the secret key on this
+host -- if absent, the encrypted copy is written but the plaintext is kept.
+.PP
+.B \-\-shred
+removes the plaintext with a plain unlink. On copy-on-write filesystems (btrfs) and
+SSDs this does NOT securely erase the underlying blocks; true physical erasure
+relies on device-level trim/discard or full-disk encryption at rest, which this tool
+cannot provide, and prior exposure cannot be undone.
+.TP
+.BI \-\-encrypt " METHOD"
+Encryption method to apply:
+.B gpg
+or
+.BR openssl_enc .
+Required.
+.TP
+.BI \-\-gpg-recipient " KEYID"
+GPG recipient key (required with \fB\-\-encrypt gpg\fR).
+.TP
+.BI \-\-openssl-cipher " CIPHER"
+OpenSSL cipher for \fBopenssl_enc\fR (default aes-256-cbc).
+.TP
+.B \-\-shred
+Remove each plaintext file after a verified decrypt proof (plain unlink).
+.TP
+.B \-\-yes
+Do not prompt before removing plaintext (for scripts; with \fB\-\-shred\fR).
+.TP
+.B \-\-dry-run
+Show which plaintext streams would be encrypted, without changes.
+.TP
+.B \-\-json
+Output per-stream results in JSON format.
 .SH EXIT STATUS
 .TP
 .B 0
@@ -130,7 +184,9 @@ backup is
 .B corrupt
 or
 .BR error .
-For \fBbackfill-metadata\fR, at least one sidecar could not be written.
+For \fBbackfill-metadata\fR, at least one sidecar could not be written. For
+\fBencrypt\fR, a stream could not be encrypted, or \fB\-\-shred\fR was requested but
+a plaintext could not be safely removed (proof failed or unlink error).
 .TP
 .B 2
 Invalid target (for example a non-raw URL scheme), or a
@@ -161,6 +217,12 @@ Preview backfilling sidecars for legacy streams:
 .TP
 Backfill sidecars for legacy streams:
 .B btrfs-backup-ng raw backfill-metadata raw:///mnt/usb/backups
+.TP
+Encrypt plaintext backups with openssl (keeping the plaintext):
+.B btrfs-backup-ng raw encrypt raw:///mnt/usb/backups --encrypt openssl_enc
+.TP
+Encrypt and then remove the plaintext after a verified proof:
+.B btrfs-backup-ng raw encrypt raw:///mnt/usb/backups --encrypt openssl_enc --shred
 .SH SEE ALSO
 .BR btrfs-backup-ng (1),
 .BR btrfs-backup-ng-restore (1),

--- a/src/btrfs_backup_ng/cli/dispatcher.py
+++ b/src/btrfs_backup_ng/cli/dispatcher.py
@@ -427,6 +427,59 @@ def create_subcommand_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Use sudo for remote commands on a raw+ssh target",
     )
+    raw_encrypt_parser = raw_subs.add_parser(
+        "encrypt",
+        help="Encrypt plaintext raw streams in place (remediation)",
+        description="Encrypt raw backups written as plaintext; verify then optionally"
+        " remove the plaintext",
+    )
+    raw_encrypt_parser.add_argument(
+        "target",
+        metavar="TARGET",
+        help="Local raw target: raw://PATH or a plain path (not raw+ssh)",
+    )
+    raw_encrypt_parser.add_argument(
+        "--encrypt",
+        required=True,
+        choices=["gpg", "openssl_enc"],
+        help="Encryption method to apply",
+    )
+    raw_encrypt_parser.add_argument(
+        "--gpg-recipient",
+        metavar="KEYID",
+        help="GPG recipient key (required with --encrypt gpg)",
+    )
+    raw_encrypt_parser.add_argument(
+        "--gpg-keyring",
+        metavar="FILE",
+        help="Use a non-default GPG keyring for encrypt and the decrypt proof",
+    )
+    raw_encrypt_parser.add_argument(
+        "--openssl-cipher",
+        metavar="CIPHER",
+        help="OpenSSL cipher for --encrypt openssl_enc (default aes-256-cbc)",
+    )
+    raw_encrypt_parser.add_argument(
+        "--shred",
+        action="store_true",
+        help="Remove each plaintext file after a verified decrypt proof "
+        "(plain unlink; not a secure wipe on CoW/SSD)",
+    )
+    raw_encrypt_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Do not prompt before removing plaintext (for scripts; with --shred)",
+    )
+    raw_encrypt_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show which plaintext streams would be encrypted without changes",
+    )
+    raw_encrypt_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output in JSON format for scripting",
+    )
 
     # install command
     install_parser = subparsers.add_parser(

--- a/src/btrfs_backup_ng/cli/raw_cmd.py
+++ b/src/btrfs_backup_ng/cli/raw_cmd.py
@@ -11,11 +11,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
 from btrfs_backup_ng import endpoint
 from btrfs_backup_ng.__logger__ import logger
+from btrfs_backup_ng.endpoint import raw as raw_mod
+from btrfs_backup_ng.endpoint.raw_metadata import RawSnapshot
 
 
 def execute_raw(args: argparse.Namespace) -> int:
@@ -27,6 +30,8 @@ def execute_raw(args: argparse.Namespace) -> int:
         return _raw_verify(args)
     if action == "backfill-metadata":
         return _raw_backfill(args)
+    if action == "encrypt":
+        return _raw_encrypt(args)
     # No/unknown action: argparse allows a bare `raw`, so guide the user.
     print("No raw action specified. Try: btrfs-backup-ng raw list <target>")
     return 1
@@ -285,4 +290,186 @@ def _raw_backfill(args: argparse.Namespace) -> int:
             )
 
     bad = any(r["action"] == "error" for r in results)
+    return 1 if bad else 0
+
+
+def _raw_encrypt(args: argparse.Namespace) -> int:
+    """Encrypt plaintext raw streams in place (remediation for backups written as
+    plaintext despite an encrypt config -- GHSA-vr25-6vrh-869j).
+
+    For each plaintext stream: write an encrypted copy (new sidecar,
+    provenance_origin=remediation), then run a LIVE decrypt-to-identical proof
+    (decrypt the new stream and confirm it is byte-identical to the plaintext). The
+    plaintext is removed ONLY when that proof passes AND ``--shred`` was given -- and
+    even then by a plain unlink: on copy-on-write filesystems (btrfs) and SSDs an
+    overwrite does not erase the underlying blocks, so true physical erasure relies
+    on device-level trim/discard or full-disk encryption, which this tool cannot
+    provide. Prior plaintext exposure (old media, indexes) cannot be undone."""
+    spec = _coerce_raw_spec(args.target)
+    if spec.startswith("raw+ssh://"):
+        print(
+            "raw encrypt runs locally so the passphrase/keys never leave this host. "
+            "For a remote target, mount it locally and use a raw:// path."
+        )
+        return 2
+
+    try:
+        ep, spec = _open_target(args)
+    except ValueError as e:
+        print(str(e))
+        return 2
+
+    encrypt = args.encrypt
+    if encrypt == "gpg" and not getattr(args, "gpg_recipient", None):
+        print("--gpg-recipient is required with --encrypt gpg")
+        return 2
+    if encrypt == "openssl_enc" and raw_mod._selected_passphrase_env() is None:
+        print(
+            "openssl_enc requires a passphrase in BTRFS_BACKUP_PASSPHRASE or "
+            "BTRBK_PASSPHRASE"
+        )
+        return 2
+
+    try:
+        snapshots = ep.list_snapshots(flush_cache=True)
+    except Exception as e:  # pragma: no cover - defensive; endpoint errors vary
+        logger.debug("raw encrypt failed", exc_info=True)
+        print(f"Failed to list {spec}: {e}")
+        return 1
+    plaintext = [s for s in snapshots if not s.encrypt]
+    if not plaintext:
+        print(f"Raw target: {spec}  (no plaintext streams to encrypt)")
+        return 0
+
+    dry = getattr(args, "dry_run", False)
+    shred = getattr(args, "shred", False)
+    cipher = getattr(args, "openssl_cipher", None) or "aes-256-cbc"
+    gpg_recipient = getattr(args, "gpg_recipient", None)
+    gpg_keyring = getattr(args, "gpg_keyring", None)
+    ext = ".gpg" if encrypt == "gpg" else ".enc"
+    # The decrypt proof (and any pre-existing-twin check) uses this endpoint's
+    # send(); make it use the requested gpg keyring so encrypt and verify agree.
+    if gpg_keyring:
+        ep.gpg_keyring = gpg_keyring
+
+    # Destructive-op confirmation: --shred is the opt-in; an interactive TTY still
+    # confirms unless --yes was passed (mirrors restore's dangerous-op pattern). The
+    # prompt goes to stderr so --json output on stdout stays clean.
+    if shred and not dry and not getattr(args, "yes", False) and sys.stdin.isatty():
+        print(
+            f"About to encrypt {len(plaintext)} plaintext stream(s) and, after a "
+            "verified decrypt proof, DELETE each plaintext file (plain unlink; not a "
+            "secure wipe -- see --help). Continue? [y/N] ",
+            end="",
+            file=sys.stderr,
+        )
+        if input().strip().lower() not in ("y", "yes"):
+            print("Aborted.", file=sys.stderr)
+            return 1
+
+    results = []
+    for s in plaintext:
+        entry: dict = {"name": s.name, "stream": str(s.stream_path)}
+        if dry:
+            entry["action"] = "would-encrypt-and-shred" if shred else "would-encrypt"
+            results.append(entry)
+            continue
+        enc_path = Path(str(s.stream_path) + ext)
+        pre_existing = enc_path.exists()
+        if pre_existing:
+            # Never clobber an existing encrypted stream. Verify it decrypts to THIS
+            # plaintext; if so it is a valid prior remediation (idempotent re-run).
+            twin: RawSnapshot = RawSnapshot(
+                name=s.name,
+                stream_path=enc_path,
+                encrypt=encrypt,
+                compress=None,
+                openssl_cipher=cipher if encrypt == "openssl_enc" else None,
+            )
+        else:
+            try:
+                twin = ep.remediate_plaintext(
+                    s,
+                    encrypt=encrypt,
+                    gpg_recipient=gpg_recipient,
+                    gpg_keyring=gpg_keyring,
+                    openssl_cipher=cipher,
+                )
+            except Exception as e:
+                logger.debug("remediate failed for %s", s.name, exc_info=True)
+                entry["action"] = "error"
+                entry["error"] = str(e)
+                results.append(entry)
+                continue
+        entry["encrypted"] = str(enc_path)
+        verified = ep.decrypt_matches_plaintext(twin, s.stream_path)
+        entry["verified"] = verified
+        if not verified:
+            # Fresh: encrypted but unprovable (e.g. gpg without the secret key) -> keep
+            # the plaintext. Pre-existing: it does not decrypt to this plaintext ->
+            # never touch it or the plaintext.
+            entry["action"] = (
+                "existing-encrypted-differs" if pre_existing else "encrypted-unverified"
+            )
+            results.append(entry)
+            continue
+        if shred:
+            try:
+                os.unlink(s.stream_path)
+                if s.metadata_path.exists():
+                    os.unlink(s.metadata_path)
+                entry["action"] = "removed-plaintext"
+            except OSError as e:
+                entry["action"] = "remove-failed"
+                entry["error"] = str(e)
+        else:
+            entry["action"] = "already-encrypted" if pre_existing else "encrypted"
+        results.append(entry)
+
+    if getattr(args, "json", False):
+        print(json.dumps(results, indent=2))
+    else:
+        plural = "" if len(results) == 1 else "s"
+        print(f"Raw target: {spec}  ({len(results)} plaintext stream{plural})")
+        for r in results:
+            print(f"  {r['action'].upper():<28} {r['name']}")
+        if not dry:
+            unver = sum(1 for r in results if r["action"] == "encrypted-unverified")
+            if unver:
+                print(
+                    f"  {unver} encrypted but NOT verified (plaintext kept); check the "
+                    "passphrase, or that a trusted gpg key with its secret is on this "
+                    "host."
+                )
+            differs = sum(
+                1 for r in results if r["action"] == "existing-encrypted-differs"
+            )
+            if differs:
+                print(
+                    f"  {differs} skipped: an encrypted stream already exists that does "
+                    "NOT match the plaintext; resolve it manually (not overwritten)."
+                )
+            if not shred and any(
+                r["action"] in ("encrypted", "already-encrypted") for r in results
+            ):
+                print(
+                    "  Plaintext kept alongside the encrypted copy (no --shred). Once "
+                    "you have confirmed the encrypted backups, re-run with --shred to "
+                    "remove the plaintext."
+                )
+            if any(r["action"] == "removed-plaintext" for r in results):
+                print(
+                    "  Note: plaintext was removed by a plain unlink. On btrfs (CoW) "
+                    "or SSDs this does NOT securely erase the blocks -- rely on device "
+                    "trim/discard or full-disk encryption. Prior exposure cannot be "
+                    "undone."
+                )
+
+    bad = any(r["action"] in ("error", "remove-failed") for r in results) or (
+        shred
+        and any(
+            r["action"] in ("encrypted-unverified", "existing-encrypted-differs")
+            for r in results
+        )
+    )
     return 1 if bad else 0

--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -599,6 +599,144 @@ class RawEndpoint(Endpoint):
         overwritten with a backfill record. The raw+ssh subclass tests the remote."""
         return snapshot.metadata_path.exists()
 
+    def remediate_plaintext(
+        self,
+        snapshot: RawSnapshot,
+        *,
+        encrypt: str,
+        gpg_recipient: str | None = None,
+        gpg_keyring: str | None = None,
+        openssl_cipher: str = "aes-256-cbc",
+    ) -> RawSnapshot:
+        """Write an ENCRYPTED copy of a plaintext ``snapshot``'s stream (the same
+        bytes with an encryption layer added) atomically, plus its authoritative
+        sidecar (``provenance_origin=remediation``, ``remediated_from`` audit ref).
+
+        Does NOT touch the plaintext -- the caller removes it only after
+        ``decrypt_matches_plaintext`` proves the encryption is reversible and only
+        when the operator opted in. Returns the new RawSnapshot. Raises
+        FileExistsError if the encrypted target already exists (never clobber a prior
+        encrypted stream)."""
+        if encrypt not in ("gpg", "openssl_enc"):
+            # Defense in depth: a caller error must never produce a plaintext file
+            # wearing an encrypted name/label (the GHSA-vr25 class this remediates).
+            raise ValueError(
+                f"remediate_plaintext requires a real encryption method, got {encrypt!r}"
+            )
+        orig = snapshot.stream_path
+        ext = ".gpg" if encrypt == "gpg" else ".enc"
+        enc_path = Path(str(orig) + ext)
+        if enc_path.exists():
+            raise FileExistsError(
+                f"{enc_path} already exists; refusing to overwrite an existing "
+                "encrypted stream"
+            )
+        part = Path(str(enc_path) + PARTIAL_SUFFIX)
+        # A compress-less endpoint yields an ENCRYPT-ONLY argv (the plaintext bytes
+        # are already whatever they are), reusing the PR4-hardened crypto command.
+        enc_ep = RawEndpoint(
+            config={
+                "path": str(Path(self.config["path"])),
+                "encrypt": encrypt,
+                "gpg_recipient": gpg_recipient,
+                "gpg_keyring": gpg_keyring,
+                "openssl_cipher": openssl_cipher,
+            }
+        )
+        pipeline = enc_ep._build_receive_pipeline(enc_path)
+        if len(pipeline) != 1 or pipeline[0][:1] == ["cat"]:
+            raise RuntimeError("internal: expected a single encrypt stage")
+        encrypt_argv = pipeline[0]
+        # Open the .part with O_NOFOLLOW|O_EXCL so a pre-planted <orig>.<ext>.part
+        # symlink cannot redirect this (often root) write to an arbitrary file, and a
+        # stale/hostile pre-existing .part cannot be reused -- matching the O_NOFOLLOW
+        # hardening on save_metadata/_sha256_file for the untrusted-directory model.
+        part_fd = os.open(
+            part, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600
+        )
+        try:
+            with open(orig, "rb") as stdin:
+                proc = subprocess.Popen(
+                    encrypt_argv, stdin=stdin, stdout=part_fd, stderr=subprocess.PIPE
+                )
+                _, err = proc.communicate()
+        finally:
+            os.close(part_fd)
+        if proc.returncode != 0:
+            try:
+                part.unlink()
+            except OSError:
+                pass
+            msg = err.decode(errors="replace").strip() if err else "encryption failed"
+            raise RuntimeError(f"Encrypting {orig} failed: {msg}")
+        # Atomic publish of the encrypted stream (fsync -> rename -> dir fsync).
+        fd = os.open(part, os.O_RDONLY)
+        try:
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        os.replace(part, enc_path)
+        self._fsync_dir(enc_path.parent)
+        new_snap = RawSnapshot(
+            name=snapshot.name,
+            stream_path=enc_path,
+            parent_name=snapshot.parent_name,
+            created=datetime.now(timezone.utc),
+            size=enc_path.stat().st_size,
+            compress=snapshot.compress,  # unchanged: the bytes were already compressed
+            encrypt=encrypt,
+            gpg_recipient=gpg_recipient,
+            openssl_cipher=openssl_cipher if encrypt == "openssl_enc" else None,
+            provenance_origin="remediation",
+            stream_completeness=snapshot.stream_completeness,
+            remediation_source=orig.name,
+            checksum_value=_sha256_file(enc_path),
+        )
+        self.write_sidecar(new_snap)
+        self._cached_snapshots = None  # a new stream now exists; re-discover on list
+        return new_snap
+
+    def decrypt_matches_plaintext(
+        self, new_snapshot: RawSnapshot, plaintext_path: Path
+    ) -> bool:
+        """LIVE proof that ``new_snapshot``'s encrypted stream decrypts back to
+        exactly ``plaintext_path``.
+
+        Reverses ONLY the encryption (the verify snapshot has ``compress=None``), so
+        the decrypt output must equal the original (possibly still-compressed)
+        plaintext file byte for byte. For gpg this needs the secret key on THIS host;
+        if it is absent the decrypt fails and this returns False -- so the plaintext
+        is never removed on a host that cannot prove reversibility."""
+        verify_snap = RawSnapshot(
+            name=new_snapshot.name,
+            stream_path=new_snapshot.stream_path,
+            encrypt=new_snapshot.encrypt,
+            compress=None,
+            openssl_cipher=new_snapshot.openssl_cipher,
+        )
+        try:
+            proc = self.send(verify_snap)
+        except Exception:
+            return False
+        stdout = proc.stdout
+        if stdout is None:
+            return False
+        # Any failure to PROVE reversibility -> False (so the plaintext is kept); an
+        # I/O error here must never crash the batch or leave the decision ambiguous.
+        try:
+            h = hashlib.sha256()
+            for chunk in iter(lambda: stdout.read(1024 * 1024), b""):
+                h.update(chunk)
+            stdout.close()
+            if proc.stderr is not None:
+                proc.stderr.read()  # drain (small) so wait() cannot deadlock
+            if proc.wait() != 0:
+                return False
+            plaintext_hash = _sha256_file(plaintext_path)
+            return plaintext_hash is not None and h.hexdigest() == plaintext_hash
+        except OSError:
+            return False
+
     def streams_without_sidecar(self) -> list[RawSnapshot]:
         """Return backfill candidates: RawSnapshots reconstructed from the filename
         for streams under this target that have NO ``.meta`` sidecar (legacy

--- a/src/btrfs_backup_ng/endpoint/raw_metadata.py
+++ b/src/btrfs_backup_ng/endpoint/raw_metadata.py
@@ -136,6 +136,9 @@ class RawSnapshot:
     # is a MARKER for callers to treat such a record conservatively (do not assume a
     # verified complete backup); it is not itself an enforced prune guard.
     stream_completeness: str = "complete"
+    # For a `raw encrypt` remediation: the filename of the plaintext stream this
+    # encrypted stream was produced from (audit trail). None otherwise.
+    remediation_source: str | None = None
     # --- Snapshot-interface compatibility (0.8.5) ---
     prefix: str = ""
     time_format: str | None = None
@@ -238,6 +241,7 @@ class RawSnapshot:
             "provenance": {
                 "origin": self.provenance_origin,
                 "stream_completeness": self.stream_completeness,
+                "remediated_from": self.remediation_source,
                 "tool_version": __version__,
             },
             # Kept for backward compatibility with v1 readers.
@@ -315,6 +319,7 @@ class RawSnapshot:
             checksum_algorithm=checksum.get("algorithm") or "sha256",
             provenance_origin=provenance.get("origin", "native-write"),
             stream_completeness=provenance.get("stream_completeness") or "complete",
+            remediation_source=provenance.get("remediated_from"),
         )
 
     @classmethod

--- a/tests/test_raw_encrypt.py
+++ b/tests/test_raw_encrypt.py
@@ -1,0 +1,358 @@
+"""raw encrypt -- plaintext remediation (0.8.5 PR6e).
+
+Encrypts raw streams written as plaintext (GHSA-vr25-6vrh-869j), then runs a LIVE
+decrypt-to-identical proof and removes the plaintext ONLY when that proof passes and
+``--shred`` was given. The removal is a plain unlink (documented as non-secure on
+CoW/SSD). raw+ssh is refused (crypto stays local).
+"""
+
+import argparse
+import hashlib
+import json
+
+import pytest
+
+from btrfs_backup_ng.cli import raw_cmd
+from btrfs_backup_ng.endpoint.raw import RawEndpoint
+
+
+def _plaintext_backup(path, name="root.20240101T120000", compress="gzip"):
+    ep = RawEndpoint(config={"path": str(path), "compress": compress})
+    src = path / (name + ".src")
+    src.write_bytes(b"plaintext-remediation-payload-" * 200)
+    with open(src, "rb") as f:
+        ep.receive(f, snapshot_name=name).communicate()
+    ep.commit_receive()
+    src.unlink()
+
+
+def _args(**kw):
+    ns = argparse.Namespace()
+    for k, v in kw.items():
+        setattr(ns, k, v)
+    return ns
+
+
+def _encrypt(tmp_path, **kw):
+    base = {
+        "raw_action": "encrypt",
+        "target": str(tmp_path),
+        "encrypt": "openssl_enc",
+        "gpg_recipient": None,
+        "openssl_cipher": None,
+        "shred": False,
+        "yes": True,  # non-interactive in tests
+        "dry_run": False,
+        "json": False,
+    }
+    base.update(kw)
+    return raw_cmd.execute_raw(_args(**base))
+
+
+# --------------------------------------------------------------------------- #
+# encrypt keeps plaintext by default; produces a verifiable encrypted stream
+# --------------------------------------------------------------------------- #
+def test_encrypt_keeps_plaintext_and_writes_remediation_sidecar(tmp_path, monkeypatch):
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "rempass")
+    _plaintext_backup(tmp_path)
+    plain = tmp_path / "root.20240101T120000.btrfs.gz"
+    plain_hash = hashlib.sha256(plain.read_bytes()).hexdigest()
+
+    rc = _encrypt(tmp_path)
+    assert rc == 0
+    # Plaintext kept (no --shred); encrypted copy + remediation sidecar written.
+    assert plain.exists()
+    enc = tmp_path / "root.20240101T120000.btrfs.gz.enc"
+    assert enc.exists()
+    doc = json.loads((tmp_path / "root.20240101T120000.btrfs.gz.enc.meta").read_text())
+    assert doc["provenance"]["origin"] == "remediation"
+    assert doc["provenance"]["remediated_from"] == "root.20240101T120000.btrfs.gz"
+    assert doc["pipeline"]["encrypt"] == "openssl_enc"
+    assert doc["pipeline"]["compress"] == "gzip"  # compression preserved
+
+    # The encrypted stream decrypts back to exactly the plaintext.
+    import subprocess
+
+    dec = subprocess.run(
+        [
+            "openssl",
+            "enc",
+            "-d",
+            "-aes-256-cbc",
+            "-pbkdf2",
+            "-pass",
+            "pass:rempass",
+            "-in",
+            str(enc),
+        ],
+        capture_output=True,
+    ).stdout
+    assert hashlib.sha256(dec).hexdigest() == plain_hash
+
+
+# --------------------------------------------------------------------------- #
+# THE safety guard: plaintext removed ONLY after a verified decrypt proof
+# --------------------------------------------------------------------------- #
+def test_shred_removes_plaintext_only_after_verified_proof(tmp_path, monkeypatch):
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "rempass")
+    _plaintext_backup(tmp_path)
+    plain = tmp_path / "root.20240101T120000.btrfs.gz"
+
+    rc = _encrypt(tmp_path, shred=True)
+    assert rc == 0
+    assert not plain.exists()  # removed after the proof passed
+    assert not (tmp_path / "root.20240101T120000.btrfs.gz.meta").exists()
+    assert (tmp_path / "root.20240101T120000.btrfs.gz.enc").exists()
+
+
+def test_shred_keeps_plaintext_when_proof_fails(tmp_path, monkeypatch, capsys):
+    """If the decrypt proof fails (e.g. gpg without the secret key on this host),
+    the plaintext MUST be kept even with --shred. Removing regardless of the proof
+    would delete it here -> this fails."""
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "rempass")
+    _plaintext_backup(tmp_path)
+    plain = tmp_path / "root.20240101T120000.btrfs.gz"
+    # Simulate an unverifiable encryption (proof fails).
+    monkeypatch.setattr(
+        RawEndpoint, "decrypt_matches_plaintext", lambda self, new, p: False
+    )
+    rc = _encrypt(tmp_path, shred=True)
+    out = capsys.readouterr().out
+    assert plain.exists()  # NEVER removed without a passing proof
+    assert "ENCRYPTED-UNVERIFIED" in out
+    assert rc == 1  # --shred requested but could not complete safely
+
+
+# --------------------------------------------------------------------------- #
+# decrypt_matches_plaintext directly
+# --------------------------------------------------------------------------- #
+def test_decrypt_matches_plaintext_true_and_false(tmp_path, monkeypatch):
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "rempass")
+    _plaintext_backup(tmp_path)
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    (plain_snap,) = ep.list_snapshots(flush_cache=True)
+    new = ep.remediate_plaintext(plain_snap, encrypt="openssl_enc")
+    assert ep.decrypt_matches_plaintext(new, plain_snap.stream_path) is True
+    # Decrypt SUCCEEDS but the bytes differ from a different reference -> the sha256
+    # comparison (not just the return code) must catch it and return False.
+    other = tmp_path / "other.plain"
+    other.write_bytes(b"totally-different-bytes")
+    assert ep.decrypt_matches_plaintext(new, other) is False
+    # Corrupt the encrypted stream -> the decrypt itself fails -> also False.
+    new.stream_path.write_bytes(new.stream_path.read_bytes() + b"TAMPER")
+    assert ep.decrypt_matches_plaintext(new, plain_snap.stream_path) is False
+
+
+# --------------------------------------------------------------------------- #
+# guards / errors
+# --------------------------------------------------------------------------- #
+def test_encrypt_dry_run_changes_nothing(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "rempass")
+    _plaintext_backup(tmp_path)
+    before = sorted(p.name for p in tmp_path.iterdir())
+    rc = _encrypt(tmp_path, shred=True, dry_run=True)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "WOULD-ENCRYPT-AND-SHRED" in out
+    assert sorted(p.name for p in tmp_path.iterdir()) == before
+
+
+def test_encrypt_refuses_raw_ssh(capsys):
+    rc = raw_cmd.execute_raw(
+        _args(
+            raw_action="encrypt",
+            target="raw+ssh://nas/backup",
+            encrypt="openssl_enc",
+            gpg_recipient=None,
+            openssl_cipher=None,
+            shred=False,
+            yes=True,
+            dry_run=False,
+            json=False,
+        )
+    )
+    assert rc == 2
+    assert "runs locally" in capsys.readouterr().out
+
+
+def test_encrypt_gpg_requires_recipient(tmp_path, capsys):
+    _plaintext_backup(tmp_path)
+    rc = _encrypt(tmp_path, encrypt="gpg", gpg_recipient=None)
+    assert rc == 2
+    assert "--gpg-recipient is required" in capsys.readouterr().out
+
+
+def test_encrypt_openssl_requires_passphrase(tmp_path, monkeypatch, capsys):
+    monkeypatch.delenv("BTRFS_BACKUP_PASSPHRASE", raising=False)
+    monkeypatch.delenv("BTRBK_PASSPHRASE", raising=False)
+    _plaintext_backup(tmp_path)
+    rc = _encrypt(tmp_path, encrypt="openssl_enc")
+    assert rc == 2
+    assert "requires a passphrase" in capsys.readouterr().out
+
+
+def test_encrypt_no_plaintext_streams(tmp_path, monkeypatch, capsys):
+    """A target whose streams are already encrypted has nothing to remediate."""
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "rempass")
+    _plaintext_backup(tmp_path)
+    assert _encrypt(tmp_path, shred=True) == 0  # encrypt the plaintext + shred it
+    capsys.readouterr()
+    # Now only the encrypted stream remains -> nothing to do.
+    rc = _encrypt(tmp_path)
+    assert rc == 0
+    assert "no plaintext streams" in capsys.readouterr().out
+
+
+def test_dispatcher_parses_raw_encrypt():
+    from btrfs_backup_ng.cli.dispatcher import create_subcommand_parser
+
+    parser = create_subcommand_parser()
+    args = parser.parse_args(
+        [
+            "raw",
+            "encrypt",
+            "/x",
+            "--encrypt",
+            "gpg",
+            "--gpg-recipient",
+            "KEYID",
+            "--shred",
+            "--yes",
+            "--dry-run",
+            "--json",
+        ]
+    )
+    assert args.command == "raw"
+    assert args.raw_action == "encrypt"
+    assert args.encrypt == "gpg"
+    assert args.gpg_recipient == "KEYID"
+    assert args.shred is True and args.yes is True and args.dry_run is True
+
+
+@pytest.mark.parametrize("shred", [False, True])
+def test_encrypted_stream_verifies_after_remediation(tmp_path, monkeypatch, shred):
+    """The remediated (encrypted) stream is a valid backup: raw verify -> ok."""
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "rempass")
+    _plaintext_backup(tmp_path)
+    assert _encrypt(tmp_path, shred=shred) == 0
+    rc = raw_cmd.execute_raw(
+        _args(raw_action="verify", target=str(tmp_path), snapshot=None, json=False)
+    )
+    assert rc == 0
+
+
+# --------------------------------------------------------------------------- #
+# security: symlink at the .part write target cannot be followed
+# --------------------------------------------------------------------------- #
+def test_encrypt_part_symlink_cannot_redirect_write(tmp_path, monkeypatch):
+    """A pre-planted <orig>.enc.part symlink must NOT redirect the (often root)
+    encrypt write to an arbitrary file. O_NOFOLLOW|O_EXCL refuses it; the outside
+    file stays intact and remediate raises."""
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "rempass")
+    _plaintext_backup(tmp_path)
+    outside = tmp_path / "outside.secret"
+    outside.write_text("DO-NOT-TRUNCATE")
+    (tmp_path / "root.20240101T120000.btrfs.gz.enc.part").symlink_to(outside)
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    (snap,) = [s for s in ep.list_snapshots(flush_cache=True) if not s.encrypt]
+    with pytest.raises((OSError, RuntimeError)):
+        ep.remediate_plaintext(snap, encrypt="openssl_enc")
+    assert outside.read_text() == "DO-NOT-TRUNCATE"
+
+
+def test_remediate_refuses_non_encryption_method(tmp_path):
+    """Defense in depth: never produce a plaintext file with an encrypted label."""
+    _plaintext_backup(tmp_path)
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    (snap,) = [s for s in ep.list_snapshots(flush_cache=True) if not s.encrypt]
+    with pytest.raises(ValueError, match="real encryption method"):
+        ep.remediate_plaintext(snap, encrypt=None)  # type: ignore[arg-type]
+
+
+def test_remediate_refuses_existing_encrypted_target(tmp_path, monkeypatch):
+    """remediate_plaintext must never os.replace over an existing encrypted stream."""
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "rempass")
+    _plaintext_backup(tmp_path)
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    (snap,) = [s for s in ep.list_snapshots(flush_cache=True) if not s.encrypt]
+    enc = tmp_path / "root.20240101T120000.btrfs.gz.enc"
+    enc.write_bytes(b"existing-do-not-clobber")
+    with pytest.raises(FileExistsError):
+        ep.remediate_plaintext(snap, encrypt="openssl_enc")
+    assert enc.read_bytes() == b"existing-do-not-clobber"
+
+
+# --------------------------------------------------------------------------- #
+# no-clobber: a pre-existing, non-matching encrypted stream is never overwritten
+# --------------------------------------------------------------------------- #
+def test_existing_encrypted_not_clobbered(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "rempass")
+    _plaintext_backup(tmp_path)
+    enc = tmp_path / "root.20240101T120000.btrfs.gz.enc"
+    enc.write_bytes(b"a-pre-existing-different-encrypted-backup")
+    rc = _encrypt(tmp_path, shred=True)
+    out = capsys.readouterr().out
+    # The pre-existing .enc is untouched and the plaintext is kept.
+    assert enc.read_bytes() == b"a-pre-existing-different-encrypted-backup"
+    assert (tmp_path / "root.20240101T120000.btrfs.gz").exists()
+    assert "EXISTING-ENCRYPTED-DIFFERS" in out
+    assert rc == 1
+
+
+# --------------------------------------------------------------------------- #
+# partial failure across a batch
+# --------------------------------------------------------------------------- #
+def test_partial_failure_shreds_verified_keeps_unverified(tmp_path, monkeypatch):
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "rempass")
+    _plaintext_backup(tmp_path, name="aaa")
+    _plaintext_backup(tmp_path, name="bbb")
+    real = RawEndpoint.decrypt_matches_plaintext
+
+    def selective(self, new, plaintext_path):
+        # Verify "aaa" for real; force "bbb" to fail the proof.
+        if "bbb" in str(plaintext_path):
+            return False
+        return real(self, new, plaintext_path)
+
+    monkeypatch.setattr(RawEndpoint, "decrypt_matches_plaintext", selective)
+    rc = _encrypt(tmp_path, shred=True)
+    assert not (tmp_path / "aaa.btrfs.gz").exists()  # verified -> removed
+    assert (tmp_path / "bbb.btrfs.gz").exists()  # unverified -> kept
+    assert rc == 1  # a stream could not be safely completed
+
+
+# --------------------------------------------------------------------------- #
+# the interactive destructive-op confirm gate
+# --------------------------------------------------------------------------- #
+def test_confirm_prompt_abort_keeps_plaintext(tmp_path, monkeypatch):
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "rempass")
+    _plaintext_backup(tmp_path)
+    plain = tmp_path / "root.20240101T120000.btrfs.gz"
+    monkeypatch.setattr(raw_cmd.sys.stdin, "isatty", lambda: True, raising=False)
+    monkeypatch.setattr("builtins.input", lambda: "n")
+    rc = _encrypt(tmp_path, shred=True, yes=False)
+    assert rc == 1
+    assert plain.exists()  # aborted before any encryption or removal
+    assert not (tmp_path / "root.20240101T120000.btrfs.gz.enc").exists()
+
+
+def test_confirm_prompt_yes_proceeds(tmp_path, monkeypatch):
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "rempass")
+    _plaintext_backup(tmp_path)
+    plain = tmp_path / "root.20240101T120000.btrfs.gz"
+    monkeypatch.setattr(raw_cmd.sys.stdin, "isatty", lambda: True, raising=False)
+    monkeypatch.setattr("builtins.input", lambda: "y")
+    rc = _encrypt(tmp_path, shred=True, yes=False)
+    assert rc == 0
+    assert not plain.exists()  # proceeded, removed after the proof
+
+
+def test_encrypt_json_output(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "rempass")
+    _plaintext_backup(tmp_path)
+    rc = _encrypt(tmp_path, json=True)
+    data = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert data[0]["name"] == "root.20240101T120000"
+    assert data[0]["action"] == "encrypted"
+    assert data[0]["verified"] is True


### PR DESCRIPTION
## 0.8.5 PR6e — `raw encrypt` (plaintext remediation) ⚠️ destructive

Remediation for raw backups written as **plaintext** despite an `encrypt=` config ([GHSA-vr25-6vrh-869j](https://github.com/berrym/btrfs-backup-ng/security/advisories/GHSA-vr25-6vrh-869j)). Built to the parameters you signed off on.

### Safety model (locked)
- **Keep plaintext unless `--shred`.** Never destroy implicitly.
- **Removal gated *solely* on a live decrypt-to-identical proof** (`sha256(decrypt(new)) == sha256(plaintext)`), never on "encrypt exited 0."
- **gpg without the secret key → keep plaintext** (can't prove reversibility).
- **Plain `os.unlink`, not overwrite-shred** — documented honestly as *not* a secure wipe on btrfs CoW / SSD (true erasure needs device trim/discard or FDE; prior exposure can't be undone).
- **`--shred` opt-in + interactive TTY confirm** (skippable `--yes`); `--dry-run`.
- **Never clobbers an existing `.enc`** (idempotent if it matches; skipped if it differs).
- Runs **locally only** (raw+ssh refused → mount locally) so keys never leave the host.

### Full 4-lens review (highest-stakes command) — every finding fixed
- 🟠 **HIGH (symlink write):** the encrypted `.part` now opens with `O_NOFOLLOW|O_EXCL`, so a planted `<orig>.enc.part` symlink can't redirect a root write to an arbitrary file (same class as PR6d; mutation-verified).
- 🟡 **MEDIUM:** refuse to clobber an existing encrypted stream; the same-name plaintext+encrypted pair is documented (shred promptly); the retention interaction is noted for R10.
- Prompt→stderr (clean `--json`), decrypt-proof degrades I/O errors to "unverified" (never crashes the batch), method-validation guard, cache invalidation, added `--gpg-keyring`.

### Proof
- **21 tests**; the two delete-safety guards (shred-only-after-verified-proof; the sha256 comparison) **and** the two security guards (`O_NOFOLLOW` symlink refusal, no-clobber) are all mutation-verified.
- **Hardware-proven** with real **openssl** and **gpg**, including the critical **no-secret-key → keep-plaintext** path.
- Full suite `2247 passed`; ruff/format@0.15.22/mypy/completions/man all clean.

Follows #21–#30. **Merge held for explicit sign-off** (deletes plaintext). Remaining before the 0.8.5 cut: the per-target lock (its own PR) + PR7 final hardware.
