### PR TITLE
fix(raw): verify a stored stream before restoring it, and pipefail the restore

### DIFF
--- a/src/btrfs_backup_ng/cli/dispatcher.py
+++ b/src/btrfs_backup_ng/cli/dispatcher.py
@@ -599,6 +599,13 @@ Config-driven restore:
         help="Force full transfers (don't use incremental)",
     )
     restore_parser.add_argument(
+        "--skip-verify",
+        action="store_true",
+        help="Skip the pre-restore integrity check for raw backups (restore even if "
+        "the stored stream's checksum no longer matches, and skip the extra read). "
+        "Use for last-copy recovery of a partially-corrupt backup.",
+    )
+    restore_parser.add_argument(
         "--overwrite",
         action="store_true",
         help="Overwrite existing snapshots instead of skipping",

--- a/src/btrfs_backup_ng/cli/restore.py
+++ b/src/btrfs_backup_ng/cli/restore.py
@@ -466,6 +466,9 @@ def _prepare_backup_endpoint(args: argparse.Namespace, source: str):
         endpoint_kwargs,
         source=False,
     )
+    # Restore-time integrity check for raw targets: default ON, disabled by
+    # --skip-verify (for last-copy recovery of a partially-corrupt backup).
+    backup_ep.config["verify_before_restore"] = not getattr(args, "skip_verify", False)
     backup_ep.prepare()
 
     return backup_ep

--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -1002,7 +1002,55 @@ class RawEndpoint(Endpoint):
 
         pipeline = self._build_restore_pipeline(snapshot)
         self._preflight_restore_tools(pipeline, snapshot)
+        self._verify_stream_integrity(snapshot)
         return self._execute_restore_pipeline(pipeline, snapshot.stream_path)
+
+    def _verify_stream_integrity(self, snapshot: RawSnapshot) -> None:
+        """Refuse to restore a stored stream that no longer matches the sha256 sealed
+        when it was written -- so a corrupted/truncated backup is detected UP FRONT
+        instead of being decoded into a corrupt subvolume (or, worse, partially
+        applied). Reads the stream once to hash it (on the remote for raw+ssh, via
+        the ``compute_stream_checksum`` override -- no re-download); the extra read is
+        the price of not restoring silently-bad data.
+
+        Skipped when the sidecar recorded no checksum (a legacy backup) or a non-sha256
+        algorithm -- there is nothing to compare against, and the restore's own decode
+        step still surfaces a genuinely unreadable stream. Also skipped (for last-copy
+        recovery of a partially-corrupt backup, and to avoid the extra full read) when
+        ``verify_before_restore`` is turned off via the restore ``--skip-verify`` flag.
+
+        NOTE (raw+ssh trust model): for a remote target both the recomputed digest and
+        the recorded checksum come from the (untrusted) remote, so this detects at-rest
+        CORRUPTION, not tampering -- a compromised target could forge a match. Verify a
+        ``raw://`` copy for tamper-evidence (same caveat as ``raw verify``)."""
+        if not self.config.get("verify_before_restore", True):
+            logger.warning(
+                "Integrity check skipped for %s (--skip-verify): restoring without "
+                "confirming the stored stream matches its recorded checksum.",
+                snapshot.name,
+            )
+            return
+        recorded = snapshot.checksum_value
+        if not recorded or snapshot.checksum_algorithm != "sha256":
+            return
+        computed = self.compute_stream_checksum(snapshot)
+        if computed is None:
+            # Could not hash the stream -- do not BLOCK the restore on an inability to
+            # verify (the decode step will surface a real read error); just note it.
+            logger.warning(
+                "Could not verify %s before restore (checksum unreadable); proceeding",
+                snapshot.name,
+            )
+            return
+        if computed != recorded:
+            raise __util__.AbortError(
+                f"Refusing to restore {snapshot.name}: the stored stream is CORRUPT "
+                f"(its sha256 {computed} does not match {recorded}, sealed when it was "
+                "backed up). The backup on disk has changed since it was written. "
+                "Restore an intact copy if you have one; if this is the only copy, "
+                "'restore --skip-verify' will attempt it anyway (the result may be "
+                "incomplete). Run 'raw verify' to inspect the target."
+            )
 
     def _build_restore_pipeline(self, snapshot: RawSnapshot) -> list[list[str]]:
         """Build the decryption/decompression pipeline for restore.
@@ -1138,14 +1186,16 @@ class RawEndpoint(Endpoint):
 
         logger.debug("Executing restore pipeline: %s", shell_cmd)
 
-        proc = subprocess.Popen(
+        # pipefail so a mid-pipe decrypt/decompress failure (e.g. a wrong passphrase,
+        # a truncated stream) is NOT masked by the last stage exiting 0 -- otherwise a
+        # garbage/partial stream could be fed to btrfs receive and reported as a
+        # successful restore. Mirrors the write pipeline.
+        return _popen_pipeline_pipefail(
             shell_cmd,
-            shell=True,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        return proc
 
     def list_snapshots(self, flush_cache: bool = False) -> list[RawSnapshot]:
         """List all raw snapshots in the target directory.
