### PR TITLE
fix: deliver every failure as a clean, actionable message (never a traceback)

### DIFF
--- a/src/btrfs_backup_ng/__util__.py
+++ b/src/btrfs_backup_ng/__util__.py
@@ -174,7 +174,20 @@ def exec_subprocess(command, method="check_output", **kwargs):
         raise AbortError(f"Command not found: {command[0]}") from e
     except subprocess.CalledProcessError as e:
         logger.error("Error on command: %s\nCaught: %s", command, e)
-        raise AbortError from e
+        # Give the AbortError a real message. A bare ``raise AbortError from e`` left
+        # it empty, so callers logged garbled lines like "Failed to create snapshot: "
+        # with no reason. Include the command's exit status and its stderr when it was
+        # captured so the failure is self-explanatory.
+        stderr = e.stderr
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode("utf-8", "replace")
+        detail = (stderr or "").strip()
+        cmd_name = str(command[0]) if command else "command"
+        if detail:
+            raise AbortError(
+                f"{cmd_name} failed (exit {e.returncode}): {detail}"
+            ) from e
+        raise AbortError(f"{cmd_name} failed with exit status {e.returncode}") from e
     except Exception as e:
         logger.error("Unexpected error executing command: %s\nError: %s", command, e)
         raise AbortError(f"Error executing {command[0]}: {e}") from e

--- a/src/btrfs_backup_ng/cli/dispatcher.py
+++ b/src/btrfs_backup_ng/cli/dispatcher.py
@@ -8,6 +8,8 @@ import argparse
 import sys
 from typing import Callable
 
+from .. import __util__
+from ..__logger__ import logger
 from .common import add_fs_checks_args, add_progress_args, add_verbosity_args
 
 # Known subcommands for the new CLI
@@ -1575,10 +1577,38 @@ def run_subcommand(args: argparse.Namespace) -> int:
     }
 
     handler = handlers.get(args.command)
-    if handler:
-        return handler(args)
-    else:
+    if handler is None:
         print(f"Unknown command: {args.command}")
