### PR TITLE
feat(raw): serialize mutating raw operations with a per-target lock

### DIFF
--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -937,6 +937,8 @@ Inspect and maintain [raw-target](#raw-targets) backups directly. Raw targets ho
 btrfs-backup-ng raw SUBCOMMAND [OPTIONS]
 ```
 
+Mutating operations on a local `raw://` target (a backup's commit, prune, `backfill-metadata`, and `encrypt`) hold an exclusive per-target lock so they cannot race each other; concurrent operations serialize rather than corrupt one another. The lock is an empty `.btrfs-backup-ng.lock` file kept in the target directory — it is created `0600`, is safe to leave in place, and is never listed as a backup. Because the lock lives inside the target directory, that directory must not be writable by untrusted users. The lock is currently local-only: `raw+ssh://` maintenance is not serialized, so run it while the target is otherwise idle.
+
 #### raw list
 
 List the backups a raw target holds, read from each stream's `.meta` sidecar (falling back to filename inference for legacy streams written before sidecars existed).
@@ -1024,7 +1026,7 @@ btrfs-backup-ng raw backfill-metadata TARGET [OPTIONS]
 
 Each backfilled sidecar records the pipeline inferred from the filename (compression/encryption) and a sha256 of the stream as it exists now, and is stamped `provenance_origin=backfill` with `stream_completeness=unknown`. A legacy stream's completeness cannot be proven (it might have been truncated), so a backfilled sidecar is marked as a **reconstructed, non-authoritative** record — the checksum lets `raw verify` detect later corruption, but does not confirm the original backup was complete. Exit status is `1` if any sidecar write failed, else `0`.
 
-Run `backfill-metadata` when no backup or prune is in flight against the same target: it re-checks for a sidecar immediately before writing (so a concurrently-committed backup is not overwritten), but a per-target lock is not yet in place.
+On a local `raw://` target, `backfill-metadata` holds the per-target lock while it works, so a concurrent backup or prune serializes against it; it also re-checks for a sidecar immediately before writing, so a concurrently-committed backup is never overwritten. On a `raw+ssh://` target the lock is a no-op (remote locking is not yet implemented) and the command warns you — run remote maintenance while the target is idle.
 
 **Example Output:**
 ```

--- a/man/man1/btrfs-backup-ng-raw.1
+++ b/man/man1/btrfs-backup-ng-raw.1
@@ -23,6 +23,14 @@ cipher), size, provenance, and creation time.
 .PP
 These subcommands read and maintain such a target directly, independently of any
 configured backup job.
+.PP
+On a local \fBraw://\fR target, mutating operations (a backup's commit, prune,
+\fBbackfill-metadata\fR, and \fBencrypt\fR) hold an exclusive per-target lock so
+they serialize instead of racing. The lock is an empty \fB.btrfs-backup-ng.lock\fR
+file in the target directory, created mode \fB0600\fR; it is safe to leave in place
+and is never listed as a backup. Because the lock lives inside the target
+directory, that directory must not be writable by untrusted users. Remote
+\fBraw+ssh://\fR maintenance is not yet lock-protected.
 .SH SUBCOMMANDS
 .SS list
 List the backups a raw target holds.
@@ -105,8 +113,13 @@ with
 a legacy stream's completeness cannot be proven, so a backfilled sidecar is a
 reconstructed, non-authoritative record. The checksum lets
 .B raw verify
-detect later corruption, not confirm the original backup was complete. Run this
-command when no backup or prune is in flight against the same target.
+detect later corruption, not confirm the original backup was complete. On a local
+.B raw://
+target this holds the per-target lock, so a concurrent backup or prune serializes
+against it; on a
+.B raw+ssh://
+target the lock is a no-op (remote locking is not yet implemented) and the command
+warns you, so run remote maintenance while the target is idle.
 .TP
 .B \-\-dry-run
 Show which streams would be backfilled without writing anything.

--- a/src/btrfs_backup_ng/cli/raw_cmd.py
+++ b/src/btrfs_backup_ng/cli/raw_cmd.py
@@ -10,6 +10,7 @@ via their sidecars (falling back to filename inference for legacy streams); late
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import os
 import sys
@@ -88,6 +89,20 @@ def _open_target(args: argparse.Namespace):
                 file=sys.stderr,
             )
     return ep, spec
+
+
+def _warn_remote_no_lock(ep) -> None:
+    """Warn (on stderr, so ``--json`` stays clean) that a raw+ssh target is not
+    lock-protected. The per-target mutual-exclusion lock is local-only (a remote
+    lock needs a persistent connection to hold an flock, which is deferred), so a
+    remote maintenance write can still race a concurrent backup/prune -- run it
+    while the target is idle."""
+    if getattr(ep, "_is_remote", False):
+        print(
+            "warning: raw+ssh targets are not lock-protected; run maintenance while "
+            "the target is idle (no concurrent backup or prune to this target).",
+            file=sys.stderr,
+        )
 
 
 def _raw_list(args: argparse.Namespace) -> int:
@@ -227,48 +242,52 @@ def _raw_backfill(args: argparse.Namespace) -> int:
         print(str(e))
         return 2
 
+    dry = getattr(args, "dry_run", False)
+    if not dry:
+        _warn_remote_no_lock(ep)
+    # Hold the per-target lock across scan + write so a concurrent backup/prune
+    # cannot interleave (a dry-run is read-only, so it needs no lock).
+    lock_ctx = contextlib.nullcontext() if dry else ep.target_lock()
+    results = []
     try:
-        candidates = ep.streams_without_sidecar()
+        with lock_ctx:
+            candidates = ep.streams_without_sidecar()
+            for snap in candidates:
+                entry = {
+                    "name": snap.name,
+                    "stream": str(snap.stream_path),
+                    "compress": snap.compress,
+                    "encrypt": snap.encrypt,
+                }
+                if dry:
+                    entry["action"] = "would-backfill"
+                else:
+                    # Seal a checksum of the stream as it is now (detects later
+                    # corruption); completeness stays "unknown" -- this does not
+                    # prove the legacy stream is a complete btrfs send.
+                    snap.checksum_value = ep.compute_stream_checksum(snap)
+                    # Belt-and-suspenders under the lock: a sidecar should not appear
+                    # mid-operation now, but re-check and never overwrite one.
+                    if ep.sidecar_exists(snap):
+                        entry["action"] = "skipped"
+                        results.append(entry)
+                        continue
+                    try:
+                        ep.write_sidecar(snap)
+                        entry["action"] = "backfilled"
+                        entry["checksum"] = snap.checksum_value
+                    except Exception as e:
+                        logger.debug("backfill sidecar write failed", exc_info=True)
+                        entry["action"] = "error"
+                        entry["error"] = str(e)
+                results.append(entry)
+    except RuntimeError as e:  # target busy (lock timeout)
+        print(f"Cannot backfill {spec}: {e}")
+        return 1
     except Exception as e:  # pragma: no cover - defensive; endpoint errors vary
         logger.debug("raw backfill-metadata failed", exc_info=True)
         print(f"Failed to scan {spec}: {e}")
         return 1
-
-    dry = getattr(args, "dry_run", False)
-    results = []
-    for snap in candidates:
-        entry = {
-            "name": snap.name,
-            "stream": str(snap.stream_path),
-            "compress": snap.compress,
-            "encrypt": snap.encrypt,
-        }
-        if dry:
-            entry["action"] = "would-backfill"
-        else:
-            # Seal a checksum of the stream as it is now (detects later corruption);
-            # completeness stays "unknown" -- this does not prove the legacy stream
-            # is a complete btrfs send.
-            snap.checksum_value = ep.compute_stream_checksum(snap)
-            # Re-check immediately before writing: if a sidecar appeared since the
-            # scan (a backup committed concurrently -- commit publishes the stream
-            # then writes its sidecar as two steps), do NOT overwrite the
-            # authoritative sidecar with a backfill record. (A full per-target lock
-            # covering backup/prune/backfill lands with the raw maintenance lock;
-            # this re-check closes the practical window.)
-            if ep.sidecar_exists(snap):
-                entry["action"] = "skipped"
-                results.append(entry)
-                continue
-            try:
-                ep.write_sidecar(snap)
-                entry["action"] = "backfilled"
-                entry["checksum"] = snap.checksum_value
-            except Exception as e:
-                logger.debug("backfill sidecar write failed", exc_info=True)
-                entry["action"] = "error"
-                entry["error"] = str(e)
-        results.append(entry)
 
     if getattr(args, "json", False):
         print(json.dumps(results, indent=2))
@@ -367,64 +386,79 @@ def _raw_encrypt(args: argparse.Namespace) -> int:
             print("Aborted.", file=sys.stderr)
             return 1
 
-    results = []
-    for s in plaintext:
-        entry: dict = {"name": s.name, "stream": str(s.stream_path)}
-        if dry:
-            entry["action"] = "would-encrypt-and-shred" if shred else "would-encrypt"
-            results.append(entry)
-            continue
-        enc_path = Path(str(s.stream_path) + ext)
-        pre_existing = enc_path.exists()
-        if pre_existing:
-            # Never clobber an existing encrypted stream. Verify it decrypts to THIS
-            # plaintext; if so it is a valid prior remediation (idempotent re-run).
-            twin: RawSnapshot = RawSnapshot(
-                name=s.name,
-                stream_path=enc_path,
-                encrypt=encrypt,
-                compress=None,
-                openssl_cipher=cipher if encrypt == "openssl_enc" else None,
-            )
-        else:
-            try:
-                twin = ep.remediate_plaintext(
-                    s,
-                    encrypt=encrypt,
-                    gpg_recipient=gpg_recipient,
-                    gpg_keyring=gpg_keyring,
-                    openssl_cipher=cipher,
+    def _process() -> list:
+        out: list = []
+        for s in plaintext:
+            entry: dict = {"name": s.name, "stream": str(s.stream_path)}
+            if dry:
+                entry["action"] = (
+                    "would-encrypt-and-shred" if shred else "would-encrypt"
                 )
-            except Exception as e:
-                logger.debug("remediate failed for %s", s.name, exc_info=True)
-                entry["action"] = "error"
-                entry["error"] = str(e)
-                results.append(entry)
+                out.append(entry)
                 continue
-        entry["encrypted"] = str(enc_path)
-        verified = ep.decrypt_matches_plaintext(twin, s.stream_path)
-        entry["verified"] = verified
-        if not verified:
-            # Fresh: encrypted but unprovable (e.g. gpg without the secret key) -> keep
-            # the plaintext. Pre-existing: it does not decrypt to this plaintext ->
-            # never touch it or the plaintext.
-            entry["action"] = (
-                "existing-encrypted-differs" if pre_existing else "encrypted-unverified"
-            )
-            results.append(entry)
-            continue
-        if shred:
-            try:
-                os.unlink(s.stream_path)
-                if s.metadata_path.exists():
-                    os.unlink(s.metadata_path)
-                entry["action"] = "removed-plaintext"
-            except OSError as e:
-                entry["action"] = "remove-failed"
-                entry["error"] = str(e)
-        else:
-            entry["action"] = "already-encrypted" if pre_existing else "encrypted"
-        results.append(entry)
+            enc_path = Path(str(s.stream_path) + ext)
+            pre_existing = enc_path.exists()
+            if pre_existing:
+                # Never clobber an existing encrypted stream. Verify it decrypts to
+                # THIS plaintext; if so it is a valid prior remediation (idempotent).
+                twin: RawSnapshot = RawSnapshot(
+                    name=s.name,
+                    stream_path=enc_path,
+                    encrypt=encrypt,
+                    compress=None,
+                    openssl_cipher=cipher if encrypt == "openssl_enc" else None,
+                )
+            else:
+                try:
+                    twin = ep.remediate_plaintext(
+                        s,
+                        encrypt=encrypt,
+                        gpg_recipient=gpg_recipient,
+                        gpg_keyring=gpg_keyring,
+                        openssl_cipher=cipher,
+                    )
+                except Exception as e:
+                    logger.debug("remediate failed for %s", s.name, exc_info=True)
+                    entry["action"] = "error"
+                    entry["error"] = str(e)
+                    out.append(entry)
+                    continue
+            entry["encrypted"] = str(enc_path)
+            verified = ep.decrypt_matches_plaintext(twin, s.stream_path)
+            entry["verified"] = verified
+            if not verified:
+                # Fresh: encrypted but unprovable (e.g. gpg without the secret key)
+                # -> keep the plaintext. Pre-existing: it does not decrypt to this
+                # plaintext -> never touch it or the plaintext.
+                entry["action"] = (
+                    "existing-encrypted-differs"
+                    if pre_existing
+                    else "encrypted-unverified"
+                )
+                out.append(entry)
+                continue
+            if shred:
+                try:
+                    os.unlink(s.stream_path)
+                    if s.metadata_path.exists():
+                        os.unlink(s.metadata_path)
+                    entry["action"] = "removed-plaintext"
+                except OSError as e:
+                    entry["action"] = "remove-failed"
+                    entry["error"] = str(e)
+            else:
+                entry["action"] = "already-encrypted" if pre_existing else "encrypted"
+            out.append(entry)
+        return out
+
+    # Hold the per-target lock across the whole remediation (a dry-run is read-only).
+    lock_ctx = contextlib.nullcontext() if dry else ep.target_lock()
+    try:
+        with lock_ctx:
+            results = _process()
+    except RuntimeError as e:  # target busy (lock timeout)
+        print(f"Cannot encrypt {spec}: {e}")
+        return 1
 
     if getattr(args, "json", False):
         print(json.dumps(results, indent=2))

--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -13,6 +13,9 @@ Encryption methods:
 
 from __future__ import annotations
 
+import contextlib
+import errno
+import fcntl
 import hashlib
 import json
 import os
@@ -20,6 +23,8 @@ import re
 import shlex
 import shutil
 import subprocess
+import time
+from collections.abc import Iterator
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, TypedDict
@@ -145,6 +150,10 @@ def _openssl_pass_arg() -> str:
 # transfer can never be listed as a complete backup.
 PARTIAL_SUFFIX = ".part"
 
+# Per-target advisory lock file. Mutating operations (backup commit, prune, backfill,
+# encrypt) hold an exclusive flock on it so they are mutually exclusive on one target.
+LOCK_FILENAME = ".btrfs-backup-ng.lock"
+
 
 def _sha256_file(path: Path) -> str | None:
     """Return the hex sha256 of ``path``'s bytes, or None on any I/O error.
@@ -253,6 +262,17 @@ class RawEndpoint(Endpoint):
             config.get("openssl_cipher") or "aes-256-cbc"
         )
 
+        # How long a mutating op waits for the per-target lock before reporting the
+        # target busy. The base __init__ only keeps known keys, so register it here.
+        # A generous default: the commit critical section is sub-second, but slow
+        # storage (NFS/SMB) can make a legitimate peer's own commit take longer.
+        try:
+            self.config["lock_timeout"] = float(config.get("lock_timeout", 30.0))
+        except (TypeError, ValueError):
+            raise ValueError("lock_timeout must be a number of seconds") from None
+        if self.config["lock_timeout"] < 0:
+            raise ValueError("lock_timeout must not be negative")
+
         # Validate encryption config
         if self.encrypt == "gpg" and not self.gpg_recipient:
             raise ValueError("gpg_recipient is required when encrypt=gpg")
@@ -321,6 +341,84 @@ class RawEndpoint(Endpoint):
         """Return a unique identifier for this endpoint."""
         path = self._normalize_path(self.config["path"])
         return f"raw://{path}"
+
+    @contextlib.contextmanager
+    def target_lock(self, *, timeout: float | None = None) -> Iterator[None]:
+        """Hold an exclusive lock on the target directory for a MUTATING operation.
+
+        Backup (commit), prune, ``raw backfill-metadata`` and ``raw encrypt`` on the
+        same raw target all take this lock, so they are mutually exclusive -- closing
+        the transient two-files-one-name window (e.g. a backfill mislabelling a native
+        backup during its non-atomic stream-then-sidecar commit, or a prune racing a
+        backfill).
+
+        A bounded-blocking exclusive ``flock``: it waits up to ``timeout`` seconds for
+        a peer to finish (so legitimate parallel commits to one target SERIALIZE rather
+        than fail), then raises RuntimeError if still busy. ``timeout`` defaults to the
+        ``lock_timeout`` config key (30s). The lock is released when the fd is closed
+        and is auto-released if the process dies, so it can never go stale.
+
+        Failure posture: a planted lock symlink (O_NOFOLLOW -> ELOOP), a lock that is
+        a directory (EISDIR), a foreign-owned/non-writable lock file (EACCES), or a
+        filesystem that cannot flock (ENOLCK) all raise RuntimeError rather than an
+        uncaught OSError -- so a hostile or mis-owned lock file degrades to the same
+        bounded fail/skip as contention instead of crashing every backup. The lock
+        lives inside the target directory, so that directory MUST NOT be writable by
+        untrusted users. The raw+ssh subclass overrides this as a no-op (remote
+        locking is a separate concern -- there is no persistent connection to hold an
+        flock)."""
+        if timeout is None:
+            timeout = float(self.config.get("lock_timeout", 30.0))
+        path = Path(self.config["path"])
+        path.mkdir(parents=True, exist_ok=True, mode=0o700)
+        lockfile = path / LOCK_FILENAME
+        # O_NOFOLLOW: refuse a planted <target>/.btrfs-backup-ng.lock symlink so the
+        # (often root) open cannot be pointed at an arbitrary file, matching the
+        # symlink hardening elsewhere in this module. Any open failure (symlink,
+        # directory, foreign-owned/unwritable regular file) is mapped to RuntimeError
+        # so it cannot escape as an uncaught OSError and turn a hostile/mis-owned lock
+        # file into a permanent DoS on backups and prune.
+        try:
+            fd = os.open(lockfile, os.O_WRONLY | os.O_CREAT | os.O_NOFOLLOW, 0o600)
+        except OSError as e:
+            logger.warning(
+                "Cannot open raw target lock file %s: %s -- a planted symlink, a "
+                "directory, or a foreign-owned/non-writable lock file. The target "
+                "directory must not be writable by untrusted users and the lock file "
+                "must be owned by the backup user.",
+                lockfile,
+                e,
+            )
+            raise RuntimeError(
+                f"raw target {path} is unavailable: cannot open its lock file "
+                f"{lockfile} ({e})"
+            ) from e
+        deadline = time.monotonic() + max(0.0, timeout)
+        try:
+            while True:
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except OSError as e:
+                    # EAGAIN/EWOULDBLOCK (BlockingIOError) is the real contention
+                    # signal -- retry until the deadline. Any other errno (e.g. ENOLCK
+                    # from a filesystem that cannot flock) will never clear, so fail
+                    # immediately with an accurate message instead of polling for the
+                    # full timeout and mislabelling it "busy".
+                    if e.errno not in (errno.EAGAIN, errno.EWOULDBLOCK):
+                        raise RuntimeError(
+                            f"raw target {path}: cannot lock {lockfile} ({e}); the "
+                            "filesystem may not support flock"
+                        ) from e
+                    if time.monotonic() >= deadline:
+                        raise RuntimeError(
+                            f"raw target {path} is busy (another operation holds the "
+                            "lock); retry when it finishes"
+                        ) from None
+                    time.sleep(0.2)
+            yield
+        finally:
+            os.close(fd)  # releases the flock
 
     def _prepare(self) -> None:
         """Prepare the endpoint for use."""
@@ -543,32 +641,43 @@ class RawEndpoint(Endpoint):
                 f"cannot publish {final_path}"
             )
         # Flush the stream's bytes to disk BEFORE renaming, so the final name can
-        # never refer to unflushed data.
+        # never refer to unflushed data. Done OUTSIDE the lock: the ``.part`` name is
+        # unique to this transfer so no peer touches it, and this fsync can take a
+        # long time on a multi-GB stream -- holding the lock across it would make a
+        # legitimately parallel commit exceed the wait and FAIL instead of serialize.
         fd = os.open(part_path, os.O_RDONLY)
         try:
             os.fsync(fd)
         finally:
             os.close(fd)
-        os.replace(part_path, final_path)
-        # Persist the rename itself.
-        self._fsync_dir(final_path.parent)
-        # Write the authoritative sidecar now that the stream is durable at its
-        # final name. Written last + atomically, so a crash yields at most a
-        # stream-without-sidecar (discovery falls back to filename inference),
-        # never a sidecar describing a missing/partial stream. Best-effort: the
-        # backup data already succeeded, so a sidecar error must not fail it.
-        try:
-            size = final_path.stat().st_size
-            # sha256 of the committed ciphertext, read back from disk so it
-            # reflects the bytes that actually landed (raw verify recomputes and
-            # compares). Best-effort: on failure the checksum stays null.
-            checksum = _sha256_file(final_path)
-            self.write_sidecar(self._sidecar_snapshot(final_path, size, checksum))
-        except Exception as e:
-            # The backup data is already durable; a sidecar error must NEVER flip
-            # an already-successful transfer into a reported failure (PR1 contract).
-            # A missing sidecar just degrades to filename inference.
-            logger.warning("Failed to write sidecar for %s: %s", final_path, e)
+        # Hash the ``.part`` now too (also outside the lock, same slow-read reason).
+        # ``os.replace`` is a pure rename, so the committed stream's bytes are
+        # byte-identical to the ``.part`` -- this sha256 describes the final file, and
+        # ``_sha256_file`` drops the page cache (POSIX_FADV_DONTNEED) after the fsync
+        # above so it reflects the bytes actually on disk. Best-effort: None on error.
+        checksum = _sha256_file(part_path)
+        # Only the rename (which makes the stream visible under its shared final name)
+        # through the sidecar write must be mutually exclusive, so a concurrent
+        # backfill/prune cannot observe the stream in the window after the rename but
+        # before the sidecar is written (and mislabel it). This section is sub-second
+        # (a metadata rename + a directory fsync + a small sidecar write).
+        with self.target_lock():
+            os.replace(part_path, final_path)
+            # Persist the rename itself.
+            self._fsync_dir(final_path.parent)
+            # Write the authoritative sidecar now that the stream is durable at its
+            # final name. Written last + atomically, so a crash yields at most a
+            # stream-without-sidecar (discovery falls back to filename inference),
+            # never a sidecar describing a missing/partial stream. Best-effort: the
+            # backup data already succeeded, so a sidecar error must not fail it.
+            try:
+                size = final_path.stat().st_size
+                self.write_sidecar(self._sidecar_snapshot(final_path, size, checksum))
+            except Exception as e:
+                # The backup data is already durable; a sidecar error must NEVER flip
+                # an already-successful transfer into a reported failure (PR1
+                # contract). A missing sidecar just degrades to filename inference.
+                logger.warning("Failed to write sidecar for %s: %s", final_path, e)
         self._cached_snapshots = None  # re-discover to include the new sidecar
         logger.debug("Committed raw stream + sidecar: %s", final_path)
 
@@ -755,7 +864,10 @@ class RawEndpoint(Endpoint):
             # must not be treated as a real backup (defends the write + the hash).
             if item.is_symlink() or not item.is_file() or item.suffix == ".meta":
                 continue
-            if item.name.endswith((".part", ".tmp")) or ".btrfs" not in item.name:
+            if (
+                item.name.endswith((".part", ".tmp", ".lock"))
+                or ".btrfs" not in item.name
+            ):
                 continue
             if item.with_name(item.name + ".meta").exists():
                 continue  # already has an authoritative sidecar
@@ -974,6 +1086,16 @@ class RawEndpoint(Endpoint):
             snapshots: List of snapshots to delete
             **kwargs: Additional arguments (unused)
         """
+        # Prune under the per-target lock so it cannot race a concurrent backup
+        # commit or backfill. If the target is busy, skip (safe -- do NOT delete
+        # during contention); retention retries on the next run.
+        try:
+            with self.target_lock():
+                self._delete_snapshots_locked(snapshots)
+        except RuntimeError as e:
+            logger.warning("Skipping raw delete (target busy): %s", e)
+
+    def _delete_snapshots_locked(self, snapshots: list[RawSnapshot]) -> None:
         for snapshot in snapshots:
             try:
                 # Delete stream file
@@ -1020,7 +1142,15 @@ class RawEndpoint(Endpoint):
         to_delete = snapshots[:-keep]
         for snapshot in to_delete:
             logger.info("Deleting old raw snapshot: %s", snapshot.name)
-            self.delete_snapshot(snapshot)
+        # One lock for the whole prune pass so it is atomic as a unit (a concurrent
+        # commit cannot interleave between two deletions) and a busy target yields a
+        # single skip decision, not a partial prune. Call the non-locking variant --
+        # delete_snapshot would re-take the lock per snapshot and self-deadlock.
+        try:
+            with self.target_lock():
+                self._delete_snapshots_locked(to_delete)
+        except RuntimeError as e:
+            logger.warning("Skipping raw prune (target busy): %s", e)
 
     def get_space_info(self, path: str | None = None) -> Any:
         """Get space information for the raw target directory.
@@ -1087,6 +1217,15 @@ class SSHRawEndpoint(RawEndpoint):
             f"{self.username}@{self.hostname}" if self.username else self.hostname
         )
         return f"raw+ssh://{user_host}{self.config['path']}"
+
+    @contextlib.contextmanager
+    def target_lock(self, *, timeout: float | None = None) -> Iterator[None]:
+        """No-op for raw+ssh. A per-target lock over ssh needs a remote lockfile with
+        stale-detection (there is no persistent connection to hold an flock), which is
+        a separate change; concurrent-operation protection is currently local-only. Run
+        maintenance commands against a raw+ssh target when it is otherwise idle. The
+        raw maintenance CLI warns the operator of this at the point of use."""
+        yield
 
     def _build_ssh_command(self) -> list[str]:
         """Build the base SSH command."""
@@ -1388,7 +1527,7 @@ class SSHRawEndpoint(RawEndpoint):
         metas = set(self._remote_find("*.meta"))
         out: list[RawSnapshot] = []
         for sp in streams:
-            if sp.endswith((".meta", ".part", ".tmp")):
+            if sp.endswith((".meta", ".part", ".tmp", ".lock")):
                 continue
             if sp + ".meta" in metas:
                 continue  # already has an authoritative sidecar
@@ -1624,7 +1763,7 @@ class SSHRawEndpoint(RawEndpoint):
         loaded_paths = {str(s.stream_path) for s in snapshots}
         for stream_path_str in stream_files:
             if not stream_path_str or stream_path_str.endswith(
-                (".meta", ".part", ".tmp")
+                (".meta", ".part", ".tmp", ".lock")
             ):
                 continue
             if stream_path_str in loaded_paths:
@@ -1681,8 +1820,14 @@ class SSHRawEndpoint(RawEndpoint):
         self._cached_snapshots = snapshots
         return list(snapshots)
 
-    def delete_snapshots(self, snapshots: list[RawSnapshot], **kwargs: Any) -> None:
-        """Delete snapshots on the remote host."""
+    def _delete_snapshots_locked(self, snapshots: list[RawSnapshot]) -> None:
+        """Delete snapshots on the remote host (issuing a remote ``rm``).
+
+        This overrides the LOCAL delete primitive rather than ``delete_snapshots``,
+        so both entry points that wrap it in ``target_lock`` -- ``delete_snapshots``
+        (per batch) and ``delete_old_snapshots`` (whole prune pass) -- dispatch to the
+        remote deletion for a raw+ssh target. Inheriting the base ``delete_snapshots``
+        keeps the (no-op) lock discipline uniform across local and remote."""
         ssh_cmd = self._build_ssh_command()
 
         for snapshot in snapshots:

--- a/src/btrfs_backup_ng/endpoint/raw_metadata.py
+++ b/src/btrfs_backup_ng/endpoint/raw_metadata.py
@@ -460,11 +460,11 @@ def discover_raw_snapshots(
         if not item.is_file() or item.suffix == ".meta":
             continue
 
-        # Skip in-progress artifacts: a ".part" file is an uncommitted stream and
-        # a ".tmp" file is an uncommitted sidecar (save_metadata writes
-        # "<name>.meta.tmp"). Both contain ".btrfs" in their name, so without this
-        # they would be parsed as phantom complete backups.
-        if item.name.endswith((".part", ".tmp")):
+        # Skip in-progress artifacts and the per-target lock file: a ".part" is an
+        # uncommitted stream, a ".tmp" is an uncommitted sidecar, and
+        # ".btrfs-backup-ng.lock" is the mutual-exclusion lock. All contain ".btrfs"
+        # in their name, so without this they would be parsed as phantom backups.
+        if item.name.endswith((".part", ".tmp", ".lock")):
             continue
 
         # Check if it's a btrfs stream file

--- a/tests/test_raw_lock.py
+++ b/tests/test_raw_lock.py
@@ -1,0 +1,274 @@
+"""Per-target mutual-exclusion lock (0.8.5).
+
+Mutating raw operations (backup commit, prune, `raw backfill-metadata`, `raw
+encrypt`) hold an exclusive flock on the target dir so they cannot race. The lock
+file must never be mistaken for a backup stream.
+"""
+
+import argparse
+import os
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from btrfs_backup_ng.cli import raw_cmd
+from btrfs_backup_ng.endpoint import raw as raw_mod
+from btrfs_backup_ng.endpoint.raw import LOCK_FILENAME, RawEndpoint, SSHRawEndpoint
+from btrfs_backup_ng.endpoint.raw_metadata import RawSnapshot
+
+
+def _args(**kw):
+    ns = argparse.Namespace()
+    for k, v in kw.items():
+        setattr(ns, k, v)
+    return ns
+
+
+def test_target_lock_is_mutually_exclusive(tmp_path):
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    with ep.target_lock():
+        # A second acquisition (a distinct open fd, i.e. a peer operation) must not
+        # get the lock -> times out -> "busy".
+        with pytest.raises(RuntimeError, match="busy"):
+            with ep.target_lock(timeout=0.1):
+                pass
+
+
+def test_target_lock_released_after_context(tmp_path):
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    with ep.target_lock():
+        pass
+    # Released on exit -> immediately re-acquirable.
+    with ep.target_lock(timeout=0.1):
+        pass
+
+
+def test_target_lock_excludes_across_processes(tmp_path):
+    """The real cross-process guarantee (a same-process two-fd test is only a proxy):
+    a forked child holding the lock makes a short-deadline acquire in the parent time
+    out (busy), and a generous-deadline acquire SERIALIZE -- block until the child
+    releases, then succeed, NOT fail."""
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    r, w = os.pipe()
+    pid = os.fork()
+    if pid == 0:  # child: take the lock, signal the parent, hold ~1s, release
+        os.close(r)
+        try:
+            with ep.target_lock():
+                os.write(w, b"held")
+                time.sleep(1.0)
+        except BaseException:
+            pass
+        finally:
+            os.close(w)
+            os._exit(0)
+    # parent
+    os.close(w)
+    # b"" (EOF) would mean the child never acquired -> this assert fails cleanly.
+    assert os.read(r, 4) == b"held"
+    # Child still holds it: a short deadline reports busy (a bounded fail, no crash).
+    with pytest.raises(RuntimeError, match="busy"):
+        with ep.target_lock(timeout=0.1):
+            pass
+    # A generous deadline serializes: block until the child releases (~1s), then get it.
+    with ep.target_lock(timeout=5.0):
+        pass
+    os.close(r)
+    os.waitpid(pid, 0)
+
+
+def test_planted_lock_directory_degrades_to_runtime_error(tmp_path):
+    """A hostile or mis-created lock file (here a directory) must surface as a bounded
+    RuntimeError, never an uncaught OSError -- otherwise a planted lock in a shared
+    target dir would permanently crash every backup and prune (a DoS), which is worse
+    than having no lock at all."""
+    (tmp_path / LOCK_FILENAME).mkdir()
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    with pytest.raises(RuntimeError):
+        with ep.target_lock(timeout=0.1):
+            pass
+
+
+def test_planted_lock_symlink_is_refused(tmp_path):
+    """A planted lock symlink cannot redirect the (often root) open: O_NOFOLLOW makes
+    it fail, mapped to RuntimeError, and the link target is never opened/written."""
+    victim = tmp_path / "victim"
+    victim.write_text("original")
+    (tmp_path / LOCK_FILENAME).symlink_to(victim)
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    with pytest.raises(RuntimeError):
+        with ep.target_lock(timeout=0.1):
+            pass
+    assert victim.read_text() == "original"  # never followed
+
+
+def test_lock_timeout_defaults_from_config(tmp_path):
+    """target_lock reads its default timeout from the lock_timeout config key, so a
+    slow-storage target can widen the serialize window without a code change."""
+    ep = RawEndpoint(config={"path": str(tmp_path), "lock_timeout": 0.1})
+    with ep.target_lock():
+        started = time.monotonic()
+        with pytest.raises(RuntimeError, match="busy"):
+            with ep.target_lock():  # no explicit timeout -> config's 0.1s, quick busy
+                pass
+        assert time.monotonic() - started < 5.0  # used 0.1s, not the 30s hard default
+
+
+def test_lock_file_is_not_a_snapshot(tmp_path):
+    """The .btrfs-backup-ng.lock file contains '.btrfs' but must never be discovered
+    as a backup stream (list, verify, backfill)."""
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    with ep.target_lock():
+        pass
+    assert (tmp_path / LOCK_FILENAME).exists()
+    assert ep.list_snapshots(flush_cache=True) == []
+    assert ep.streams_without_sidecar() == []
+
+
+def test_ssh_target_lock_is_noop(tmp_path):
+    """raw+ssh locking is deferred: target_lock is a no-op that never blocks."""
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+    with ep.target_lock():
+        with ep.target_lock(timeout=0.1):  # no conflict, no RuntimeError
+            pass
+
+
+def _busy_lock(self, **kw):
+    @contextmanager
+    def _cm():
+        raise RuntimeError("raw target /x is busy (test)")
+        yield
+
+    return _cm()
+
+
+def test_backfill_reports_busy_target(tmp_path, monkeypatch, capsys):
+    # Seed a legacy (sidecar-less) stream so there is work to do.
+    ep0 = RawEndpoint(config={"path": str(tmp_path)})
+    src = tmp_path / "s.src"
+    src.write_bytes(b"data")
+    with open(src, "rb") as f:
+        ep0.receive(f, snapshot_name="root.20240101T120000").communicate()
+    ep0.commit_receive()
+    for meta in tmp_path.glob("*.meta"):
+        meta.unlink()
+    src.unlink()
+
+    monkeypatch.setattr(RawEndpoint, "target_lock", _busy_lock)
+    rc = raw_cmd.execute_raw(
+        _args(
+            raw_action="backfill-metadata",
+            target=str(tmp_path),
+            dry_run=False,
+            json=False,
+        )
+    )
+    assert rc == 1
+    assert "busy" in capsys.readouterr().out
+
+
+def test_encrypt_reports_busy_target(tmp_path, monkeypatch, capsys):
+    ep0 = RawEndpoint(config={"path": str(tmp_path), "compress": "gzip"})
+    src = tmp_path / "s.src"
+    src.write_bytes(b"data")
+    with open(src, "rb") as f:
+        ep0.receive(f, snapshot_name="root.20240101T120000").communicate()
+    ep0.commit_receive()
+    src.unlink()
+
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "x")
+    monkeypatch.setattr(RawEndpoint, "target_lock", _busy_lock)
+    rc = raw_cmd.execute_raw(
+        _args(
+            raw_action="encrypt",
+            target=str(tmp_path),
+            encrypt="openssl_enc",
+            gpg_recipient=None,
+            gpg_keyring=None,
+            openssl_cipher=None,
+            shred=False,
+            yes=True,
+            dry_run=False,
+            json=False,
+        )
+    )
+    assert rc == 1
+    assert "busy" in capsys.readouterr().out
+
+
+def test_prune_takes_lock_once_for_whole_pass(tmp_path, monkeypatch):
+    """delete_old_snapshots holds ONE lock for the entire prune (atomic as a unit --
+    a concurrent commit cannot interleave between two deletions, and a busy target
+    yields a single skip decision), not one acquisition per snapshot."""
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    for i in range(3):
+        src = tmp_path / f"s{i}.src"
+        src.write_bytes(b"x")
+        with open(src, "rb") as f:
+            ep.receive(f, snapshot_name=f"root.2024010{i + 1}T120000").communicate()
+        ep.commit_receive()
+        src.unlink()
+    assert len(ep.list_snapshots(flush_cache=True)) == 3
+
+    calls = {"n": 0}
+    real = RawEndpoint.target_lock
+
+    def counting(self, **kw):
+        calls["n"] += 1
+        return real(self, **kw)
+
+    monkeypatch.setattr(RawEndpoint, "target_lock", counting)
+    ep.delete_old_snapshots(keep=1)  # deletes the 2 oldest
+    assert calls["n"] == 1  # one lock for the whole pass, not one per snapshot
+    assert len(ep.list_snapshots(flush_cache=True)) == 1
+
+
+def test_ssh_prune_issues_remote_rm(monkeypatch):
+    """delete_old_snapshots must prune a raw+ssh target via a remote rm. The atomic-
+    prune refactor routes deletion through _delete_snapshots_locked, so SSHRawEndpoint
+    overrides THAT (not delete_snapshots); otherwise remote retention silently deletes
+    nothing (it would fall through to the inherited LOCAL unlink of a remote path)."""
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+    snaps = [
+        RawSnapshot(
+            name=f"root.2024010{i + 1}T120000",
+            stream_path=Path(f"/backup/root.2024010{i + 1}T120000.btrfs"),
+        )
+        for i in range(3)
+    ]
+    monkeypatch.setattr(ep, "list_snapshots", lambda *a, **k: list(snaps))
+
+    rm_targets: list[str] = []
+
+    def fake_run(cmd, **kwargs):
+        joined = " ".join(str(c) for c in cmd)
+        if "rm -f" in joined:
+            rm_targets.append(joined)
+
+        class _R:
+            returncode = 0
+            stdout = b""
+            stderr = b""
+
+        return _R()
+
+    monkeypatch.setattr(raw_mod.subprocess, "run", fake_run)
+    ep.delete_old_snapshots(keep=1)  # prune the 2 oldest remotely
+    assert len(rm_targets) == 2
+    assert all("root.20240103" not in t for t in rm_targets)  # newest kept
+
+
+def test_backup_commit_still_works_under_lock(tmp_path):
+    """A normal backup commit acquires + releases the lock and publishes the
+    stream + sidecar (the lock does not break the hardware-proven commit path)."""
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    src = tmp_path / "src"
+    src.write_bytes(b"stream-bytes" * 100)
+    with open(src, "rb") as f:
+        ep.receive(f, snapshot_name="root.20240101T120000").communicate()
+    ep.commit_receive()
+    (snap,) = ep.list_snapshots(flush_cache=True)
+    assert snap.name == "root.20240101T120000"
+    assert snap.metadata_path.exists()


### PR DESCRIPTION
## Summary

Adds a **per-target mutual-exclusion lock** so mutating raw operations on one target cannot race. Backup commit, prune, `raw backfill-metadata`, and `raw encrypt` on a local `raw://` target now hold an exclusive `flock` on a `.btrfs-backup-ng.lock` file in the target directory. This closes the transient two-files-one-name window where a backfill could mislabel a native backup during its non-atomic stream-then-sidecar commit, or a prune could race a backfill.

This is the last correctness PR before the final 0.8.5 hardware pass — it completes the raw pipeline's concurrency story.

## Behaviour

- **Bounded-blocking**: a mutating op waits up to `lock_timeout` seconds (config key, default 30s) for a peer to finish, so legitimate parallel commits to one target **serialize rather than fail**, then reports the target busy.
- **Never stale**: the lock auto-releases when the fd is closed or the process dies.
- **Prune** degrades to a skip on a busy target (retention retries next run, never deletes during contention); **backfill/encrypt** report the target busy and exit 1.
- **raw+ssh** targets are not yet lock-protected (no persistent connection to hold an flock); the maintenance CLI warns the operator and the docs say to run remote maintenance while the target is idle.

## Notable design points (each surfaced by adversarial review)

- `commit_receive` keeps only the rename + directory fsync + sidecar write under the lock. The stream fsync and the full-file `sha256` read-back run **outside** it, so a large commit to slow storage cannot make a parallel commit exceed the wait and fail. `os.replace` is a pure rename, so the checksum computed on the `.part` file describes the committed stream (and `_sha256_file` drops the page cache after the fsync, so it still reflects the bytes on disk).
- The lock-file open uses `O_NOFOLLOW` and maps **any** open failure (planted symlink, directory, or foreign-owned/unwritable lock file) to a bounded `RuntimeError` + a WARNING. A hostile or mis-owned lock file degrades to the same fail/skip as contention instead of crashing every backup and prune. Because the lock lives in the target directory, that directory **must not be writable by untrusted users** (documented).
- Prune deletion is unified on `_delete_snapshots_locked` as the polymorphic primitive, so both `delete_snapshots` (per batch) and `delete_old_snapshots` (whole pass, one lock) dispatch to the remote `rm` for raw+ssh targets.

## Testing

- 13 tests in `tests/test_raw_lock.py`, including a **real cross-process fork test** (proves parallel commits serialize, not fail — not the same-process fd proxy), planted-symlink and planted-directory DoS tests, a config-timeout test, an atomic-prune (one-lock-per-pass) test, and a raw+ssh remote-prune regression test.
- **Mutation-verified** enforcement points: `os.open` OSError→RuntimeError mapping, `O_NOFOLLOW`, atomic-prune single-lock, and the raw+ssh `_delete_snapshots_locked` dispatch.
- Full suite: 2260 passed, 1 skipped. ruff / ruff-format / mypy clean.
- Docs (`CLI-REFERENCE.md`) and the `raw` man page updated (lock file described; stale "lock not yet in place" note removed).
