### PR TITLE
fix(raw): record compression in the sidecar so compressed backups restore

### DIFF
--- a/src/btrfs_backup_ng/cli/common.py
+++ b/src/btrfs_backup_ng/cli/common.py
@@ -202,3 +202,29 @@ def thread_raw_encryption(kwargs: dict, target) -> None:
     kwargs["gpg_recipient"] = getattr(target, "gpg_recipient", None)
     kwargs["gpg_keyring"] = getattr(target, "gpg_keyring", None)
     kwargs["openssl_cipher"] = getattr(target, "openssl_cipher", None)
+
+
+def thread_raw_compression(kwargs: dict, target, override: str | None = None) -> None:
+    """Thread the EFFECTIVE compression into an endpoint config dict.
+
+    The mirror of ``thread_raw_encryption`` for compression. Without this, a raw
+    target's ``compress`` is dropped from the endpoint config and instead applied
+    by the generic *transfer layer* -- which is invisible to the raw ``.meta``
+    sidecar, so the sidecar records ``compress: null`` while the stream is actually
+    compressed. Restore then does not decompress and the backup is UNRESTORABLE.
+    Threading it here makes the raw endpoint own compression (in its own
+    ``send|compress|encrypt>file`` pipeline) and RECORD it in the sidecar, so
+    restore can reverse it. ``send_snapshot`` separately suppresses the
+    transfer-layer stage for raw destinations so the stream is never
+    double-compressed.
+
+    The effective value is the CLI ``--compress`` ``override`` if given, else the
+    target's configured ``compress`` -- the SAME expression the transfer options
+    use -- so a ``--compress`` override actually compresses a raw target (not just
+    non-raw ones) instead of being silently dropped. Harmless for non-raw targets
+    (dropped by the base config whitelist). After threading, feed the resulting
+    ``kwargs["compress"]`` to ``endpoint.assert_compression_applied`` so the guard
+    checks the effective value that was requested, not a possibly-different config
+    value (otherwise the guard is tautological and cannot catch a dropped override).
+    """
+    kwargs["compress"] = override or getattr(target, "compress", None)

--- a/src/btrfs_backup_ng/cli/run.py
+++ b/src/btrfs_backup_ng/cli/run.py
@@ -32,6 +32,7 @@ from .common import (
     get_log_level,
     get_timestamp_format,
     should_show_progress,
+    thread_raw_compression,
     thread_raw_encryption,
 )
 
