### PR TITLE
fix(raw): fail loud when a raw stream cannot be decoded or a tool is missing

### DIFF
--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -30,6 +30,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, TypedDict
 
+from btrfs_backup_ng import __util__
 from btrfs_backup_ng.__logger__ import logger
 from btrfs_backup_ng.endpoint.common import Endpoint
 from btrfs_backup_ng.endpoint.raw_metadata import (
@@ -483,8 +484,16 @@ class RawEndpoint(Endpoint):
             logger.info("Creating raw target directory: %s", path)
             path.mkdir(parents=True, exist_ok=True, mode=0o700)
 
-        # Verify required tools are available
-        self._check_tools()
+        # Fail loud (before any transfer) with an actionable message if a required
+        # compression/encryption tool is missing, instead of a raw errno part-way
+        # through the send pipeline.
+        missing = self._check_tools()
+        if missing:
+            raise __util__.AbortError(
+                f"Cannot back up to raw target {path}: the required tool(s) "
+                f"{', '.join(missing)} are not installed. Install them (or change the "
+                "compress/encrypt method) and retry."
+            )
 
     def _check_tools(self) -> list[str]:
         """Check that required tools are available.
@@ -992,6 +1001,7 @@ class RawEndpoint(Endpoint):
             raise FileNotFoundError(f"Stream file not found: {snapshot.stream_path}")
 
         pipeline = self._build_restore_pipeline(snapshot)
+        self._preflight_restore_tools(pipeline, snapshot)
         return self._execute_restore_pipeline(pipeline, snapshot.stream_path)
 
     def _build_restore_pipeline(self, snapshot: RawSnapshot) -> list[list[str]]:
@@ -1035,19 +1045,69 @@ class RawEndpoint(Endpoint):
                 _openssl_pass_arg(),
             ]
             pipeline.append(openssl_cmd)
+        elif snapshot.encrypt:
+            # The sidecar records an encryption method this version does not know how
+            # to reverse. NEVER silently skip decryption -- that would pipe the still
+            # ENCRYPTED bytes into btrfs receive and produce a corrupt restore with no
+            # error (the same silent-corruption class as an unknown compression).
+            raise __util__.AbortError(
+                f"Cannot restore {snapshot.name}: it is encrypted with "
+                f"{snapshot.encrypt!r}, which this version cannot decrypt (supported: "
+                "gpg, openssl_enc). Restore with a version that supports it."
+            )
 
         # Decompression stage
         if snapshot.compress:
-            config = COMPRESSION_CONFIG.get(snapshot.compress, {})
-            cmd = config.get("decompress_cmd", [])
-            if cmd:
-                pipeline.append(list(cmd))
+            config = COMPRESSION_CONFIG.get(snapshot.compress)
+            cmd = config.get("decompress_cmd", []) if config else []
+            if not cmd:
+                # The sidecar records a compression this version cannot reverse. NEVER
+                # silently skip decompression -- that pipes the still-compressed bytes
+                # into btrfs receive and produces a corrupt restore with no error.
+                supported = ", ".join(sorted(COMPRESSION_CONFIG))
+                raise __util__.AbortError(
+                    f"Cannot restore {snapshot.name}: it is compressed with "
+                    f"{snapshot.compress!r}, which this version cannot decompress "
+                    f"(supported: {supported}). Restore with a version that supports "
+                    "it, or decompress the stream manually."
+                )
+            pipeline.append(list(cmd))
 
         # If no processing needed, just cat
         if not pipeline:
             pipeline.append(["cat"])
 
         return pipeline
+
+    @staticmethod
+    def _describe_pipeline(snapshot: RawSnapshot) -> str:
+        """A short human phrase describing a snapshot's pipeline, for error messages."""
+        parts = []
+        if snapshot.compress:
+            parts.append(f"compressed with {snapshot.compress}")
+        if snapshot.encrypt:
+            parts.append(f"encrypted with {snapshot.encrypt}")
+        return " and ".join(parts) if parts else "a plain btrfs stream"
+
+    def _preflight_restore_tools(
+        self, pipeline: list[list[str]], snapshot: RawSnapshot
+    ) -> None:
+        """Fail loud (before any bytes flow) if a tool the restore pipeline needs is
+        not installed, so a missing decompressor/decryptor gives a clear, actionable
+        message instead of a raw FileNotFoundError traceback part-way through the
+        restore. Kept separate from pipeline CONSTRUCTION so the built pipeline can be
+        inspected without requiring the tools to be present."""
+        for stage in pipeline:
+            tool = stage[0]
+            # "cat" is the pipeline's no-op passthrough sentinel (always present,
+            # never a decoder), so skipping it is not a generic "assume installed".
+            if tool != "cat" and shutil.which(tool) is None:
+                raise __util__.AbortError(
+                    f"Cannot restore {snapshot.name}: the tool {tool!r} is required "
+                    "to restore this backup (it is "
+                    f"{self._describe_pipeline(snapshot)}) but is not installed. "
+                    f"Install {tool!r} and retry."
+                )
 
     def _execute_restore_pipeline(
         self, pipeline: list[list[str]], input_path: Path
@@ -1368,8 +1428,15 @@ class SSHRawEndpoint(RawEndpoint):
                 "SMB/NFS/cloud target, mount it locally and use a raw:// path."
             )
 
-        # Check local tools
-        self._check_tools()
+        # Check local tools (compression/encryption run locally before the ssh pipe);
+        # fail loud with an actionable message rather than a raw errno mid-transfer.
+        missing = self._check_tools()
+        if missing:
+            raise __util__.AbortError(
+                f"Cannot back up to raw+ssh target {self.hostname}: the required local "
+                f"tool(s) {', '.join(missing)} are not installed. Install them (or "
+                "change the compress/encrypt method) and retry."
+            )
 
     def _execute_pipeline(
         self, pipeline: list[list[str]], stdin: Any
@@ -1696,6 +1763,11 @@ class SSHRawEndpoint(RawEndpoint):
         if not isinstance(snapshot, RawSnapshot):
             raise TypeError(f"Expected RawSnapshot, got {type(snapshot)}")
         remote = str(snapshot.stream_path)
+        # Build + preflight the LOCAL decrypt/decompress pipeline FIRST, so an
+        # undecodable sidecar (unknown algo/cipher) or a missing local tool fails
+        # offline and instantly, before we open an ssh connection to the remote.
+        pipeline = self._build_restore_pipeline(snapshot)
+        self._preflight_restore_tools(pipeline, snapshot)
         # Clear error if the stream is not on the remote (vs a cryptic pipe fail).
         test = self._exec_remote_command(
             ["sh", "-c", f"test -f {shlex.quote(remote)}"], check=False
@@ -1705,7 +1777,6 @@ class SSHRawEndpoint(RawEndpoint):
                 f"Remote stream not found: {self.hostname}:{remote}"
             )
 
-        pipeline = self._build_restore_pipeline(snapshot)  # LOCAL decrypt/decompress
         ssh_cmd = self._build_ssh_command()
         remote_cat = f"cat {shlex.quote(remote)}"
         if self.ssh_sudo:

--- a/tests/test_raw_pipeline_validation.py
+++ b/tests/test_raw_pipeline_validation.py
@@ -1,0 +1,94 @@
+"""Raw pipeline tool validation (restore + backup).
+
+A restore must FAIL LOUD when it cannot actually decode a stream -- an unknown
+compression algorithm recorded in the sidecar (T5) or a missing decompress/decrypt
+tool (T2) -- instead of silently piping bad data into ``btrfs receive`` or crashing
+with a raw ``FileNotFoundError``. A backup must fail its preflight (not mid-transfer)
+when a required compress/encrypt tool is absent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import btrfs_backup_ng.endpoint.raw as raw_mod
+from btrfs_backup_ng.__util__ import AbortError
+from btrfs_backup_ng.endpoint.raw import RawEndpoint
+from btrfs_backup_ng.endpoint.raw_metadata import RawSnapshot
+
+
+# --- T5: unknown compression algorithm must not silently pass through ---------
+
+
+def test_unknown_compress_algo_fails_loud(tmp_path):
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    snap = RawSnapshot(
+        name="s", stream_path=tmp_path / "s.btrfs", compress="frobnicate"
+    )
+    with pytest.raises(AbortError, match="cannot decompress"):
+        ep._build_restore_pipeline(snap)
+
+
+def test_unknown_encrypt_method_fails_loud(tmp_path):
+    """Symmetric to the compress case: an encryption method the sidecar records but
+    this version cannot reverse must NOT silently pass the encrypted bytes through."""
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    snap = RawSnapshot(
+        name="s", stream_path=tmp_path / "s.btrfs.enc", encrypt="future_cipher_v9"
+    )
+    with pytest.raises(AbortError, match="cannot decrypt"):
+        ep._build_restore_pipeline(snap)
+
+
+# --- T2: tool preflight (restore) --------------------------------------------
+
+
+def test_restore_missing_tool_preflights_with_clear_message(tmp_path, monkeypatch):
+    stream = tmp_path / "s.20240101T120000.btrfs.zst"
+    stream.write_bytes(b"x")
+    RawSnapshot(
+        name="s.20240101T120000", stream_path=stream, compress="zstd", size=1
+    ).save_metadata()
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    (snap,) = ep.list_snapshots(flush_cache=True)
+    monkeypatch.setattr(raw_mod.shutil, "which", lambda _t: None)  # nothing installed
+    with pytest.raises(AbortError, match="zstd.*not installed|Install 'zstd'"):
+        ep.send(snap)
+
+
+def test_restore_preflight_passes_when_tools_present(tmp_path):
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    snap = RawSnapshot(name="s", stream_path=tmp_path / "s.btrfs.zst", compress="zstd")
+    pipeline = ep._build_restore_pipeline(snap)
+    ep._preflight_restore_tools(pipeline, snap)  # zstd installed -> no raise
+
+
+def test_pipeline_construction_is_independent_of_tool_availability(
+    tmp_path, monkeypatch
+):
+    """Building the pipeline must NOT require the tools to be installed -- the
+    availability check is a separate preflight. Guards the construction/preflight
+    split so `_build_restore_pipeline` can be inspected in any environment."""
+    monkeypatch.setattr(raw_mod.shutil, "which", lambda _t: None)
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    snap = RawSnapshot(name="s", stream_path=tmp_path / "s.btrfs.zst", compress="zstd")
+    pipeline = ep._build_restore_pipeline(snap)  # must not raise despite which=None
+    assert any("zstd" in stage[0] for stage in pipeline)
+
+
+# --- T2: tool preflight (backup) ---------------------------------------------
+
+
+def test_backup_prepare_fails_loud_on_missing_tool(tmp_path, monkeypatch):
+    ep = RawEndpoint(config={"path": str(tmp_path), "compress": "zstd"})
+    monkeypatch.setattr(raw_mod.shutil, "which", lambda _t: None)
+    with pytest.raises(AbortError, match="not installed"):
+        ep.prepare()
+
+
+def test_backup_prepare_ok_when_tools_present(tmp_path):
+    ep = RawEndpoint(config={"path": str(tmp_path), "compress": "zstd"})
+    ep.prepare()  # zstd installed here -> no raise
+    assert Path(tmp_path).exists()

--- a/tests/test_raw_ssh_restore.py
+++ b/tests/test_raw_ssh_restore.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from btrfs_backup_ng.__util__ import AbortError
 from btrfs_backup_ng.endpoint.raw import SSHRawEndpoint
 from btrfs_backup_ng.endpoint.raw_metadata import RawSnapshot
 
@@ -77,6 +78,21 @@ def test_prepare_preflight_passes_when_tools_present():
     ):
         with patch.object(ep, "_check_tools", return_value=[]):
             ep._prepare()  # must not raise
+
+
+def test_prepare_fails_loud_when_local_compress_tool_missing():
+    """A raw+ssh backup whose LOCAL compress/encrypt tool is missing (compression
+    runs locally before the ssh pipe) must fail its preflight with an actionable
+    message, not a raw errno part-way through the transfer."""
+    ep = SSHRawEndpoint(
+        config={"path": "/backup", "hostname": "nas", "compress": "zstd"}
+    )
+    with patch(
+        "subprocess.run", return_value=MagicMock(returncode=0, stdout=b"RAWSSHOK\n")
+    ):
+        with patch("btrfs_backup_ng.endpoint.raw.shutil.which", return_value=None):
+            with pytest.raises(AbortError, match="not installed"):
+                ep._prepare()
 
 
 def test_send_encrypted_decrypts_locally_after_ssh_cat():


### PR DESCRIPTION
## Summary

Two robustness fixes from the empirical adversarial break campaign, both on the paths that matter most for a backup tool.

**1. Unknown pipeline → silent corrupt restore (CRITICAL).** `_build_restore_pipeline` silently skipped the stage when the sidecar recorded a compression algorithm — *or an encryption method* — this version doesn't know: the still-compressed (or still-**encrypted**) bytes were piped into `btrfs receive`, producing a corrupt restore with rc 0 and no error. Now an unrecognized `compress`/`encrypt` value raises a clear `AbortError` listing the supported methods — it can never pass undecoded bytes forward.

**2. Missing tool → opaque failure (HIGH).** A decompressor/decryptor absent at restore threw a raw `FileNotFoundError` traceback; on backup, `prepare()` checked the tools but only warned and proceeded, so a missing tool surfaced as a raw errno mid-transfer. Restore now **preflights** every tool in the built pipeline (new `_preflight_restore_tools`, run by both local and raw+ssh `send()` before any bytes flow), and both `_prepare()` methods now abort with an actionable *"install X and retry"*.

Construction and preflight are kept **separate** (the pipeline can be inspected without the tools installed). For raw+ssh, the local decode pipeline is built + preflighted **before** the remote round-trip, so an undecodable sidecar or missing local tool fails offline and instantly.

## Adversarial review
2-lens review (correctness/data-integrity + regression/delivery). Verdict: **no correctness or data-integrity defects**. It confirmed the unknown-algo check catches wrong-typed values, the preflight covers both `send()` callers, and the `AbortError` is delivered cleanly on every path (`core/restore.py` catches `AbortError`; `verify`'s decrypt-proof degrades to keep-plaintext). It specifically hunted the symmetric **encryption** silent-skip — which this PR already closes. Findings addressed: a codecov coverage gap (added an SSH backup-preflight test), the SSH offline-fail reorder, and a sentinel comment.

## Testing
Empirically verified end-to-end: CLI `restore` of an unknown-algorithm backup exits 1 with a clean message and **no traceback** (no silent corruption); missing restore/backup tools abort with "install X". 8 new tests; the unknown-algo/unknown-cipher raises, the restore preflight, and the backup preflight are **mutation-verified**. Full suite: 2285 passed; ruff / ruff-format@0.15.22 / mypy clean.