### PR TITLE
fix(raw): never report an unreachable raw+ssh target as an empty one

### DIFF
--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -184,6 +184,42 @@ def _lock_open_reason(e: OSError) -> str:
     return reasons.get(e.errno, str(e))
 
 
+def _check_remote_listing(
+    result: subprocess.CompletedProcess, host: str, path: Any
+) -> None:
+    """Guard a remote enumeration so a CONNECTION failure is never reported as an
+    empty target.
+
+    A raw+ssh ``list``/``verify`` that cannot reach the host must NOT silently return
+    "0 snapshots" / "all ok" -- that is a false all-clear that hides a down server (or
+    makes lost backups look intentionally absent). ``ssh`` exits 255 on its own
+    connection/auth/DNS failures, so that is raised as a clear error. A ``find`` on an
+    empty but reachable directory exits 0 (a genuinely empty target); any other
+    non-zero (e.g. a missing directory) is logged and treated as "no snapshots" rather
+    than swallowed silently."""
+    if result.returncode == 0:
+        return
+    stderr = (result.stderr or "").strip()
+    # Invariant: 255 is attributed to an ssh transport/auth/DNS failure. This relies on
+    # the remote enumeration command never itself exiting 255 -- true for the commands
+    # here (find exits 0/1/2; sudo exits 1 on auth failure). ssh's default BatchMode +
+    # ConnectTimeout (see _build_ssh_command) make a down/black-holing host reach this
+    # 255 path fast rather than hanging.
+    if result.returncode == 255:
+        raise RuntimeError(
+            f"Cannot reach raw+ssh target {host}: {stderr or 'ssh connection failed'}. "
+            "Its backups could NOT be listed -- this is NOT an empty target. Check the "
+            "host is up and reachable, then retry."
+        )
+    logger.warning(
+        "Listing raw+ssh target %s returned rc=%s (%s); reporting only the backups "
+        "that were readable",
+        path,
+        result.returncode,
+        stderr or "no stderr",
+    )
+
+
 def _sha256_file(path: Path) -> str | None:
     """Return the hex sha256 of ``path``'s bytes, or None on any I/O error.
 
@@ -1394,16 +1430,34 @@ class SSHRawEndpoint(RawEndpoint):
         yield
 
     def _build_ssh_command(self) -> list[str]:
-        """Build the base SSH command."""
+        """Build the base SSH command.
+
+        User ``ssh_opts`` come FIRST so they take precedence (ssh uses the first value
+        seen for each option), then defaults that make an unattended backup tool
+        behave: ``BatchMode=yes`` (never block on a password/host-key prompt), and
+        ``ConnectTimeout`` + ``ServerAlive*`` so a DOWN or packet-dropping host fails
+        FAST with ssh exit 255 -- which the listing guard turns into a clear "cannot
+        reach" error -- instead of hanging for the OS TCP timeout (or forever)."""
         cmd = ["ssh"]
+        cmd.extend(self.ssh_opts)
+        cmd.extend(
+            [
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "ConnectTimeout=10",
+                "-o",
+                "ServerAliveInterval=5",
+                "-o",
+                "ServerAliveCountMax=3",
+            ]
+        )
 
         if self.port and self.port != 22:
             cmd.extend(["-p", str(self.port)])
 
         if self.ssh_key:
             cmd.extend(["-i", self.ssh_key])
-
-        cmd.extend(self.ssh_opts)
 
         user_host = (
             f"{self.username}@{self.hostname}" if self.username else self.hostname
@@ -1652,15 +1706,14 @@ class SSHRawEndpoint(RawEndpoint):
         )
         if self.ssh_sudo:
             find_cmd = f"sudo {find_cmd}"
