### PR TITLE
fix(raw): surface a damaged sidecar instead of silently degrading or crashing

### DIFF
--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -1958,8 +1958,24 @@ class SSHRawEndpoint(RawEndpoint):
                 stream_path = Path(meta_path[:-5])  # Remove .meta
                 snapshot = RawSnapshot.from_dict(data, stream_path)
                 snapshots.append(snapshot)
-            except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
-                logger.debug("Failed to parse remote metadata %s: %s", meta_path, e)
+            except subprocess.CalledProcessError as e:
+                # The `cat` failed (file vanished between find and cat, or a mid-listing
+                # connection drop -- a persistent outage is already caught at the find).
+                logger.debug("Could not read remote sidecar %s: %s", meta_path, e)
+                continue
+            except Exception as e:
+                # The sidecar was readable but could not be PARSED (corrupt/truncated/
+                # non-UTF8/pathologically-nested JSON). Warn instead of silently
+                # degrading to filename inference (which loses the authoritative
+                # compress/encrypt/cipher/checksum); the broad except also keeps a
+                # RecursionError from one bad sidecar from aborting the whole listing.
+                logger.warning(
+                    "Remote raw sidecar %s is unreadable/corrupt and was ignored (%s); "
+                    "its stream will be listed from the filename only, losing the "
+                    "recorded compress/encrypt/cipher/checksum.",
+                    meta_path,
+                    e,
+                )
                 continue
 
         # Second pass: sidecar-less remote streams (legacy backups, direct

