### PR TITLE
fix(raw): count each stream once, under one name, in enumeration

### DIFF
--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -1957,6 +1957,15 @@ class SSHRawEndpoint(RawEndpoint):
                 # Derive stream path from meta path
                 stream_path = Path(meta_path[:-5])  # Remove .meta
                 snapshot = RawSnapshot.from_dict(data, stream_path)
+                if not snapshot.name:
+                    # An empty/missing name is a meaningless phantom; skip it so the
+                    # stream is listed from its filename in the second pass instead.
+                    logger.warning(
+                        "Remote raw sidecar %s records no snapshot name; ignoring it "
+                        "(the stream will be listed from its filename).",
+                        meta_path,
+                    )
+                    continue
                 snapshots.append(snapshot)
             except subprocess.CalledProcessError as e:
                 # The `cat` failed (file vanished between find and cat, or a mid-listing
@@ -2005,20 +2014,36 @@ class SSHRawEndpoint(RawEndpoint):
         # a stream that also has a .meta is never enumerated twice even if its
         # recorded name differs from the filename stem.
         loaded_paths = {str(s.stream_path) for s in snapshots}
-        for stream_path_str in stream_files:
+        inferred_names: set[str] = set()
+        # Sorted so a same-name collision resolves deterministically across runs.
+        for stream_path_str in sorted(stream_files):
             if not stream_path_str or stream_path_str.endswith(
                 (".meta", ".part", ".tmp", ".lock")
             ):
                 continue
-            if stream_path_str in loaded_paths:
-                continue
             stream_path = Path(stream_path_str)
+            # Compare a NORMALIZED path: loaded_paths holds str(Path(...)) (collapsed
+            # // and /./), but the raw find output is not normalized, so a config path
+            # like "/backup//" would otherwise miss the dedup and double-count.
+            if str(stream_path) in loaded_paths:
+                continue
             parsed = parse_stream_filename(stream_path.name)
             name = parsed["name"]
             if name in loaded_names:
                 continue
             if prefix and not name.startswith(prefix):
                 continue
+            # Two sidecar-less remote streams deriving the same name (plaintext +
+            # compressed copy) violate name-based identity; keep the first, warn.
+            if name in inferred_names:
+                logger.warning(
+                    "Two remote raw streams derive the same name %r; keeping the "
+                    "first and ignoring %s.",
+                    name,
+                    stream_path_str,
+                )
+                continue
+            inferred_names.add(name)
             # Portable mtime+size: GNU/busybox `stat -c`, else BSD/macOS `stat -f`.
             q = shlex.quote(stream_path_str)
             stat_cmd = f"stat -c '%Y %s' {q} 2>/dev/null || stat -f '%m %z' {q}"