@@ -358,12 +359,14 @@ def _backup_volume(
                 dest_kwargs["ssh_identity_file"] = target.ssh_key
 
             thread_raw_encryption(dest_kwargs, target)
+            thread_raw_compression(dest_kwargs, target, compress_override)
             dest_endpoint = endpoint.choose_endpoint(
                 target.path,
                 dest_kwargs,
                 source=False,
             )
             endpoint.assert_encryption_applied(target.encrypt, dest_endpoint)
+            endpoint.assert_compression_applied(dest_kwargs["compress"], dest_endpoint)
             dest_endpoint.prepare()
             # Store endpoint with its target config for compression/throttle options
             destination_endpoints.append((dest_endpoint, target))
@@ -540,10 +543,14 @@ def _backup_snapper_volume(
                 snapper_endpoint_config["ssh_identity_file"] = target.ssh_key
                 snapper_endpoint_config["ssh_key"] = target.ssh_key
             thread_raw_encryption(snapper_endpoint_config, target)
+            thread_raw_compression(snapper_endpoint_config, target, compress_override)
             destination_endpoint = endpoint.choose_endpoint(
                 target.path, snapper_endpoint_config
             )
             endpoint.assert_encryption_applied(target.encrypt, destination_endpoint)
+            endpoint.assert_compression_applied(
+                snapper_endpoint_config["compress"], destination_endpoint
+            )
 
             # Sync snapper snapshots to this target
             logger.info("Syncing snapper config '%s' to %s", config_name, target.path)

--- a/src/btrfs_backup_ng/cli/snapper_cmd.py
+++ b/src/btrfs_backup_ng/cli/snapper_cmd.py
@@ -245,10 +245,18 @@ def _handle_backup(args: argparse.Namespace) -> int:
         endpoint_config["gpg_recipient"] = getattr(args, "gpg_recipient", None)
         endpoint_config["gpg_keyring"] = getattr(args, "gpg_keyring", None)
         endpoint_config["openssl_cipher"] = getattr(args, "openssl_cipher", None)
+    # Compression for raw targets must be owned by the raw endpoint (recorded in the
+    # sidecar so restore can reverse it), not the transfer layer -- else the backup
+    # is unrestorable. Thread it here; send_snapshot suppresses the transfer-layer
+    # stage for raw so it is not double-compressed.
+    compress = getattr(args, "compress", None) or "none"
+    if compress != "none":
+        endpoint_config["compress"] = compress
     destination_endpoint = choose_endpoint(target_path, endpoint_config)
-    from ..endpoint import assert_encryption_applied
+    from ..endpoint import assert_compression_applied, assert_encryption_applied
 
     assert_encryption_applied(encrypt, destination_endpoint)
+    assert_compression_applied(compress, destination_endpoint)
 
     # Determine if this is a local or remote transfer
     is_remote = getattr(destination_endpoint, "_is_remote", False)

--- a/src/btrfs_backup_ng/cli/transfer.py
+++ b/src/btrfs_backup_ng/cli/transfer.py
@@ -9,7 +9,12 @@ from .. import __util__, endpoint
 from ..__logger__ import add_file_handler, create_logger
 from ..config import ConfigError, find_config_file, load_config
 from ..core.operations import sync_snapshots
-from .common import get_log_level, get_timestamp_format, thread_raw_encryption
+from .common import (
+    get_log_level,
+    get_timestamp_format,
+    thread_raw_compression,
+    thread_raw_encryption,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -159,12 +164,18 @@ def execute_transfer(args: argparse.Namespace) -> int:
                         dest_kwargs["ssh_identity_file"] = target.ssh_key
 
                     thread_raw_encryption(dest_kwargs, target)
+                    thread_raw_compression(
+                        dest_kwargs, target, getattr(args, "compress", None)
+                    )
                     dest_endpoint = endpoint.choose_endpoint(
                         target.path,
                         dest_kwargs,
                         source=False,
                     )
                     endpoint.assert_encryption_applied(target.encrypt, dest_endpoint)
+                    endpoint.assert_compression_applied(
+                        dest_kwargs["compress"], dest_endpoint
+                    )
                     dest_endpoint.prepare()
 
                     # Build transfer options with compression and throttling

--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -128,6 +128,23 @@ def send_snapshot(
     if clones:
         logger.info(f"  Using clones: {clones!r}")
 
+    # Raw targets own their compression INSIDE the endpoint pipeline (recorded in the
+    # .meta sidecar so restore can reverse it). Applying the generic transfer-layer
+    # compression on top would (a) double-compress and (b) be invisible to the
+    # sidecar, yielding a compressed stream restore cannot detect or decompress -> an
+    # UNRESTORABLE backup. Neutralize any transfer-layer compress for raw destinations
+    # up front (on a COPY, so the caller's options dict is untouched) so NEITHER the
+    # chunked nor the standard path can double-compress. This single choke point keeps
+    # every backup path safe, including ones that never thread compress into the
+    # endpoint -- those simply do not compress, but stay restorable.
+    from ..endpoint.raw import RawEndpoint
+
+    if (
+        isinstance(destination_endpoint, RawEndpoint)
+        and options.get("compress", "none") != "none"
+    ):
+        options = {**options, "compress": "none"}
+
     # Check if chunked transfer is requested
     use_chunked = options.get("use_chunked", False)
     if use_chunked and chunked_manager is None:

--- a/src/btrfs_backup_ng/endpoint/__init__.py
+++ b/src/btrfs_backup_ng/endpoint/__init__.py
@@ -35,6 +35,43 @@ def assert_encryption_applied(requested_encrypt, endpoint) -> None:
         )
 
 
+def assert_compression_applied(requested_compress, endpoint) -> None:
+    """Fail closed if requested compression did not reach the destination endpoint.
+
+    Defense-in-depth for the raw-target unrestorable-backup bug: a raw target's
+    ``compress`` must be owned by the raw endpoint (so it is recorded in the
+    ``.meta`` sidecar and restore can reverse it). If some config-threading site is
+    missed, the compression would instead be applied by the generic transfer layer,
+    invisibly to the sidecar -- producing a compressed stream that restore cannot
+    detect or decompress. Refuse to write rather than silently produce an
+    unrestorable backup. A no-op for non-raw endpoints, which legitimately delegate
+    compression to the transfer layer (their receive side decompresses
+    symmetrically). Call after building a destination endpoint and before transfer.
+
+    Raises:
+        AbortError: if ``requested_compress`` is a real method but a RAW endpoint
+            did not receive it.
+    """
+    if requested_compress in (None, "none"):
+        return
+    # Only raw endpoints record compression in a sidecar; non-raw targets decompress
+    # symmetrically at the transfer layer, so this guard does not apply to them.
+    from .raw import RawEndpoint
+
+    if not isinstance(endpoint, RawEndpoint):
+        return
+    effective = getattr(endpoint, "compress", None)
+    if effective in (None, "none"):
+        from .. import __util__
+
+        raise __util__.AbortError(
+            f"Compression '{requested_compress}' was requested for a raw target but "
+            f"the destination endpoint did not receive it. Writing now would record "
+            f"'compress: null' in the sidecar while the stream is compressed, "
+            f"producing an UNRESTORABLE backup; aborting instead."
+        )
+
+
 def choose_endpoint(spec, common_config=None, source=False, excluded_types=()):
     """
     Chooses a suitable endpoint based on the specification given.

--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -247,6 +247,11 @@ class RawEndpoint(Endpoint):
 
         # Raw-specific configuration
         self.compress = config.get("compress")
+        # "none" (the config sentinel) and None both mean no compression; normalize
+        # so a caller threading compress="none" is not treated as an unknown
+        # algorithm by the validation below (mirrors the encrypt handling).
+        if self.compress == "none":
+            self.compress = None
         self.encrypt = config.get("encrypt")
         # "none" (the documented string) and None both mean plaintext; normalize
         # so callers threading encrypt="none" do not trip the method validation.

--- a/tests/test_raw_compress_integrity.py
+++ b/tests/test_raw_compress_integrity.py
@@ -1,0 +1,228 @@
+"""Compression integrity for raw targets (0.8.5).
+
+A raw target's ``compress`` must be owned by the raw endpoint -- applied in its
+own pipeline AND recorded in the ``.meta`` sidecar -- so restore can reverse it.
+The bug these tests guard: compression routed to the generic transfer layer is
+invisible to the sidecar, so the sidecar records ``compress: null`` while the
+stream is compressed, producing an UNRESTORABLE backup.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from btrfs_backup_ng import __util__
+from btrfs_backup_ng.cli.common import thread_raw_compression
+from btrfs_backup_ng.core import operations
+from btrfs_backup_ng.endpoint import (
+    assert_compression_applied,
+    choose_endpoint,
+)
+from btrfs_backup_ng.endpoint.raw import RawEndpoint
+
+
+def _target(**kw):
+    ns = argparse.Namespace()
+    for k, v in kw.items():
+        setattr(ns, k, v)
+    return ns
+
+
+# --- thread_raw_compression --------------------------------------------------
+
+
+def test_thread_raw_compression_copies_target_compress():
+    kwargs: dict = {}
+    thread_raw_compression(kwargs, _target(compress="zstd"))
+    assert kwargs["compress"] == "zstd"
+
+
+def test_thread_raw_compression_defaults_none_when_absent():
+    kwargs: dict = {}
+    thread_raw_compression(kwargs, _target())  # no compress attr
+    assert kwargs["compress"] is None
+
+
+def test_thread_raw_compression_override_wins():
+    """A CLI --compress override must reach a raw endpoint (else it is silently
+    dropped and the raw target is written uncompressed despite the flag)."""
+    kwargs: dict = {}
+    thread_raw_compression(kwargs, _target(compress="none"), override="zstd")
+    assert kwargs["compress"] == "zstd"
+
+
+def test_thread_raw_compression_no_override_uses_target():
+    kwargs: dict = {}
+    thread_raw_compression(kwargs, _target(compress="gzip"), override=None)
+    assert kwargs["compress"] == "gzip"
+
+
+# --- assert_compression_applied (fail-closed guard) --------------------------
+
+
+def test_guard_raises_when_raw_endpoint_missing_compress(tmp_path):
+    """A raw endpoint that did NOT receive the requested compression must abort --
+    otherwise the stream is compressed by the transfer layer but the sidecar records
+    null, an unrestorable backup."""
+    ep = RawEndpoint(config={"path": str(tmp_path)})  # compress unset
+    assert ep.compress is None
+    with pytest.raises(__util__.AbortError, match="UNRESTORABLE"):
+        assert_compression_applied("zstd", ep)
+
+
+def test_guard_passes_when_raw_endpoint_has_compress(tmp_path):
+    ep = RawEndpoint(config={"path": str(tmp_path), "compress": "zstd"})
+    assert_compression_applied("zstd", ep)  # no raise
+
+
+def test_guard_noop_when_no_compression_requested(tmp_path):
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    assert_compression_applied(None, ep)
+    assert_compression_applied("none", ep)  # neither raises
+
+
+def test_guard_noop_for_non_raw_endpoint():
+    """Non-raw targets legitimately delegate compression to the transfer layer
+    (their receive side decompresses symmetrically), so the guard must not fire."""
+
+    class _NotRaw:
+        compress = None
+
+    assert_compression_applied("zstd", _NotRaw())  # no raise
+
+
+# --- config -> endpoint threading -------------------------------------------
+
+
+def test_choose_endpoint_threads_compress_into_raw_endpoint(tmp_path):
+    """The threaded compress key must survive choose_endpoint's whitelist and reach
+    RawEndpoint.compress (else it never gets recorded in the sidecar)."""
+    ep = choose_endpoint(f"raw://{tmp_path}", {"compress": "zstd"})
+    assert isinstance(ep, RawEndpoint)
+    assert ep.compress == "zstd"
+
+
+def test_compress_none_sentinel_normalized_not_rejected(tmp_path):
+    """The config sentinel compress="none" (the default for every target) must
+    normalize to no-compression, NOT be rejected as an unknown algorithm -- so
+    threading it on plaintext/uncompressed targets does not abort the backup."""
+    ep = choose_endpoint(f"raw://{tmp_path}", {"compress": "none"})
+    assert ep.compress is None
+    assert_compression_applied("none", ep)  # no false abort
+
+
+# --- write-time sidecar recording -------------------------------------------
+
+
+def test_commit_records_compress_in_sidecar_and_round_trips(tmp_path):
+    """End-to-end at the endpoint layer (no btrfs needed): a compress-configured raw
+    endpoint compresses the stream, records compress in the sidecar, and restore
+    (send) decompresses back to the exact original bytes."""
+    payload = b"btrfs-stream\x00" + b"the quick brown fox " * 5000
+    ep = RawEndpoint(config={"path": str(tmp_path), "compress": "gzip"})
+    src = tmp_path / "in.bin"
+    src.write_bytes(payload)
+    with open(src, "rb") as f:
+        ep.receive(f, snapshot_name="root.20240101T120000").communicate()
+    ep.commit_receive()
+
+    (snap,) = ep.list_snapshots(flush_cache=True)
+    assert snap.compress == "gzip"  # recorded in the sidecar
+    # The committed stream is really compressed (smaller than the raw payload).
+    assert snap.stream_path.stat().st_size < len(payload)
+    # Restore reverses it: send() decompresses back to the original bytes.
+    proc = ep.send(snap)
+    out, _ = proc.communicate()
+    assert out == payload
+
+
+# --- no double-compression at the transfer layer for raw ---------------------
+
+
+def test_send_snapshot_suppresses_transfer_compress_for_raw(tmp_path, monkeypatch):
+    """send_snapshot must neutralize transfer-layer compression for a raw
+    destination, so the raw endpoint is the ONLY thing that compresses (single,
+    sidecar-recorded compression). Otherwise: double-compression + null sidecar."""
+    captured: dict = {}
+
+    class _Stop(Exception):
+        pass
+
+    def fake_process_transfer(send_process, dest, receive_process, is_ssh, **kw):
+        captured["compress"] = kw.get("compress")
+        raise _Stop  # stop before the (irrelevant) post-transfer path
+
+    monkeypatch.setattr(operations, "_do_process_transfer", fake_process_transfer)
+
+    raw_ep = RawEndpoint(config={"path": str(tmp_path), "compress": "zstd"})
+    snap = Mock()
+    snap.get_path.return_value = str(tmp_path / "snap")
+    snap.__str__ = lambda self: "root.20240101T120000"
+    snap.endpoint.send.return_value = Mock()  # non-None send process
+
+    with pytest.raises(_Stop):
+        operations.send_snapshot(
+            snap, raw_ep, options={"compress": "zstd", "show_progress": False}
+        )
+    # The transfer layer was asked for NO compression despite options requesting zstd.
+    assert captured["compress"] == "none"
+
+
+def test_send_snapshot_preserves_transfer_compress_for_non_raw(tmp_path, monkeypatch):
+    """The raw suppression must NOT strip transfer-layer compression from non-raw
+    targets (local/ssh btrfs) -- they legitimately compress at the transfer layer and
+    decompress symmetrically on receive. Guards against a future edit widening the
+    isinstance check."""
+    captured: dict = {}
+
+    class _Stop(Exception):
+        pass
+
+    def fake_process_transfer(send_process, dest, receive_process, is_ssh, **kw):
+        captured["compress"] = kw.get("compress")
+        raise _Stop
+
+    monkeypatch.setattr(operations, "_do_process_transfer", fake_process_transfer)
+
+    # A non-raw destination (plain object, NOT a RawEndpoint instance).
+    class _NotRaw:
+        _is_remote = False
+        config = {"path": "/dest"}
+
+    snap = Mock()
+    snap.get_path.return_value = "/x/snap"
+    snap.__str__ = lambda self: "root.20240101T120000"
+    snap.endpoint.send.return_value = Mock()
+
+    with pytest.raises(_Stop):
+        operations.send_snapshot(
+            snap, _NotRaw(), options={"compress": "zstd", "show_progress": False}
+        )
+    assert captured["compress"] == "zstd"  # preserved for non-raw
+
+
+def test_ssh_raw_receive_pipeline_is_compress_then_encrypt(monkeypatch):
+    """raw+ssh (SSHRawEndpoint) must build the write pipeline compress-THEN-encrypt so
+    restore's decrypt-then-decompress reverses it, and it inherits the compress path
+    so the sidecar records it."""
+    from btrfs_backup_ng.endpoint.raw import SSHRawEndpoint
+
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "x")
+    ep = SSHRawEndpoint(
+        config={
+            "path": "/backup",
+            "hostname": "nas",
+            "compress": "zstd",
+            "encrypt": "openssl_enc",
+        }
+    )
+    assert ep.compress == "zstd"  # normalized/kept, will be recorded in the sidecar
+    stages = ep._build_receive_pipeline(Path("/backup/x.btrfs.zst.enc"))
+    # Find the compress and encrypt stages; compress must come first.
+    prog_order = [s[0] for s in stages]
+    assert "zstd" in prog_order and "openssl" in prog_order
+    assert prog_order.index("zstd") < prog_order.index("openssl")


### PR DESCRIPTION
## Summary

Fixes a **release-blocking bug** found during the 0.8.5 hardware-validation pass: a raw target configured with compression (`compress = "zstd"` in config, or `--compress zstd`) wrote a genuinely-compressed stream but recorded `compress: null` in the `.meta` sidecar. On restore the raw endpoint saw no compression, piped the compressed bytes straight into `btrfs receive`, and the restore **hung** — the backup was **unrestorable**.

Root cause: compression was applied by the generic *transfer layer* (symmetric with receive-side decompression for btrfs targets) but invisible to the raw sidecar. Encryption is threaded into the raw endpoint config (recorded, reversed on restore); compression was not — the same class of bug `thread_raw_encryption` was written to fix, but for compression the failure mode is *unrestorable data* rather than plaintext.

## The fix — make the raw endpoint own compression (mirror encryption)

- **`cli/common.py`**: new `thread_raw_compression(kwargs, target, override)` threads the **effective** compression (CLI `--compress` override, else the target's `compress`) into the raw endpoint config, so the endpoint compresses in its own `send | compress | encrypt > file` pipeline and **records it in the sidecar**. Wired into `run` (native + snapper), `transfer`, and the `snapper backup` command.
- **`endpoint/__init__.py`**: new `assert_compression_applied(requested, endpoint)` fail-closed guard (mirror of `assert_encryption_applied`) — aborts if a raw endpoint didn't receive the requested compression, instead of silently writing a compressed stream with a null sidecar. Fed the **effective** threaded value so it's non-tautological and catches a dropped `--compress` override.
- **`core/operations.py` `send_snapshot`**: for a `RawEndpoint` destination, neutralize the transfer-layer compression up front (on a *copy* of options), so the stream is never double-compressed. This single choke point also makes every non-threaded path (e.g. the legacy CLI) **safe** — those write an uncompressed-but-restorable stream with an accurate `compress: null` sidecar, never an unrestorable one.
- **`endpoint/raw.py`**: normalize `compress = "none"` → `None` (mirrors the existing `encrypt = "none"` handling) so the threaded config sentinel isn't rejected as an unknown algorithm.

`--compress` now actually compresses raw targets (previously silently dropped for raw). **Non-raw targets are unaffected** — they still compress at the transfer layer and decompress symmetrically on receive (verified by a dedicated regression test).

## Adversarial review

4-lens review (correctness / regression / completeness / security-data). All lenses confirmed the core fix closes the unrestorable-backup bug with no remaining compressed/null-sidecar path and no non-raw regression. It found a **HIGH** — `--compress` override and the guard were tautological (fed `target.compress`) — which is fixed in this PR by threading/guarding the effective value.

## Deferred (documented, not data-loss)

The legacy positional-argument CLI (`_legacy_main.py`) doesn't thread compress/encrypt into raw endpoints; the `send_snapshot` choke point keeps its raw backups uncompressed-but-restorable (accurate null sidecar). Honoring compress/encrypt there — and the parallel pre-existing legacy *encryption* gap — is left to a follow-up.

## Testing

- **Hardware-proven** on loopback btrfs + a real macOS/APFS `raw+ssh` target: `raw://` and `raw+ssh://` round-trips for **zstd, zstd+openssl, gpg, gpg+zstd**, and the `--compress` override all restore **byte-identical**; plaintext (compress sentinel `"none"`) does not false-abort. Single-compression confirmed via `btrfs-stream` magic after one `zstd -d`.
- 14 new tests in `tests/test_raw_compress_integrity.py`; the `send_snapshot` raw-suppression and the fail-closed guard are **mutation-verified**.
- Full suite: 2274 passed, 1 skipped. ruff / ruff-format@0.15.22 / mypy clean.