--- a/src/btrfs_backup_ng/endpoint/raw_metadata.py
+++ b/src/btrfs_backup_ng/endpoint/raw_metadata.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from btrfs_backup_ng import __version__
+from btrfs_backup_ng.__logger__ import logger
 
 # Compression tool configurations
 COMPRESSION_CONFIG: dict[str, dict[str, Any]] = {
@@ -449,9 +450,25 @@ def discover_raw_snapshots(
             snapshot = RawSnapshot.load_metadata(meta_path)
             if not prefix or snapshot.name.startswith(prefix):
                 snapshots.append(snapshot)
-        except (json.JSONDecodeError, OSError, ValueError, TypeError, AttributeError):
-            # Skip a single malformed sidecar rather than aborting the whole
-            # directory listing (bad JSON, wrong types, unexpected structure).
+        except Exception as e:
+            # A sidecar EXISTS but could not be parsed (corrupt/truncated JSON, wrong
+            # types, non-UTF8, pathologically-nested JSON). Two rules:
+            #  1. Skip only THIS file, never abort the whole directory listing -- so a
+            #     broad except (a RecursionError from deeply-nested JSON is a
+            #     RuntimeError, NOT in the old narrow tuple, and would otherwise blind
+            #     the tool to every healthy backup in the directory).
+            #  2. Do NOT silently pretend the sidecar is absent: WARN by name. The
+            #     stream still falls back to filename inference in the second pass, but
+            #     that loses the authoritative compress/encrypt/cipher/checksum, so the
+            #     operator must know their metadata was damaged.
+            logger.warning(
+                "Raw sidecar %s is unreadable/corrupt and was ignored (%s); its "
+                "stream will be listed from the filename only, losing the recorded "
+                "compress/encrypt/cipher/checksum. Re-run the backup, or "
+                "'raw backfill-metadata' to rebuild a (non-authoritative) sidecar.",
+                meta_path,
+                e,
+            )
             continue
 
     # Second pass: find stream files without metadata
@@ -486,7 +503,14 @@ def discover_raw_snapshots(
         # reconstructed from the filename (no authoritative sidecar), so its origin
         # is "filename-inferred" and its completeness is unknown -- never present it
         # as a native atomic backup.
-        stat = item.stat()
+        try:
+            stat = item.stat()
+        except OSError:
+            # The stream vanished between iterdir() and stat() (e.g. a concurrent
+            # prune). Skip just this one rather than aborting the whole listing --
+            # mirrors the raw+ssh second pass, and the same one-bad-file-blinds-all
+            # class the sidecar loop above closes.
+            continue
         snapshot = RawSnapshot(
             name=name,
             stream_path=item,

--- a/tests/test_raw_sidecar_robustness.py
+++ b/tests/test_raw_sidecar_robustness.py
@@ -1,0 +1,111 @@
+"""Damaged raw sidecars must degrade LOUDLY, never silently or catastrophically (T3).
+
+A corrupt/truncated/unparseable ``.meta`` sidecar must (1) never abort discovery of
+the healthy backups sharing its directory (a single bad neighbour must not blind the
+tool), and (2) never be silently swallowed -- the operator must be warned that the
+authoritative record was lost and the stream fell back to filename inference.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import btrfs_backup_ng.endpoint.raw as raw_mod
+import btrfs_backup_ng.endpoint.raw_metadata as meta_mod
+from btrfs_backup_ng.endpoint.raw import SSHRawEndpoint
+from btrfs_backup_ng.endpoint.raw_metadata import RawSnapshot, discover_raw_snapshots
+
+
+def test_damaged_sidecar_does_not_abort_directory_listing(tmp_path, monkeypatch):
+    """A sidecar that raises an exception OUTSIDE the old narrow catch tuple (e.g. a
+    RecursionError from pathologically-nested JSON -- forced here so the guard is
+    deterministic across CPython versions and json backends, some of which parse deep
+    nesting iteratively) must NOT abort the listing of the healthy backups sharing its
+    directory. Mutation guard: reverting the broad `except Exception` re-raises this."""
+    (tmp_path / "good.20240101T000000.btrfs").write_bytes(b"data")
+    RawSnapshot(
+        name="good.20240101T000000",
+        stream_path=tmp_path / "good.20240101T000000.btrfs",
+        size=4,
+    ).save_metadata()
+    bad_meta = tmp_path / "bad.20240102T000000.btrfs.meta"
+    bad_meta.write_text("{}")
+    (tmp_path / "bad.20240102T000000.btrfs").write_bytes(b"data")
+
+    real_load = meta_mod.RawSnapshot.load_metadata
+
+    def load(meta_path):
+        if meta_path == bad_meta:
+            raise RecursionError("deeply nested sidecar")  # NOT in the old narrow tuple
+        return real_load(meta_path)
+
+    monkeypatch.setattr(meta_mod.RawSnapshot, "load_metadata", staticmethod(load))
+    names = {s.name for s in discover_raw_snapshots(tmp_path, "")}
+    assert "good.20240101T000000" in names  # not hidden by the bad neighbour
+
+
+def test_vanishing_sidecarless_stream_does_not_abort_listing(tmp_path, monkeypatch):
+    """A sidecar-less stream removed between iterdir() and stat() (a concurrent prune)
+    must skip just that one, not abort the whole listing -- the same one-bad-file
+    class the sidecar loop closes, one loop down."""
+    good = tmp_path / "good.20240101T000000.btrfs"
+    good.write_bytes(b"d")
+    RawSnapshot(name="good.20240101T000000", stream_path=good, size=1).save_metadata()
+    vanish = tmp_path / "vanish.20240102T000000.btrfs"
+    vanish.write_bytes(b"d")
+
+    real_stat = meta_mod.Path.stat
+    seen = {"n": 0}
+
+    def stat(self, *a, **k):
+        if self == vanish:  # is_file()'s stat succeeds; the explicit .stat() fails
+            seen["n"] += 1
+            if seen["n"] >= 2:
+                raise FileNotFoundError(str(vanish))
+        return real_stat(self, *a, **k)
+
+    monkeypatch.setattr(meta_mod.Path, "stat", stat)
+    names = {s.name for s in discover_raw_snapshots(tmp_path, "")}
+    assert "good.20240101T000000" in names  # not aborted by the vanishing neighbour
+
+
+def test_corrupt_sidecar_warns_rather_than_silently_degrading(tmp_path, monkeypatch):
+    st = tmp_path / "x.20240101T000000.btrfs.zst"
+    st.write_bytes(b"data")
+    RawSnapshot(
+        name="x.20240101T000000", stream_path=st, compress="zstd", size=4
+    ).save_metadata()
+    (tmp_path / "x.20240101T000000.btrfs.zst.meta").write_text('{"version":2, TRUNC')
+
+    calls = []
+    monkeypatch.setattr(meta_mod.logger, "warning", lambda *a, **k: calls.append(a))
+    snaps = discover_raw_snapshots(tmp_path, "")
+    # Warned by name (not silent), and the stream is still surfaced (filename-inferred).
+    assert any("unreadable/corrupt" in str(a) for a in calls)
+    assert any(s.provenance_origin == "filename-inferred" for s in snaps)
+
+
+def test_ssh_corrupt_remote_sidecar_warns(monkeypatch):
+    """The raw+ssh listing must also warn (not silently skip) on a corrupt remote
+    sidecar, and a RecursionError from one must not abort the remote listing."""
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+
+    def fake_run(cmd, **kwargs):
+        joined = " ".join(cmd)
+        if "-name '*.meta'" in joined:  # first-pass find -> one .meta
+            return MagicMock(
+                returncode=0, stdout="/backup/s.20240101T000000.btrfs.meta\n", stderr=""
+            )
+        if "cat " in joined:  # reading that sidecar -> corrupt JSON
+            return MagicMock(
+                returncode=0, stdout="{ this is not valid json ]]]", stderr=""
+            )
+        return MagicMock(
+            returncode=0, stdout="", stderr=""
+        )  # second-pass find -> empty
+
+    monkeypatch.setattr(raw_mod.subprocess, "run", fake_run)
+    calls = []
+    monkeypatch.setattr(raw_mod.logger, "warning", lambda *a, **k: calls.append(a))
+    ep.list_snapshots(flush_cache=True)  # must not raise
+    assert any("unreadable/corrupt" in str(a) for a in calls)


### PR DESCRIPTION
## Summary

Two ways a damaged raw `.meta` sidecar was mishandled (both from the break campaign):

1. `discover_raw_snapshots` caught only a narrow exception tuple, so a **RecursionError** from a pathologically-nested JSON sidecar **aborted the entire directory listing** — hiding every healthy backup (list/verify/prune/restore all go through discovery). One bad neighbour blinded the tool.
2. A corrupt/truncated/empty/non-UTF8 sidecar was **silently** skipped → filename inference, losing the authoritative compress/encrypt/cipher/checksum with no signal.

## Fix
- Broaden the per-sidecar catch to `except Exception` (a RecursionError now skips only that file; `KeyboardInterrupt`/`SystemExit` still propagate) and **warn** naming the sidecar so the operator knows its metadata was lost and the stream is now filename-inferred only.
- Split the raw+ssh per-sidecar parse the same way (failed `cat` = debug skip; unparseable = warn; broadened catch stops a remote RecursionError aborting the listing).
- Guard the local second-pass `item.stat()` too, so a sidecar-less stream vanishing mid-scan (concurrent prune) skips just that one — mirrors the raw+ssh second pass, closing the same one-bad-file-blinds-all class one loop down.

Note: the warning **recurs each run** until the operator re-runs the backup or `raw backfill-metadata` — warn level is intentional (losing authoritative crypto/checksum metadata is exactly the silent-degradation class this fixes).

## Adversarial review
2-lens. Caught a **MEDIUM**: my abort-guard test was version-fragile (CPython 3.14's C json scanner parses deep nesting iteratively → `AttributeError`, which was in the old tuple → the test wouldn't guard the broadening there). Rewritten to force a deterministic `RecursionError` via monkeypatch — now mutation-verifies across versions. Also fixed the review's **LOW** (unguarded local second-pass `stat()`) and a path-granularity nit.

## Testing
Empirically: a good backup survives both a RecursionError-raising sidecar and a vanishing sidecar-less stream; a corrupt sidecar warns + surfaces filename-inferred. 4 tests; the no-abort broadening, warn-not-silent, and vanishing-stream guard are **mutation-verified**. Full suite 2303; ruff / ruff-format@0.15.22 / mypy clean.