-        try:
-            res = subprocess.run(
-                self._build_ssh_command() + [find_cmd],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-        except subprocess.CalledProcessError:
-            return []
+        res = subprocess.run(
+            self._build_ssh_command() + [find_cmd],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        # Never let an unreachable host look like an empty target (false all-clear).
+        _check_remote_listing(res, self.hostname, base)
         out: list[str] = []
         for p in res.stdout.split("\x00"):
             if not p or "\n" in p:
@@ -1880,15 +1933,10 @@ class SSHRawEndpoint(RawEndpoint):
 
         full_cmd = ssh_cmd + [find_cmd]
 
-        try:
-            result = subprocess.run(
-                full_cmd, check=True, capture_output=True, text=True
-            )
-            meta_files = (
-                result.stdout.strip().split("\n") if result.stdout.strip() else []
-            )
-        except subprocess.CalledProcessError:
-            meta_files = []
+        result = subprocess.run(full_cmd, check=False, capture_output=True, text=True)
+        # Never let an unreachable host look like an empty target (false all-clear).
+        _check_remote_listing(result, self.hostname, path)
+        meta_files = result.stdout.strip().split("\n") if result.stdout.strip() else []
 
         # For each metadata file, fetch and parse
         snapshots: list[RawSnapshot] = []
@@ -1925,18 +1973,17 @@ class SSHRawEndpoint(RawEndpoint):
         )
         if self.ssh_sudo:
             find_stream_cmd = f"sudo {find_stream_cmd}"
-        try:
-            result = subprocess.run(
-                ssh_cmd + [find_stream_cmd],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-            stream_files = (
-                result.stdout.strip().split("\n") if result.stdout.strip() else []
-            )
-        except subprocess.CalledProcessError:
-            stream_files = []
+        result = subprocess.run(
+            ssh_cmd + [find_stream_cmd], check=False, capture_output=True, text=True
+        )
+        # This is a fresh ssh call: a connection that succeeded on the first-pass find
+        # but DROPS before/at this second pass (e.g. a ServerAlive keepalive timeout
+        # mid-listing) must still fail loudly rather than truncate the legacy-stream
+        # pass to [] and under-report the target's backups.
+        _check_remote_listing(result, self.hostname, path)
+        stream_files = (
+            result.stdout.strip().split("\n") if result.stdout.strip() else []
+        )
 
         # Dedup on the stream PATH (unambiguous) as well as the derived name, so
         # a stream that also has a .meta is never enumerated twice even if its

--- a/tests/test_raw_ssh_list_errors.py
+++ b/tests/test_raw_ssh_list_errors.py
@@ -1,0 +1,86 @@
+"""raw+ssh listing must not report an unreachable host as an empty target (T9).
+
+A connection/auth/DNS failure to a raw+ssh target must FAIL loudly, not silently
+return "0 snapshots" / "all ok" -- otherwise a down server (or lost backups) reads
+as an intentionally-empty target, a dangerous false all-clear for a backup tool.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+import btrfs_backup_ng.endpoint.raw as raw_mod
+from btrfs_backup_ng.endpoint.raw import SSHRawEndpoint, _check_remote_listing
+
+
+def _cp(rc, stderr=""):
+    return subprocess.CompletedProcess(
+        args=["ssh"], returncode=rc, stdout="", stderr=stderr
+    )
+
+
+# --- the guard helper --------------------------------------------------------
+
+
+def test_guard_raises_on_ssh_connection_failure():
+    with pytest.raises(RuntimeError, match="Cannot reach|NOT an empty"):
+        _check_remote_listing(
+            _cp(255, "ssh: connect ... Connection refused"), "nas", "/b"
+        )
+
+
+def test_guard_noop_on_success():
+    _check_remote_listing(_cp(0), "nas", "/b")  # reachable + ran -> no raise
+
+
+def test_guard_warns_but_does_not_raise_on_other_nonzero(monkeypatch):
+    """A reachable host whose listing command failed for another reason (e.g. a
+    missing dir) is logged, not raised -- and never silently swallowed."""
+    calls = []
+    monkeypatch.setattr(raw_mod.logger, "warning", lambda *a, **k: calls.append(a))
+    _check_remote_listing(_cp(1, ""), "nas", "/b")  # must not raise
+    assert calls  # a warning was emitted (not silently swallowed)
+
+
+# --- endpoint behaviour ------------------------------------------------------
+
+
+def test_list_snapshots_unreachable_host_raises(monkeypatch):
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+    monkeypatch.setattr(
+        raw_mod.subprocess,
+        "run",
+        lambda *a, **k: _cp(255, "ssh: connect to host nas port 22: No route to host"),
+    )
+    with pytest.raises(RuntimeError, match="Cannot reach"):
+        ep.list_snapshots(flush_cache=True)
+
+
+def test_list_snapshots_reachable_empty_target_returns_empty(monkeypatch):
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+    monkeypatch.setattr(raw_mod.subprocess, "run", lambda *a, **k: _cp(0, ""))
+    assert ep.list_snapshots(flush_cache=True) == []
+
+
+def test_ssh_command_fails_fast_on_a_down_host():
+    """The ssh command must carry BatchMode + ConnectTimeout so a down/black-holing
+    host errors quickly (ssh exit 255) instead of hanging past the OS TCP timeout --
+    otherwise the 'never report a down server as empty' guard is never even reached."""
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+    cmd = ep._build_ssh_command()
+    assert "BatchMode=yes" in cmd
+    assert "ConnectTimeout=10" in cmd
+    assert "ServerAliveInterval=5" in cmd
+
+
+def test_streams_without_sidecar_unreachable_raises(monkeypatch):
+    """The backfill enumeration path must also refuse to treat an unreachable host as
+    'no legacy streams'."""
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+    monkeypatch.setattr(
+        raw_mod.subprocess, "run", lambda *a, **k: _cp(255, "Connection refused")
+    )
+    with pytest.raises(RuntimeError, match="Cannot reach"):
+        ep.streams_without_sidecar()


### PR DESCRIPTION
## Summary

From the empirical break campaign: `raw list` / `raw verify` on an **unreachable / refused / bad-auth** raw+ssh host reported **exit 0 with "(0 snapshots)" / "0 ok"** — the enumeration swallowed the ssh failure into an empty list. For a backup tool that's a dangerous **false all-clear**: a down server (or lost backups) reads as an intentionally-empty target.

## Fix
- New `_check_remote_listing` guard on all three remote enumeration sites (`list_snapshots` both passes + the backfill enumeration): ssh **exit 255** (its own connection/auth/DNS failure) → clear `RuntimeError` *"Cannot reach raw+ssh target … this is NOT an empty target"*; a reachable-but-empty dir still lists 0; any other non-zero (e.g. missing dir) is logged, not swallowed. So `list`/`verify` exit non-zero with an actionable message, and a backup to an unreachable destination fails early instead of planning against a phantom-empty target (delivery traced clean via `run.py`).
- Harden `_build_ssh_command` so the guard is *reachable*: add `BatchMode=yes` + `ConnectTimeout` + `ServerAlive*` (mirroring the btrfs ssh endpoint) so a **down/black-holing host fails fast** with ssh 255 instead of hanging for the OS TCP timeout. User `ssh_opts` placed first so they still take precedence.

## Adversarial review
2-lens (correctness + regression/delivery). Confirmed rc-255 is the right discriminator (our `find`/`sudo` never exit 255) and delivery is clean on every path. It found a **MEDIUM** — without `BatchMode`/`ConnectTimeout` a black-holing host would *hang* and never reach the guard — which this PR fixes; nits (invariant comments) folded in.

## Testing
Empirically: refused port and a black-holing TEST-NET host both now exit 1 with "Cannot reach …" (black-hole in ~10s, not a hang); reachable-empty still shows "(0 snapshots)". 7 tests; the ssh-failure raise is **mutation-verified** across all three enumeration paths. Full suite 2299; ruff / ruff-format@0.15.22 / mypy clean.