### PR TITLE
fix(raw): stop a FIFO lock file from hanging every operation forever

### DIFF
--- a/src/btrfs_backup_ng/cli/raw_cmd.py
+++ b/src/btrfs_backup_ng/cli/raw_cmd.py
@@ -281,8 +281,10 @@ def _raw_backfill(args: argparse.Namespace) -> int:
                         entry["action"] = "error"
                         entry["error"] = str(e)
                 results.append(entry)
-    except RuntimeError as e:  # target busy (lock timeout)
-        print(f"Cannot backfill {spec}: {e}")
+    except (
+        RuntimeError
+    ) as e:  # target busy / hostile lock -- to stderr so --json stays clean
+        print(f"Cannot backfill {spec}: {e}", file=sys.stderr)
         return 1
     except Exception as e:  # pragma: no cover - defensive; endpoint errors vary
         logger.debug("raw backfill-metadata failed", exc_info=True)
@@ -456,8 +458,10 @@ def _raw_encrypt(args: argparse.Namespace) -> int:
     try:
         with lock_ctx:
             results = _process()
-    except RuntimeError as e:  # target busy (lock timeout)
-        print(f"Cannot encrypt {spec}: {e}")
+    except (
+        RuntimeError
+    ) as e:  # target busy / hostile lock -- to stderr so --json stays clean
+        print(f"Cannot encrypt {spec}: {e}", file=sys.stderr)
         return 1
 
     if getattr(args, "json", False):

--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -22,6 +22,7 @@ import os
 import re
 import shlex
 import shutil
+import stat
 import subprocess
 import time
 from collections.abc import Iterator
@@ -153,6 +154,33 @@ PARTIAL_SUFFIX = ".part"
 # Per-target advisory lock file. Mutating operations (backup commit, prune, backfill,
 # encrypt) hold an exclusive flock on it so they are mutually exclusive on one target.
 LOCK_FILENAME = ".btrfs-backup-ng.lock"
+
+
+def _lock_open_reason(e: OSError) -> str:
+    """A plain-language reason a lock-file open failed, for a user-facing message.
+
+    Translates the errno so a regular user sees why the lock could not be taken and
+    what to check, instead of a bare ``[Errno NN]`` repr (whose default text is
+    sometimes misleading -- e.g. ELOOP prints 'Too many levels of symbolic links'
+    for a single planted symlink)."""
+    reasons = {
+        errno.ELOOP: "it is a symlink (refused for safety)",
+        errno.EISDIR: "it is a directory, not a file",
+        errno.ENXIO: "it is a FIFO/special file with no reader (refused)",
+        errno.EACCES: (
+            "permission denied -- check the target directory's ownership and "
+            "permissions"
+        ),
+        errno.EPERM: (
+            "operation not permitted -- check the target directory's ownership and "
+            "permissions"
+        ),
+        errno.EROFS: "the filesystem is read-only",
+        errno.ENOTDIR: "a parent path component is not a directory",
+    }
+    if e.errno is None:
+        return str(e)
+    return reasons.get(e.errno, str(e))
 
 
 def _sha256_file(path: Path) -> str | None:
@@ -364,11 +392,14 @@ class RawEndpoint(Endpoint):
         and is auto-released if the process dies, so it can never go stale.
 
         Failure posture: a planted lock symlink (O_NOFOLLOW -> ELOOP), a lock that is