@@ -1776,6 +1826,10 @@ class SSHRawEndpoint(RawEndpoint):
             raise FileNotFoundError(
                 f"Remote stream not found: {self.hostname}:{remote}"
             )
+        # Verify the remote stream against its sealed sha256 (hashed ON the remote --
+        # no re-download) before streaming it down, so a corrupted remote backup is
+        # refused up front rather than decoded into a corrupt subvolume.
+        self._verify_stream_integrity(snapshot)
 
         ssh_cmd = self._build_ssh_command()
         remote_cat = f"cat {shlex.quote(remote)}"

--- a/tests/test_raw_restore_integrity.py
+++ b/tests/test_raw_restore_integrity.py
@@ -1,0 +1,111 @@
+"""Restore-side integrity (T1).
+
+Restore must not feed bad data into ``btrfs receive``: it verifies the stored
+stream against the sha256 sealed at backup time BEFORE decoding (so a corrupted
+backup is refused, not decoded into a corrupt subvolume), and the multi-stage
+restore pipeline runs under ``pipefail`` so a mid-pipe decrypt/decompress failure
+cannot be masked by the last stage exiting 0.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from btrfs_backup_ng.__util__ import AbortError
+from btrfs_backup_ng.endpoint.raw import RawEndpoint
+from btrfs_backup_ng.endpoint.raw_metadata import RawSnapshot
+
+
+def _sealed(tmp_path, *, corrupt=False, checksum=True):
+    data = b"btrfs-stream\x00" + b"payload " * 2000
+    stream = tmp_path / "root.20240101T120000.btrfs"
+    stream.write_bytes(data)
+    kw = {"checksum_value": hashlib.sha256(data).hexdigest()} if checksum else {}
+    RawSnapshot(
+        name="root.20240101T120000", stream_path=stream, size=len(data), **kw
+    ).save_metadata()
+    if corrupt:
+        b = bytearray(stream.read_bytes())
+        b[5000] ^= 0xFF
+        stream.write_bytes(bytes(b))
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    return ep, ep.list_snapshots(flush_cache=True)[0]
+
+
+def test_corrupt_stored_stream_is_refused_before_restore(tmp_path):
+    ep, snap = _sealed(tmp_path, corrupt=True)
+    with pytest.raises(AbortError, match="CORRUPT"):
+        ep.send(snap)
+
+
+def test_intact_stream_passes_verification_and_restores(tmp_path):
+    ep, snap = _sealed(tmp_path, corrupt=False)
+    proc = ep.send(snap)  # verify passes -> restore proceeds
+    proc.stdout.read()
+    proc.wait()
+    assert proc.returncode == 0
+
+
+def test_legacy_stream_without_checksum_skips_verify(tmp_path):
+    """A legacy backup with no recorded checksum has nothing to compare against, so
+    verification is skipped (it must not block the restore)."""
+    ep, snap = _sealed(tmp_path, checksum=False)
+    assert snap.checksum_value is None
+    proc = ep.send(snap)  # must not raise
+    proc.stdout.read()
+    proc.wait()
+
+
+def test_verify_does_not_block_when_checksum_unreadable(tmp_path, monkeypatch):
+    """If the stream cannot be hashed, verification must not BLOCK the restore (the
+    decode step surfaces a genuine read error); it warns and proceeds."""
+    ep, snap = _sealed(tmp_path, corrupt=False)
+    monkeypatch.setattr(ep, "compute_stream_checksum", lambda _s: None)
+    proc = ep.send(snap)  # must not raise despite unreadable checksum
+    proc.stdout.read()
+    proc.wait()
+
+
+def test_skip_verify_allows_corrupt_restore_for_last_copy_recovery(tmp_path):
+    """--skip-verify (verify_before_restore=False) must let a corrupt stream through
+    (last-copy recovery), warning instead of hard-refusing."""
+    ep, snap = _sealed(tmp_path, corrupt=True)
+    ep.config["verify_before_restore"] = False  # as _prepare_backup_endpoint sets it
+    proc = ep.send(snap)  # must NOT raise despite the corruption
+    proc.stdout.read()
+    proc.wait()
+
+
+def test_restore_pipeline_pipefail_surfaces_midpipe_failure(tmp_path):
+    """A real multi-stage restore where an EARLY stage fails but the LAST exits 0 must
+    still report non-zero -- proving pipefail actually surfaces a masked mid-pipe
+    failure (without it, `false | cat` returns the last stage's 0)."""
+    ep, snap = _sealed(tmp_path, corrupt=False)
+    proc = ep._execute_restore_pipeline([["false"], ["cat"]], snap.stream_path)
+    proc.communicate()
+    assert proc.returncode != 0
+
+
+def test_multistage_restore_pipeline_uses_pipefail(tmp_path, monkeypatch):
+    """A multi-stage restore pipeline (decrypt|decompress) must run under pipefail so
+    a mid-pipe failure is not masked by the last stage's exit 0."""
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "x")
+    stream = tmp_path / "root.20240101T120000.btrfs.gz.enc"
+    stream.write_bytes(b"data")
+    RawSnapshot(
+        name="root.20240101T120000",
+        stream_path=stream,
+        compress="gzip",
+        encrypt="openssl_enc",
+        openssl_cipher="aes-256-cbc",
+        size=4,
+    ).save_metadata()
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    (snap,) = ep.list_snapshots(flush_cache=True)
+    with patch("btrfs_backup_ng.endpoint.raw._popen_pipeline_pipefail") as pp:
+        pp.return_value = MagicMock()
+        ep.send(snap)
+    assert pp.called  # the multi-stage restore went through the pipefail helper