--- a/src/btrfs_backup_ng/endpoint/raw_metadata.py
+++ b/src/btrfs_backup_ng/endpoint/raw_metadata.py
@@ -448,8 +448,6 @@ def discover_raw_snapshots(
     for meta_path in meta_files:
         try:
             snapshot = RawSnapshot.load_metadata(meta_path)
-            if not prefix or snapshot.name.startswith(prefix):
-                snapshots.append(snapshot)
         except Exception as e:
             # A sidecar EXISTS but could not be parsed (corrupt/truncated JSON, wrong
             # types, non-UTF8, pathologically-nested JSON). Two rules:
@@ -470,10 +468,45 @@ def discover_raw_snapshots(
                 e,
             )
             continue
+        # An empty/missing name yields a meaningless phantom record (and, paired with
+        # the second pass, double-counts the stream). Treat it as invalid: warn + skip
+        # so the stream is instead listed from its filename with a real name.
+        if not snapshot.name:
+            logger.warning(
+                "Raw sidecar %s records no snapshot name; ignoring it (the stream will "
+                "be listed from its filename instead).",
+                meta_path,
+            )
+            continue
+        # A sidecar whose recorded name disagrees with its own filename is suspicious
+        # (a renamed stream, or a hand-crafted/corrupt sidecar). Keep the authoritative
+        # record, but warn so the operator can reconcile -- and the path-based dedup in
+        # the second pass ensures the stream is not ALSO counted under its filename.
+        filename_name = parse_stream_filename(meta_path.with_suffix("").name)["name"]
+        if snapshot.name != filename_name:
+            logger.warning(
+                "Raw sidecar %s records name %r but its stream file is named %r; using "
+                "the sidecar's name.",
+                meta_path,
+                snapshot.name,
+                filename_name,
+            )
+        if not prefix or snapshot.name.startswith(prefix):
+            snapshots.append(snapshot)
 
     # Second pass: find stream files without metadata
     loaded_names = {s.name for s in snapshots}
-    for item in directory.iterdir():
+    # Dedup by resolved stream PATH as well as by name, so a stream whose sidecar
+    # records a name different from its filename is never counted twice (once from the
+    # sidecar, once inferred from the filename).
+    loaded_paths = {str(s.stream_path) for s in snapshots}
+    inferred_names: set[str] = set()
+    # Sorted so that when two streams collide on a derived name the winner is
+    # DETERMINISTIC across runs and hosts (iterdir order is otherwise arbitrary). The
+    # winner is the lexicographically-first filename (so a plaintext ".btrfs" beats a
+    # ".btrfs.zst" of the same name) -- arbitrary-but-stable; a real collision is a
+    # warned anomaly the operator should resolve, not a normal state.
+    for item in sorted(directory.iterdir()):
         if not item.is_file() or item.suffix == ".meta":
             continue
 
@@ -488,16 +521,37 @@ def discover_raw_snapshots(
         if ".btrfs" not in item.name:
             continue
 
+        # This exact stream is already represented by a sidecar (matched by path, so a
+        # sidecar whose recorded name differs from the filename does not cause a
+        # second, filename-inferred entry for the same file).
+        if str(item) in loaded_paths:
+            continue
+
         parsed = parse_stream_filename(item.name)
         name = parsed["name"]
 
-        # Skip if already loaded from metadata
+        # Skip if already loaded from metadata (by name)
         if name in loaded_names:
             continue
 
         # Skip if doesn't match prefix
         if prefix and not name.startswith(prefix):
             continue
+
+        # Two DIFFERENT sidecar-less stream files that derive the SAME name (e.g. a
+        # plaintext `x.btrfs` and a compressed `x.btrfs.zst`) would both be listed under
+        # one name, violating the name-based identity restore/prune rely on. Keep the
+        # first, warn on the collision.
+        if name in inferred_names:
+            logger.warning(
+                "Two raw streams in %s derive the same name %r (e.g. a plaintext and a "
+                "compressed copy); keeping the first and ignoring %s.",
+                directory,
+                name,
+                item.name,
+            )
+            continue
+        inferred_names.add(name)
 
         # Create snapshot from filename parsing. Mark it honestly: this record was
         # reconstructed from the filename (no authoritative sidecar), so its origin

--- a/tests/test_raw_enumeration_integrity.py
+++ b/tests/test_raw_enumeration_integrity.py
@@ -1,0 +1,129 @@
+"""Raw enumeration integrity (T4).
+
+One physical stream must be listed exactly once, under one name. Bugs this guards:
+a sidecar whose recorded name differs from its filename double-counted the stream
+(name-based dedup missed it); two sidecar-less streams sharing a base name
+(``x.btrfs`` + ``x.btrfs.zst``) were both listed under the same name (violating the
+name-based identity restore/prune rely on); an empty/missing name in a sidecar
+produced a phantom ``name=''`` record plus a duplicate.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import btrfs_backup_ng.endpoint.raw as raw_mod
+from btrfs_backup_ng.endpoint.raw import SSHRawEndpoint
+from btrfs_backup_ng.endpoint.raw_metadata import RawSnapshot, discover_raw_snapshots
+
+
+# --- local discover_raw_snapshots --------------------------------------------
+
+
+def test_sidecar_name_differs_from_filename_counts_once(tmp_path):
+    stream = tmp_path / "actual.20240101T000000.btrfs"
+    stream.write_bytes(b"d")
+    RawSnapshot(name="RECORDED_NAME", stream_path=stream, size=1).save_metadata()
+    snaps = discover_raw_snapshots(tmp_path, "")
+    assert len(snaps) == 1  # ONE stream -> ONE entry (not one per name)
+    assert snaps[0].name == "RECORDED_NAME"  # the authoritative sidecar name wins
+
+
+def test_two_streams_same_base_name_count_once(tmp_path):
+    (tmp_path / "dup.20240101T000000.btrfs").write_bytes(b"plain")
+    (tmp_path / "dup.20240101T000000.btrfs.zst").write_bytes(b"zstd")
+    snaps = discover_raw_snapshots(tmp_path, "")
+    names = [s.name for s in snaps]
+    assert names.count("dup.20240101T000000") == 1  # no same-name duplicate
+
+
+def test_empty_name_sidecar_is_not_a_phantom(tmp_path):
+    (tmp_path / "noname.20240101T000000.btrfs").write_bytes(b"d")
+    (tmp_path / "noname.20240101T000000.btrfs.meta").write_text(
+        json.dumps({"version": 2, "size": 1})  # no "name"
+    )
+    snaps = discover_raw_snapshots(tmp_path, "")
+    names = {s.name for s in snaps}
+    assert "" not in names  # no phantom empty-name record
+    assert names == {"noname.20240101T000000"}  # listed once, from the filename
+
+
+# --- raw+ssh list_snapshots --------------------------------------------------
+
+
+def _ssh_run(meta_cat_json=None, streams=()):
+    """Build a subprocess.run stand-in dispatching by the remote command shape."""
+
+    def run(cmd, **kwargs):
+        joined = " ".join(cmd)
+        if "-name '*.meta'" in joined:
+            out = "/backup/s.20240101T000000.btrfs.meta\n" if meta_cat_json else ""
+            return MagicMock(returncode=0, stdout=out, stderr="")
+        if joined.startswith("ssh") and " cat " in f" {joined} ":
+            return MagicMock(returncode=0, stdout=meta_cat_json or "", stderr="")
+        if "-name '*.btrfs*'" in joined:
+            return MagicMock(returncode=0, stdout="\n".join(streams), stderr="")
+        if "stat -c" in joined:
+            return MagicMock(returncode=0, stdout="1700000000 100\n", stderr="")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    return run
+
+
+def test_ssh_empty_name_sidecar_is_skipped(monkeypatch):
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+    monkeypatch.setattr(
+        raw_mod.subprocess,
+        "run",
+        _ssh_run(
+            meta_cat_json=json.dumps({"version": 2, "size": 1}),  # no name
+            streams=["/backup/s.20240101T000000.btrfs"],
+        ),
+    )
+    names = {s.name for s in ep.list_snapshots(flush_cache=True)}
+    assert "" not in names  # no phantom
+    assert names == {"s.20240101T000000"}  # filename-inferred instead
+
+
+def test_ssh_double_slash_config_path_does_not_double_count(monkeypatch):
+    """A config path containing '//' must still dedup a sidecar'd stream: find output
+    is unnormalized ('/backup//x') but the sidecar's stored path is Path-normalized
+    ('/backup/x'), so the dedup must normalize both sides (else a double-count)."""
+    ep = SSHRawEndpoint(config={"path": "/backup//", "hostname": "nas"})
+    meta = "/backup//s.20240101T000000.btrfs.meta"
+    stream = "/backup//s.20240101T000000.btrfs"
+    # The sidecar name differs from the filename so ONLY path-dedup (not name-dedup)
+    # can catch the duplicate -- isolating the '//' normalization.
+    good = json.dumps({"version": 2, "name": "RECORDED_DIFFERENT", "size": 4})
+
+    def run(cmd, **kwargs):
+        joined = " ".join(cmd)
+        if "-name '*.meta'" in joined:
+            return MagicMock(returncode=0, stdout=meta + "\n", stderr="")
+        if " cat " in f" {joined} ":
+            return MagicMock(returncode=0, stdout=good, stderr="")
+        if "-name '*.btrfs*'" in joined:
+            return MagicMock(returncode=0, stdout=stream + "\n", stderr="")
+        return MagicMock(returncode=0, stdout="1700000000 4\n", stderr="")
+
+    monkeypatch.setattr(raw_mod.subprocess, "run", run)
+    snaps = ep.list_snapshots(flush_cache=True)
+    assert len(snaps) == 1  # one physical stream -> one entry, despite the '//'
+
+
+def test_ssh_two_streams_same_base_name_count_once(monkeypatch):
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+    monkeypatch.setattr(
+        raw_mod.subprocess,
+        "run",
+        _ssh_run(
+            meta_cat_json=None,  # no sidecars
+            streams=[
+                "/backup/d.20240101T000000.btrfs",
+                "/backup/d.20240101T000000.btrfs.zst",
+            ],
+        ),
+    )
+    names = [s.name for s in ep.list_snapshots(flush_cache=True)]
+    assert names.count("d.20240101T000000") == 1


### PR DESCRIPTION
## Summary

Raw enumeration could list one physical stream more than once, or under a wrong/empty name (from the break campaign):
- a sidecar whose recorded name ≠ its filename → listed **twice** (dedup keyed on name only);
- two sidecar-less streams sharing a base name (`x.btrfs` + `x.btrfs.zst`) → both under the **same name** (violates the name-based identity restore/prune use);
- an empty/missing name in a sidecar → phantom `name=""` + a duplicate.

## Fix (local `discover_raw_snapshots` + raw+ssh `list_snapshots`)
- **Skip an empty-name sidecar** (warn; the stream lists from its filename with a real name, not a phantom).
- **Warn on a name/filename mismatch** (keep the authoritative record) — verified **silent for every legitimate pipeline** (plaintext/zstd/gpg/openssl/combined/`raw encrypt` remediation), so it flags a real anomaly only.
- **Dedup by resolved stream PATH** as well as name, so a name-mismatched sidecar stream isn't *also* listed filename-inferred. The raw+ssh side **normalizes** the `find` output to match the `Path`-normalized key, so a config path with `//` or `/./` can't slip the dedup.
- **Same-name collision** → keep the first, warn. The second-pass iteration is **sorted**, so the retained twin is deterministic across runs/hosts.

## Adversarial review
2-lens. Confirmed correct for all three bugs, no regression, normal case unchanged. It caught a **MEDIUM** — the raw+ssh path-dedup compared raw `find` output against `Path`-normalized keys, so a `//`/`/./` config path reintroduced the double-count — fixed and mutation-verified; determinism (sort) and a spurious-warn check were preempted.

## Testing
Empirically verified all three cases (local + raw+ssh). 6 tests; path-dedup, empty-name skip, same-name collision, and the `//`-path normalization are **mutation-verified**. Full suite 2309; ruff / ruff-format@0.15.22 / mypy clean.