-        a directory (EISDIR), a foreign-owned/non-writable lock file (EACCES), or a
-        filesystem that cannot flock (ENOLCK) all raise RuntimeError rather than an
-        uncaught OSError -- so a hostile or mis-owned lock file degrades to the same
-        bounded fail/skip as contention instead of crashing every backup. The lock
-        lives inside the target directory, so that directory MUST NOT be writable by
+        a directory (EISDIR), a foreign-owned/non-writable lock file (EACCES), a
+        filesystem that cannot flock (ENOLCK), a planted FIFO/named-pipe (O_NONBLOCK
+        -> ENXIO instead of a permanent hang), and any non-regular lock target that
+        still opens (a FIFO with a reader, a device, or a socket -- refused by an
+        fstat check) all raise RuntimeError rather than an uncaught OSError -- so a
+        hostile or mis-created lock file degrades to the same bounded fail/skip as
+        contention instead of crashing (or hanging) every backup. The lock lives
+        inside the target directory, so that directory MUST NOT be writable by
         untrusted users. The raw+ssh subclass overrides this as a no-op (remote
         locking is a separate concern -- there is no persistent connection to hold an
         flock)."""
@@ -377,27 +408,47 @@ class RawEndpoint(Endpoint):
         path = Path(self.config["path"])
         path.mkdir(parents=True, exist_ok=True, mode=0o700)
         lockfile = path / LOCK_FILENAME
-        # O_NOFOLLOW: refuse a planted <target>/.btrfs-backup-ng.lock symlink so the
-        # (often root) open cannot be pointed at an arbitrary file, matching the
-        # symlink hardening elsewhere in this module. Any open failure (symlink,
-        # directory, foreign-owned/unwritable regular file) is mapped to RuntimeError
-        # so it cannot escape as an uncaught OSError and turn a hostile/mis-owned lock
-        # file into a permanent DoS on backups and prune.
+        # Harden the lock-file open against a hostile/mis-created lock:
+        #   O_NOFOLLOW  -- refuse a planted symlink (cannot redirect the often-root open)
+        #   O_NONBLOCK  -- a planted FIFO/named-pipe returns ENXIO immediately instead of
+        #                  blocking the open FOREVER waiting for a reader; without it a
+        #                  single FIFO wedges every backup/prune/maintenance op silently
+        #                  (a permanent DoS). No-op for a regular file.
+        # Any open failure is mapped to a bounded RuntimeError (with a plain-language
+        # reason) so it can never escape as an uncaught OSError.
         try:
-            fd = os.open(lockfile, os.O_WRONLY | os.O_CREAT | os.O_NOFOLLOW, 0o600)
-        except OSError as e:
-            logger.warning(
-                "Cannot open raw target lock file %s: %s -- a planted symlink, a "
-                "directory, or a foreign-owned/non-writable lock file. The target "
-                "directory must not be writable by untrusted users and the lock file "
-                "must be owned by the backup user.",
+            fd = os.open(
                 lockfile,
-                e,
+                os.O_WRONLY | os.O_CREAT | os.O_NOFOLLOW | os.O_NONBLOCK,
+                0o600,
             )
+        except OSError as e:
             raise RuntimeError(
-                f"raw target {path} is unavailable: cannot open its lock file "
-                f"{lockfile} ({e})"
+                f"raw target {path}: cannot acquire its lock file {lockfile} -- "
+                f"{_lock_open_reason(e)}. The target directory must not be writable by "
+                "untrusted users."
             ) from e
+        # Even if the open succeeded, refuse to trust anything that is not a REGULAR
+        # file: a FIFO that happened to have a reader, or a device/socket planted as
+        # the lock, must not be used to coordinate (or for any I/O).
+        try:
+            is_regular = stat.S_ISREG(os.fstat(fd).st_mode)
+        except OSError as e:
+            # Map to RuntimeError like every other branch here, so a stat failure on
+            # an exotic/hostile lock degrades to the bounded fail/skip posture rather
+            # than escaping as an uncaught OSError (which the prune path would not
+            # catch, and the CLI would misreport on stdout).
+            os.close(fd)
+            raise RuntimeError(
+                f"raw target {path}: cannot stat its lock file {lockfile} -- "
+                f"{_lock_open_reason(e)}"
+            ) from e
+        if not is_regular:
+            os.close(fd)
+            raise RuntimeError(
+                f"raw target {path}: lock file {lockfile} is not a regular file (a "
+                "FIFO, device, or socket may have been planted); refusing to use it"
+            )
         deadline = time.monotonic() + max(0.0, timeout)
         try:
             while True:

--- a/tests/test_raw_lock.py
+++ b/tests/test_raw_lock.py
@@ -7,6 +7,7 @@ file must never be mistaken for a backup stream.
 
 import argparse
 import os
+import signal
 import time
 from contextlib import contextmanager
 from pathlib import Path
@@ -77,6 +78,61 @@ def test_target_lock_excludes_across_processes(tmp_path):
         pass
     os.close(r)
     os.waitpid(pid, 0)
+
+
+def _raise_hung(*_a):
+    raise TimeoutError("target_lock hung")
+
+
+def test_fifo_lock_file_does_not_hang(tmp_path):
+    """A FIFO planted as the lock file must NOT block target_lock forever (O_NONBLOCK
+    -> ENXIO -> bounded RuntimeError). Without the fix the (often root) open blocks
+    indefinitely -- a silent permanent DoS on every backup/prune. A SIGALRM converts a
+    regression (hang) into a test failure instead of wedging the whole suite."""
+    os.mkfifo(tmp_path / LOCK_FILENAME)
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    old = signal.signal(signal.SIGALRM, _raise_hung)
+    signal.alarm(5)
+    try:
+        with pytest.raises(RuntimeError, match="FIFO|not a regular file"):
+            with ep.target_lock(timeout=1.0):
+                pass
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, old)
+
+
+def test_lock_fstat_failure_maps_to_runtime_error(tmp_path, monkeypatch):
+    """If fstat on the freshly-opened lock fd fails (exotic/hostile fs), it must
+    degrade to a bounded RuntimeError -- NOT escape as an uncaught OSError (the prune
+    path catches only RuntimeError, and the CLI would misreport an OSError on stdout)."""
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+
+    def boom(_fd):
+        raise OSError(5, "simulated fstat failure")
+
+    monkeypatch.setattr(raw_mod.os, "fstat", boom)
+    with pytest.raises(RuntimeError, match="cannot stat"):
+        with ep.target_lock(timeout=1.0):
+            pass
+
+
+def test_hostile_lock_messages_are_plain_language(tmp_path):
+    """Hostile/mis-created lock files must surface a plain-language reason (not a bare
+    [Errno NN] repr), so a regular user understands what to fix."""
+    for i, (setup, word) in enumerate(
+        [
+            (lambda p: p.mkdir(), "directory"),
+            (lambda p: p.symlink_to("/etc/hostname"), "symlink"),
+        ]
+    ):
+        d = tmp_path / f"c{i}"
+        d.mkdir()
+        setup(d / LOCK_FILENAME)
+        ep = RawEndpoint(config={"path": str(d)})
+        with pytest.raises(RuntimeError, match=word):
+            with ep.target_lock(timeout=1.0):
+                pass
 
 
 def test_planted_lock_directory_degrades_to_runtime_error(tmp_path):
@@ -166,7 +222,8 @@ def test_backfill_reports_busy_target(tmp_path, monkeypatch, capsys):
         )
     )
     assert rc == 1
-    assert "busy" in capsys.readouterr().out
+    # The lock error goes to stderr (so a --json run's stdout stays valid JSON).
+    assert "busy" in capsys.readouterr().err
 
 
 def test_encrypt_reports_busy_target(tmp_path, monkeypatch, capsys):
@@ -195,7 +252,8 @@ def test_encrypt_reports_busy_target(tmp_path, monkeypatch, capsys):
         )
     )
     assert rc == 1
-    assert "busy" in capsys.readouterr().out
+    # The lock error goes to stderr (so a --json run's stdout stays valid JSON).
+    assert "busy" in capsys.readouterr().err
 
 
 def test_prune_takes_lock_once_for_whole_pass(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

The first of the raw-robustness hardening PRs (from the empirical adversarial break campaign). Fixes a **CRITICAL DoS**: a FIFO (or other special file) planted as a raw target's lock file `<target>/.btrfs-backup-ng.lock` made `target_lock()` block **forever** — opening a FIFO `O_WRONLY` waits for a reader that never comes, so `lock_timeout` never fired and every backup commit, prune, `raw backfill-metadata`, and `raw encrypt` on that target wedged silently. Confirmed hang / exit 124.

## Fix
- **`O_NONBLOCK`** on the lock open (with `O_NOFOLLOW`): a FIFO returns ENXIO immediately → the existing bounded RuntimeError. No-op for a regular file; does not affect `flock`.
- **`fstat` reject**: after the open, refuse anything that is not a regular file (a FIFO with a reader, a device, or a socket), closing the fd first. A stat failure is itself mapped to RuntimeError so no `OSError` can escape the method's contract.
- **Plain-language errno** reasons (symlink / directory / FIFO / permission / read-only) instead of a misleading bare `[Errno NN]` repr; the redundant WARNING that duplicated the message is dropped.
- Lock-error prints in `raw backfill-metadata`/`raw encrypt` now go to **stderr** so a `--json` run keeps stdout valid JSON.

## Adversarial review
2-lens review (security+correctness / regression+completeness) confirmed the DoS is fully closed — empirically reproduced FIFO (no reader **and** with a reader), symlink, directory, socket, and char/block device locks, all refused with a bounded RuntimeError; TOCTOU-safe (fstat is inode-bound to the opened fd); no fd leak. It caught one MEDIUM (bare `raise` on fstat failure leaking an OSError) — fixed and mutation-verified.

## Testing
Empirically verified every special-file lock type raises a clean RuntimeError (no hang, no traceback); CLI exits 1 (was 124). 16 lock tests — the FIFO-no-hang (SIGALRM-guarded), fstat-mapping, and hostile-message tests are **mutation-verified**. Full suite: 2277 passed. ruff / ruff-format@0.15.22 / mypy clean.