### PR DESCRIPTION
## Summary

The last of the three critical restore/write-integrity fixes from the empirical break campaign.

**1. Verify-before-restore.** Both local and raw+ssh `send()` now recompute the stored stream's sha256 and compare it to the value sealed in the sidecar at backup time **before decoding anything** — a corrupted/truncated backup is **refused up front** (clean `AbortError`, no bytes written) instead of decoded into a corrupt subvolume. Skipped for legacy (no checksum) or unreadable streams. raw+ssh hashes **on the remote** (no re-download); like `raw verify`, that's at-rest corruption detection, not tamper-resistance.

Default-ON but **escapable**: `restore --skip-verify` bypasses the check (and the extra read) so a partially-corrupt **last copy** can still be attempted — `btrfs receive` then extracts what it can or fails cleanly. The refusal message names the flag.

**2. Pipefail on restore.** The multi-stage restore pipeline now runs under `set -o pipefail` (the same helper the write path uses), so a mid-pipe decrypt/decompress failure can no longer be masked by the last stage exiting 0 and reported as a successful restore.

## Adversarial review
2-lens review (correctness/data-integrity + regression/UX). Verdict: **no data-integrity defects**; the verify runs before any byte flows, delivers cleanly per-snapshot (`core/restore.py` catches `AbortError`, one corrupt stream fails only itself in `restore --all`). It raised a **MEDIUM** — refusing a last copy with no override — which this PR addresses with `--skip-verify`; plus nits (raw+ssh trust comment, a real non-mocked pipefail test, getattr simplification) all folded in.

## Testing
Hardware-proven: intact restore byte-identical; corrupt stored stream → clean "CORRUPT" refusal, exit 1, no traceback, **zero** subvolumes written; `--skip-verify` attempts it and btrfs receive fails cleanly. Mutation-verified: the verify call, the pipefail wiring, and (non-mocked) that pipefail surfaces a masked `false | cat` mid-pipe failure. Full suite: 2292 passed; ruff / ruff-format@0.15.22 / mypy clean.