+        return 1
+
+    try:
+        return handler(args)
+    except KeyboardInterrupt:
+        # Ctrl-C: acknowledge cleanly instead of dumping a KeyboardInterrupt traceback.
+        print("\nInterrupted.", file=sys.stderr)
+        return 130
+    except __util__.AbortError as e:
+        # A deliberate, already-plain-language abort (a failed integrity check, a
+        # missing tool, a refused unsafe operation). Its message carries the reason
+        # and the next step, so show it as-is.
+        message = str(e).strip()
+        print(
+            f"Error: {message}" if message else "Error: operation aborted.",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as e:  # noqa: BLE001 - last-resort user-facing guard
+        # Any other unhandled error must never reach the user as a raw Python
+        # traceback (this often fires mid-backup or mid-restore). Render one plain
+        # line plus a pointer to --debug for the full trace, and exit non-zero. The
+        # traceback itself is preserved at debug level for troubleshooting.
+        logger.debug("Unhandled error in '%s' command", args.command, exc_info=True)
+        message = str(e).strip() or e.__class__.__name__
+        print(f"Error: {message}", file=sys.stderr)
+        print(
+            "Run the same command with --debug to see the full technical traceback.",
+            file=sys.stderr,
+        )
         return 1
 
 

--- a/src/btrfs_backup_ng/cli/raw_cmd.py
+++ b/src/btrfs_backup_ng/cli/raw_cmd.py
@@ -471,6 +471,12 @@ def _raw_encrypt(args: argparse.Namespace) -> int:
         print(f"Raw target: {spec}  ({len(results)} plaintext stream{plural})")
         for r in results:
             print(f"  {r['action'].upper():<28} {r['name']}")
+            # Surface the actionable reason for failed entries in plain output too --
+            # previously it was only visible with --json, so a plain-mode "ERROR" gave
+            # the user no idea what went wrong or how to fix it.
+            reason = r.get("error")
+            if reason:
+                print(f"    reason: {reason}")
         if not dry:
             unver = sum(1 for r in results if r["action"] == "encrypted-unverified")
             if unver:

--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -335,6 +335,25 @@ def send_snapshot(
         )
         raise __util__.SnapshotTransferError(f"Exception during transfer: {e}") from e
 
+    except ValueError as e:
+        # A misconfiguration surfaced mid-transfer (e.g. a sidecar recording an
+        # unusable cipher, or a missing passphrase). Record the failed transaction and
+        # convert it into a transfer error so the per-target handler reports the reason
+        # cleanly and moves on, rather than letting it escape as a bare traceback.
+        logger.error("Transfer to %s cannot proceed: %s", dest_path, e)
+        duration = time.monotonic() - transfer_start
+        log_transaction(
+            action="transfer",
+            status="failed",
+            source=source_path,
+            destination=dest_path,
+            snapshot=snapshot_name,
+            parent=parent_name,
+            duration_seconds=duration,
+            error=str(e),
+        )
+        raise __util__.SnapshotTransferError(str(e)) from e
+
     finally:
         _cleanup_processes(send_process, receive_process)
 
@@ -1420,7 +1439,18 @@ def _execute_transfers(
         to_transfer.remove(best_snapshot)
         logger.debug("%d snapshots left to transfer", len(to_transfer))
 
-    logger.info(__util__.log_heading(f"Transfers to {destination_endpoint} complete!"))
+    # Report honestly: a "complete!" banner must not print when a transfer failed.
+    if result.failed:
+        logger.warning(
+            __util__.log_heading(
+                f"Transfers to {destination_endpoint} finished with "
+                f"{len(result.failed)} failure(s); {len(result.transferred)} succeeded"
+            )
+        )
+    else:
+        logger.info(
+            __util__.log_heading(f"Transfers to {destination_endpoint} complete!")
+        )
     return result
 
 

--- a/src/btrfs_backup_ng/endpoint/common.py
+++ b/src/btrfs_backup_ng/endpoint/common.py
@@ -171,6 +171,18 @@ class Endpoint:
         logger.debug("Acquiring snapshot lock: %s", lock_path)
         with FileLock(lock_path):
             logger.debug("Snapshot lock acquired: %s", lock_path)
+            if Path(snapshot_path).exists():
+                # A snapshot with this exact name already exists. The usual cause is two
+                # snapshots requested within the same second (identical timestamp, hence
+                # identical name). btrfs would otherwise fail here with the misleading
+                # "Could not create subvolume: Read-only file system"; give the real
+                # reason and what to do instead.
+                raise __util__.AbortError(
+                    f"A snapshot named '{snapshot.get_name()}' already exists at "
+                    f"{snapshot_path}. Two snapshots were likely requested within the "
+                    "same second (identical timestamp). Wait a second and retry; if the "
+                    "existing snapshot is incomplete, remove it first."
+                )
             self._remount(self.config["source"], read_write=True)
             commands = [
                 self._build_snapshot_cmd(

--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -112,6 +112,46 @@ def _validate_cipher(cipher: str) -> str:
     return cipher
 
 
+def _openssl_supports_cipher(cipher: str) -> bool:
+    """Whether THIS host's openssl can actually use ``cipher`` with ``openssl enc``.
+
+    ``_validate_cipher`` checks a cipher name's shape and rejects the unsafe/unusable
+    ones, but a name it accepts can still be absent from this particular openssl build
+    (a backup made on a host with a different openssl, or a hand-edited sidecar). Left
+    to the decrypt pipeline, that surfaces as a cryptic multi-line OpenSSL EVP error
+    dump. Probe the exact local binary (raw+ssh decrypts locally, so this is the binary
+    that runs) by encrypting empty input: exit 0 means the cipher is known, non-zero
+    means openssl rejects it -- the real cipher against the real binary, no fragile
+    output parsing, portable across OpenSSL/LibreSSL. Returns True when the probe cannot
+    run (openssl missing, an OS error, or a timeout) so this never blocks a restore it
+    cannot actually adjudicate -- the decrypt pipeline still fails safe if the cipher is
+    genuinely unusable."""
+    openssl = shutil.which("openssl")
+    if not openssl:
+        return True
+    try:
+        proc = subprocess.run(
+            [
+                openssl,
+                "enc",
+                f"-{cipher}",
+                "-in",
+                os.devnull,
+                "-out",
+                os.devnull,
+                "-pass",
+                "pass:x",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return True
+    return proc.returncode == 0
+
+
 def _selected_passphrase_env() -> str | None:
     """Return the NAME of the passphrase environment variable that is set (primary
     ``BTRFS_BACKUP_PASSPHRASE`` preferred, then ``BTRBK_PASSPHRASE`` for btrbk
@@ -157,13 +197,14 @@ PARTIAL_SUFFIX = ".part"
 LOCK_FILENAME = ".btrfs-backup-ng.lock"
 
 
-def _lock_open_reason(e: OSError) -> str:
-    """A plain-language reason a lock-file open failed, for a user-facing message.
+def _open_failure_reason(e: OSError) -> str:
+    """A plain-language reason opening a path failed, for a user-facing message.
 
-    Translates the errno so a regular user sees why the lock could not be taken and
+    Translates the errno so a regular user sees why the file could not be opened and
     what to check, instead of a bare ``[Errno NN]`` repr (whose default text is
     sometimes misleading -- e.g. ELOOP prints 'Too many levels of symbolic links'
-    for a single planted symlink)."""
+    for a single planted symlink). Shared by the lock open and the checksum open,
+    both of which use O_NOFOLLOW and so surface ELOOP for a planted symlink."""
     reasons = {
         errno.ELOOP: "it is a symlink (refused for safety)",
         errno.EISDIR: "it is a directory, not a file",
@@ -247,7 +288,10 @@ def _sha256_file(path: Path) -> str | None:
                 h.update(chunk)
         return h.hexdigest()
     except OSError as e:
-        logger.warning("Could not checksum %s: %s", path, e)
+        # Translate the errno to plain language: with O_NOFOLLOW a symlink stream
+        # surfaces ELOOP, whose default text ("Too many levels of symbolic links")
+        # wrongly implies a loop rather than "this is a symlink, refused for safety".
+        logger.warning("Could not checksum %s: %s", path, _open_failure_reason(e))
         return None
 
 
@@ -462,7 +506,7 @@ class RawEndpoint(Endpoint):
         except OSError as e:
             raise RuntimeError(
                 f"raw target {path}: cannot acquire its lock file {lockfile} -- "
-                f"{_lock_open_reason(e)}. The target directory must not be writable by "
+                f"{_open_failure_reason(e)}. The target directory must not be writable by "
                 "untrusted users."
             ) from e
         # Even if the open succeeded, refuse to trust anything that is not a REGULAR
@@ -478,7 +522,7 @@ class RawEndpoint(Endpoint):
             os.close(fd)
             raise RuntimeError(
                 f"raw target {path}: cannot stat its lock file {lockfile} -- "
-                f"{_lock_open_reason(e)}"
+                f"{_open_failure_reason(e)}"
             ) from e
         if not is_regular:
             os.close(fd)
@@ -1118,6 +1162,15 @@ class RawEndpoint(Endpoint):
                     "No cipher recorded for %s; restoring with endpoint cipher %s",
                     snapshot.name,
                     cipher,
+                )
+            if not _openssl_supports_cipher(cipher):
+                # Fail clearly BEFORE the pipeline dumps a cryptic OpenSSL EVP error.
+                raise __util__.AbortError(
+                    f"Cannot restore {snapshot.name}: the backup records openssl cipher "
+                    f"{cipher!r}, which this system's openssl does not support. It was "
+                    "likely created on a host with a different openssl build. Restore on "
+                    "that host, install an openssl that provides the cipher, or run "
+                    "'openssl enc -ciphers' to see what this host supports."
                 )
             openssl_cmd = [
                 "openssl",

--- a/tests/test_error_delivery.py
+++ b/tests/test_error_delivery.py
@@ -1,0 +1,356 @@
+"""Error delivery / UX (T7).
+
+A reliable backup tool must never hand a regular user a raw Python traceback or an
+empty/misleading error. Every failure here is expected to be delivered as a plain,
+self-explanatory line naming what went wrong and what to do -- and the tool must exit
+non-zero, not crash. These guard the break-campaign findings grouped under T7.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import btrfs_backup_ng.cli.dispatcher as disp
+import btrfs_backup_ng.core.operations as ops
+import btrfs_backup_ng.endpoint.raw as raw_mod
+from btrfs_backup_ng import __util__
+from btrfs_backup_ng.endpoint.local import LocalEndpoint
+from btrfs_backup_ng.endpoint.raw import RawEndpoint, RawSnapshot
+
+
+# --- top-level handler: no bare traceback ever -------------------------------
+
+
+def _run(command="raw"):
+    return disp.run_subcommand(argparse.Namespace(version=False, command=command))
+
+
+def test_uncaught_exception_renders_clean_line_not_traceback(monkeypatch, capsys):
+    """A handler raising an arbitrary error (e.g. a ValueError from a bad sidecar
+    cipher, which send_snapshot's except historically did not catch) must reach the
+    user as one plain line + a --debug hint + exit 1, never a Python traceback.
+    Mutation guard: removing the top-level ``except Exception`` re-raises to the user."""
+    monkeypatch.setattr(
+        disp, "cmd_raw", MagicMock(side_effect=ValueError("bad cipher in sidecar"))
+    )
+    rc = _run("raw")
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "Error: bad cipher in sidecar" in err
+    assert "--debug" in err
+    assert "Traceback" not in err
+
+
+def test_abort_error_renders_its_message_without_debug_hint(monkeypatch, capsys):
+    """An AbortError is a deliberate, already-plain-language stop; show its message as
+    the reason, and do NOT append the --debug traceback hint (there is nothing to
+    debug -- the message is the answer)."""
+    monkeypatch.setattr(
+        disp,
+        "cmd_raw",
+        MagicMock(side_effect=__util__.AbortError("zstd is not installed; install it")),
+    )
+    rc = _run("raw")
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "Error: zstd is not installed; install it" in err
+    assert "--debug" not in err
+    assert "Traceback" not in err
+
+
+def test_keyboard_interrupt_is_clean_130(monkeypatch, capsys):
+    monkeypatch.setattr(disp, "cmd_raw", MagicMock(side_effect=KeyboardInterrupt()))
+    rc = _run("raw")
+    err = capsys.readouterr().err
+    assert rc == 130
+    assert "Interrupted" in err
+    assert "Traceback" not in err
+
+
+# --- exec_subprocess: a command failure carries a real reason ----------------
+
+
+def test_failed_command_yields_nonempty_message():
+    """``raise AbortError from e`` left the AbortError empty, so callers logged garbled
+    lines like 'Failed to create snapshot: ' with no reason. The message must now name
+    the command and its exit status. Mutation guard: reverting to a bare
+    ``raise AbortError from e`` makes str(e) empty and fails this."""
+    with pytest.raises(__util__.AbortError) as ei:
+        __util__.exec_subprocess(["false"], method="check_call")
+    msg = str(ei.value)
+    assert msg  # not empty
+    assert "false" in msg and "exit status 1" in msg
+
+
+def test_failed_command_includes_captured_stderr():
+    """When stderr was captured, the reason must include it (the actionable detail),
+    not just the exit code."""
+    with pytest.raises(__util__.AbortError) as ei:
+        __util__.exec_subprocess(
+            ["sh", "-c", "echo boom-detail >&2; exit 3"],
+            method="check_output",
+            stderr=subprocess.PIPE,
+        )
+    msg = str(ei.value)
+    assert "boom-detail" in msg
+    assert "exit 3" in msg
+
+
+# --- same-second snapshot collision: clear, not "Read-only file system" ------
+
+
+def test_same_second_snapshot_collision_is_explained(tmp_path, monkeypatch):
+    """Two snapshots requested in the same second collide on name. btrfs would report
+    the misleading 'Could not create subvolume: Read-only file system'; the tool must
+    detect the pre-existing name first and explain the real cause. Mutation guard:
+    removing the ``snapshot_path.exists()`` pre-check drops the AbortError (the code
+    would instead reach the btrfs command, which is not run here)."""
+    src = tmp_path / "src"
+    src.mkdir()
+    snaps = tmp_path / "snaps"
+
+    # Freeze the timestamp so both the pre-created path and the endpoint's internal
+    # snapshot derive the SAME name -- a deterministic collision, no real clock race.
+    fixed = __util__.str_to_date("2026-01-02 03:04:05", fmt="%Y-%m-%d %H:%M:%S")
+    monkeypatch.setattr(__util__, "str_to_date", lambda *a, **k: fixed)
+
+    ep = LocalEndpoint(
+        config={
+            "source": str(src),
+            "path": str(snaps),
+            "snapshot_folder": str(snaps),
+            "snap_prefix": "t-",
+        }
+    )
+    name = __util__.Snapshot(snaps, "t-", ep).get_name()
+    snaps.mkdir(parents=True, exist_ok=True)
+    (snaps / name).mkdir()  # the pre-existing colliding snapshot
+
+    with pytest.raises(__util__.AbortError) as ei:
+        ep.snapshot()
+    msg = str(ei.value)
+    assert "already exists" in msg
+    assert "same second" in msg
+    assert "Read-only file system" not in msg
+
+
+# --- openssl: an unsupported cipher fails clearly, not with an EVP dump -------
+
+
+def test_unsupported_openssl_cipher_aborts_with_clear_message():
+    """A cipher this host's openssl does not know (a different openssl build, or a
+    hand-edited sidecar) must fail BEFORE the pipeline dumps a cryptic OpenSSL EVP
+    error. Mutation guard: removing the ``_openssl_supports_cipher`` branch lets the
+    pipeline build silently, so no AbortError is raised."""
+    ep = RawEndpoint(config={"path": "/tmp"})
+    snap = RawSnapshot(
+        name="x",
+        stream_path=Path("/tmp/x.btrfs.enc"),
+        encrypt="openssl_enc",
+        openssl_cipher="aes-256-cbcx",  # structurally valid, but no such cipher
+    )
+    with pytest.raises(__util__.AbortError) as ei:
+        ep._build_restore_pipeline(snap)
+    assert "aes-256-cbcx" in str(ei.value)
+    assert "openssl" in str(ei.value).lower()
+
+
+def test_supported_openssl_cipher_is_not_false_rejected(monkeypatch):
+    """The probe must not block a real cipher (guards over-eager rejection)."""
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "pw")  # so the decrypt stage builds
+    ep = RawEndpoint(config={"path": "/tmp"})
+    snap = RawSnapshot(
+        name="x",
+        stream_path=Path("/tmp/x.btrfs.enc"),
+        encrypt="openssl_enc",
+        openssl_cipher="aes-256-cbc",
+    )
+    pipeline = ep._build_restore_pipeline(snap)  # must not raise
+    assert any("openssl" in stage[0] for stage in pipeline)
+
+
+def test_openssl_support_probe_discriminates():
+    assert raw_mod._openssl_supports_cipher("aes-256-cbc") is True
+    assert raw_mod._openssl_supports_cipher("aes-256-cbcx") is False
+
+
+def test_probe_fails_open_when_openssl_missing(monkeypatch):
+    """The probe must fail OPEN when it cannot adjudicate: if openssl is absent from
+    PATH it returns True so the restore is NOT wrongly blocked (a missing tool is
+    reported by the tool preflight, not by second-guessing the cipher). Mutation guard:
+    flipping the openssl-missing ``return True`` to ``return False`` fails this."""
+    monkeypatch.setattr(raw_mod.shutil, "which", lambda name: None)
+    assert raw_mod._openssl_supports_cipher("aes-256-cbcx") is True
+
+
+def test_probe_fails_open_on_oserror(monkeypatch):
+    """If the probe subprocess cannot even spawn (OSError), fail OPEN -- do not block a
+    restore on an inability to run the check. Mutation guard: flipping the except
+    ``return True`` to ``return False`` fails this."""
+
+    def boom(*a, **k):
+        raise OSError("cannot spawn")
+
+    monkeypatch.setattr(raw_mod.subprocess, "run", boom)
+    assert raw_mod._openssl_supports_cipher("aes-256-cbc") is True
+
+
+def test_probe_fails_open_on_timeout(monkeypatch):
+    """If the probe hangs and times out, fail OPEN rather than hang or block. Mutation
+    guard: dropping TimeoutExpired from the except (or the ``return True``) fails this."""
+
+    def slow(*a, **k):
+        raise subprocess.TimeoutExpired(cmd="openssl", timeout=15)
+
+    monkeypatch.setattr(raw_mod.subprocess, "run", slow)
+    assert raw_mod._openssl_supports_cipher("aes-256-cbc") is True
+
+
+# --- checksum on a symlink: clear reason, not a scary ELOOP ------------------
+
+
+def test_checksum_symlink_reports_plain_reason(tmp_path, monkeypatch):
+    """_sha256_file opens with O_NOFOLLOW; a symlink stream surfaces ELOOP, whose
+    default text 'Too many levels of symbolic links' wrongly implies a loop. The
+    warning must say it is a symlink, refused for safety. Mutation guard: reverting to
+    logging the raw exception restores the misleading text."""
+    real = tmp_path / "real.btrfs"
+    real.write_bytes(b"data")
+    link = tmp_path / "link.btrfs"
+    link.symlink_to(real)
+
+    warnings = []
+    monkeypatch.setattr(raw_mod.logger, "warning", lambda *a, **k: warnings.append(a))
+    result = raw_mod._sha256_file(link)
+    assert result is None  # refused
+    rendered = " ".join(str(a) for w in warnings for a in w)
+    assert "symlink" in rendered
+    assert "Too many levels" not in rendered
+
+
+# --- honest transfer banner: no "complete!" when a transfer failed -----------
+
+
+def _drive_transfers(monkeypatch, send_side_effect):
+    dest = MagicMock()
+    dest.get_id.return_value = "dest-id"
+    dest.config = {"path": "/dest"}
+    src = MagicMock()
+    snap = MagicMock()
+    snap.get_name.return_value = "snap-1"
+
+    monkeypatch.setattr(ops, "send_snapshot", MagicMock(side_effect=send_side_effect))
+    monkeypatch.setattr(ops, "_cleanup_partial_local_subvolume", lambda *a, **k: None)
+    monkeypatch.setattr(ops, "_cleanup_partial_raw_stream", lambda *a, **k: None)
+
+    headings = []
+    monkeypatch.setattr(
+        ops.logger,
+        "warning",
+        lambda msg, *a, **k: headings.append(("warn", msg % a if a else msg)),
+    )
+    monkeypatch.setattr(
+        ops.logger,
+        "info",
+        lambda msg, *a, **k: headings.append(("info", msg % a if a else msg)),
+    )
+    monkeypatch.setattr(ops.logger, "error", lambda *a, **k: None)
+    monkeypatch.setattr(ops.logger, "debug", lambda *a, **k: None)
+
+    result = ops._execute_transfers(
+        source_endpoint=src,
+        destination_endpoint=dest,
+        source_snapshots=[snap],
+        destination_snapshots=[],
+        to_transfer=[snap],
+        no_incremental=True,
+        options={},
+    )
+    return result, headings
+
+
+def test_banner_reports_failure_not_complete(monkeypatch):
+    """A failed transfer must NOT print a 'complete!' banner. Mutation guard: reverting
+    to the unconditional 'complete!' info line fails the 'no complete' assertion."""
+    _, headings = _drive_transfers(
+        monkeypatch, __util__.SnapshotTransferError("send died")
+    )
+    text = " ".join(m for _, m in headings)
+    assert "failure" in text
+    assert "complete!" not in text
+
+
+def test_banner_reports_complete_on_success(monkeypatch):
+    _, headings = _drive_transfers(monkeypatch, lambda *a, **k: None)
+    text = " ".join(m for _, m in headings)
+    assert "complete!" in text
+
+
+# --- send_snapshot wraps a ValueError into a reported transfer failure --------
+
+
+def test_send_snapshot_wraps_valueerror(monkeypatch):
+    """A ValueError raised by send() (e.g. an unusable recorded cipher) must be logged
+    as a failed transaction and re-raised as SnapshotTransferError, so the per-target
+    handler reports the reason and continues -- not escape as a bare traceback.
+    Mutation guard: removing the ``except ValueError`` clause lets the ValueError
+    propagate unwrapped."""
+    snap = MagicMock()
+    snap.get_path.return_value = "/x"
+    snap.endpoint.send.side_effect = ValueError(
+        "cipher 'aes-256-gcm' is AEAD; refusing"
+    )
+    dest = MagicMock()
+    dest.config = {"path": "/dest"}
+
+    monkeypatch.setattr(ops, "_ensure_destination_exists", lambda *a, **k: None)
+    monkeypatch.setattr(ops, "_cleanup_processes", lambda *a, **k: None)
+
+    with pytest.raises(__util__.SnapshotTransferError) as ei:
+        ops.send_snapshot(snap, dest, options={"check_space": False})
+    assert "AEAD" in str(ei.value)
+
+
+# --- raw encrypt: plain output shows the actionable reason -------------------
+
+
+def test_raw_encrypt_plain_output_shows_failure_reason(tmp_path, monkeypatch, capsys):
+    """When a stream cannot be remediated, the plain (non-JSON) output must show the
+    reason -- previously it printed only 'ERROR <name>', hiding the cause unless the
+    user thought to add --json. Mutation guard: dropping the ``reason:`` line hides it
+    again."""
+    stream = tmp_path / "s.20240101T000000.btrfs"
+    stream.write_bytes(b"plaintext-stream")
+    RawSnapshot(name="s.20240101T000000", stream_path=stream, size=16).save_metadata()
+
+    monkeypatch.setenv("BTRFS_BACKUP_PASSPHRASE", "pw")
+    monkeypatch.setattr(
+        RawEndpoint,
+        "remediate_plaintext",
+        lambda self, *a, **k: (_ for _ in ()).throw(RuntimeError("gpg exploded here")),
+    )
+
+    args = argparse.Namespace(
+        target=str(tmp_path),
+        encrypt="openssl_enc",
+        openssl_cipher="aes-256-cbc",
+        gpg_recipient=None,
+        gpg_keyring=None,
+        dry_run=False,
+        shred=False,
+        yes=True,
+        json=False,
+        ssh_sudo=False,
+    )
+    from btrfs_backup_ng.cli import raw_cmd
+
+    rc = raw_cmd._raw_encrypt(args)
+    out = capsys.readouterr().out
+    assert rc == 1  # a failed remediation exits non-zero
+    assert "ERROR" in out
+    assert "gpg exploded here" in out  # the reason is visible in plain output


### PR DESCRIPTION
## Summary
A reliable backup tool must never hand a regular user a bare Python traceback or an empty/misleading error. The break campaign (theme **T7: error delivery / UX**) found eight ways a failure reached the user badly. Each is now delivered as **one plain line naming what went wrong and the next step**, with a non-zero exit — the process *reports*, it does not crash.

## The eight fixes
1. **Top-level guard** in the CLI dispatcher — any error escaping a command handler renders as a single `Error: ...` line (+ a `--debug` hint for the full traceback) and exits 1; Ctrl-C exits 130 ("Interrupted"); a deliberate `AbortError` shows its own plain message with no debug hint. Previously an uncaught error (e.g. a `ValueError` from an unusable sidecar cipher) dumped a raw interpreter traceback.
2. **send_snapshot** wraps a mid-transfer `ValueError` into a reported transfer failure, so the run continues to other targets instead of aborting with a traceback.
3. **Command failures carry a real reason** — `exec_subprocess` now includes the command, exit status, and captured stderr instead of an empty `AbortError` (no more blank "Failed to create snapshot:").
4. **Same-second snapshot collision** is explained ("a snapshot named X already exists … wait a second and retry") instead of btrfs's misleading "Could not create subvolume: Read-only file system".
5. **Unsupported/typo openssl cipher** on restore fails clearly, naming the cipher, *before* the pipeline dumps a cryptic OpenSSL EVP error. The check probes the local openssl and **fails open** (openssl missing / probe error / timeout all proceed — never blocks a restore it cannot adjudicate), with a 15s timeout so it can't hang.
6. **raw encrypt** shows the failure reason in plain output, not only with `--json`.
7. **Checksum/verify on a symlink stream** reports "it is a symlink (refused for safety)" instead of the O_NOFOLLOW ELOOP text "Too many levels of symbolic links".
8. **Honest transfer banner** — "finished with N failure(s)" on failure; "complete!" only when nothing failed.

## Empirical proof (nothing inferred)
- Traceback→clean-line conversion, the openssl support probe, and the non-empty command-failure message: reproduced directly.
- **Same-second collision on real btrfs**: first snapshot created, second (same second) → the new clear message; the misleading "Read-only file system" is gone.

## Adversarial review
4 lenses (correctness / security / robustness / test-adequacy), each with an adversarial verify pass. All correctness/security/robustness findings were refuted or below HIGH; the one surviving finding — the probe's **fail-open branches were untested** — is closed here with three mutation-verified tests (openssl-missing, OSError, timeout all fail open).

## Testing
`tests/test_error_delivery.py` — 17 tests. Every enforcement point is **mutation-verified** (each guard fails when reverted). Full suite **2326 passed**; ruff / ruff-format@0.15.22 / mypy clean.