### PR TITLE
fix: make --no-check-space/--force/--safety-margin actually take effect

### DIFF
--- a/src/btrfs_backup_ng/cli/common.py
+++ b/src/btrfs_backup_ng/cli/common.py
@@ -2,8 +2,29 @@
 
 import argparse
 import sys
+from typing import Any
 
 from .. import __util__
+
+
+def space_options_from_args(args: argparse.Namespace) -> dict[str, Any]:
+    """Space-check transfer options derived from the parsed CLI flags.
+
+    Without threading these, ``--no-check-space``/``--force``/``--safety-margin`` are
+    dead flags: ``send_snapshot`` defaults ``check_space=True`` and ``force=False``, so
+    the destination space preflight always runs and can never be bypassed -- which bites
+    hardest on raw targets, whose size estimate is conservative and can refuse a
+    transfer that would actually fit. Merge the result into the transfer ``options``
+    dict so the flags take effect (the default -- no flags -- reproduces today's
+    always-check behavior)."""
+    opts: dict[str, Any] = {
+        "check_space": not getattr(args, "no_check_space", False),
+        "force": getattr(args, "force", False),
+    }
+    margin = getattr(args, "safety_margin", None)
+    if margin is not None:
+        opts["safety_margin"] = margin
+    return opts
 
 
 def is_interactive() -> bool:

--- a/src/btrfs_backup_ng/cli/run.py
+++ b/src/btrfs_backup_ng/cli/run.py
@@ -32,6 +32,7 @@ from .common import (
     get_log_level,
     get_timestamp_format,
     should_show_progress,
+    space_options_from_args,
     thread_raw_compression,
     thread_raw_encryption,
 )
@@ -109,6 +110,9 @@ def execute_run(args: argparse.Namespace) -> int:
     # Get CLI overrides for compression/throttling
     compress_override = getattr(args, "compress", None)
     rate_limit_override = getattr(args, "rate_limit", None)
+    # Space-check flags (--no-check-space/--force/--safety-margin); threaded into the
+    # transfer options so they actually take effect (see space_options_from_args).
+    space_options = space_options_from_args(args)
 
     # Determine if progress should be shown
     show_progress = should_show_progress(args)
@@ -137,6 +141,7 @@ def execute_run(args: argparse.Namespace) -> int:
                     compress_override,
                     rate_limit_override,
                     show_progress,
+                    space_options,
                 ): volume
                 for volume in enabled_volumes
             }
@@ -163,6 +168,7 @@ def execute_run(args: argparse.Namespace) -> int:
                     compress_override,
                     rate_limit_override,
                     show_progress,
+                    space_options,
                 )
                 results.append((volume.path, success))
                 transfer_stats["completed"] += vol_stats.get("completed", 0)
@@ -248,6 +254,7 @@ def _backup_volume(
     compress_override: str | None = None,
     rate_limit_override: str | None = None,
     show_progress: bool = False,
+    space_options: dict[str, Any] | None = None,
 ) -> tuple[bool, dict[str, int], list[str]]:
     """Execute backup for a single volume.
 
@@ -258,6 +265,7 @@ def _backup_volume(
         compress_override: CLI override for compression method
         rate_limit_override: CLI override for bandwidth limit
         show_progress: Whether to show progress bars
+        space_options: Space-check options from the CLI space flags
 
     Returns:
         Tuple of (success, transfer_stats, error_messages)
@@ -274,6 +282,7 @@ def _backup_volume(
             compress_override,
             rate_limit_override,
             show_progress,
+            space_options,
         )
 
     # Build endpoint kwargs
@@ -397,6 +406,7 @@ def _backup_volume(
                     compress_override,
                     rate_limit_override,
                     show_progress,
+                    space_options,
                 ): (dest_endpoint, target_config)
                 for dest_endpoint, target_config in destination_endpoints
             }
@@ -427,6 +437,7 @@ def _backup_volume(
                     compress_override,
                     rate_limit_override,
                     show_progress,
+                    space_options,
                 )
                 if success:
                     stats["completed"] += 1
@@ -448,6 +459,7 @@ def _backup_snapper_volume(
     compress_override: str | None = None,
     rate_limit_override: str | None = None,
     show_progress: bool = False,
+    space_options: dict[str, Any] | None = None,
 ) -> tuple[bool, dict[str, int], list[str]]:
     """Execute backup for a snapper-sourced volume.
 
@@ -528,6 +540,8 @@ def _backup_snapper_volume(
                 "compress": compress_override or target.compress or default_compress,
                 "rate_limit": rate_limit_override or target.rate_limit,
                 "show_progress": show_progress,
+                # Space-check flags so --no-check-space/--force actually apply.
+                **(space_options or {}),
             }
 
             # Route the destination through the endpoint layer (local/ssh/raw),
@@ -588,6 +602,7 @@ def _transfer_to_target(
     compress_override: str | None = None,
     rate_limit_override: str | None = None,
     show_progress: bool = False,
+    space_options: dict[str, Any] | None = None,
 ) -> bool:
     """Transfer snapshot to a single target.
 
@@ -600,6 +615,7 @@ def _transfer_to_target(
         compress_override: CLI override for compression method
         rate_limit_override: CLI override for bandwidth limit
         show_progress: Whether to show progress bars
+        space_options: Space-check options from the CLI space flags
 
     Returns:
         True if successful
@@ -612,6 +628,9 @@ def _transfer_to_target(
             "rate_limit": rate_limit_override or target_config.rate_limit,
             "ssh_sudo": target_config.ssh_sudo,
             "show_progress": show_progress,
+            # Space-check flags (--no-check-space/--force/--safety-margin) so the
+            # destination space preflight can actually be bypassed when requested.
+            **(space_options or {}),
         }
 
         sync_snapshots(

--- a/src/btrfs_backup_ng/cli/transfer.py
+++ b/src/btrfs_backup_ng/cli/transfer.py
@@ -12,6 +12,7 @@ from ..core.operations import sync_snapshots
 from .common import (
     get_log_level,
     get_timestamp_format,
+    space_options_from_args,
     thread_raw_compression,
     thread_raw_encryption,
 )
@@ -187,6 +188,9 @@ def execute_transfer(args: argparse.Namespace) -> int:
                         "compress": compress_override or target.compress,
                         "rate_limit": rate_limit_override or target.rate_limit,
                         "ssh_sudo": target.ssh_sudo,
+                        # Space-check flags (--no-check-space/--force/--safety-margin)
+                        # so the destination space preflight can be bypassed.
+                        **space_options_from_args(args),
                     }
 
                     sync_snapshots(

--- a/tests/test_space_flags.py
+++ b/tests/test_space_flags.py
@@ -1,0 +1,228 @@
+"""Space-check flags must actually take effect (T8).
+
+``--no-check-space``/``--force``/``--safety-margin`` were parsed but never threaded into
+the transfer options, so ``send_snapshot`` always ran the destination space preflight and
+the flags were dead. That bit raw targets hardest: their size estimate is conservative
+(≈130 MiB for 30 MB of real data, proven on hardware), so the preflight refused transfers
+that would actually fit, with no working way to override it. These guard the plumbing that
+makes the flags real, and the send-side contract they rely on.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import btrfs_backup_ng.cli.run as run_mod
+import btrfs_backup_ng.cli.transfer as transfer_mod
+import btrfs_backup_ng.core.operations as ops
+from btrfs_backup_ng import __util__
+from btrfs_backup_ng.cli.common import space_options_from_args
+from btrfs_backup_ng.config.schema import (
+    Config,
+    GlobalConfig,
+    TargetConfig,
+    VolumeConfig,
+)
+
+
+# --- the flags -> options mapping --------------------------------------------
+
+
+def test_defaults_preserve_always_check():
+    """No flags => today's behavior: the space check runs, nothing is forced."""
+    opts = space_options_from_args(argparse.Namespace())
+    assert opts["check_space"] is True
+    assert opts["force"] is False
+    assert "safety_margin" not in opts  # left to the send-side default
+
+
+def test_no_check_space_disables_the_check():
+    """Mutation guard: dropping the ``not`` (or hardcoding True) fails this."""
+    opts = space_options_from_args(argparse.Namespace(no_check_space=True))
+    assert opts["check_space"] is False
+
+
+def test_force_is_threaded():
+    opts = space_options_from_args(argparse.Namespace(force=True))
+    assert opts["force"] is True
+
+
+def test_safety_margin_is_threaded_when_set():
+    opts = space_options_from_args(argparse.Namespace(safety_margin=25.0))
+    assert opts["safety_margin"] == 25.0
+
+
+# --- the plumbing actually reaches the transfer options ----------------------
+
+
+def test_transfer_to_target_merges_space_options(monkeypatch):
+    """_transfer_to_target must merge space_options into the options handed to
+    sync_snapshots. Mutation guard: removing ``**(space_options or {})`` from the
+    transfer_options dict drops check_space/force and fails this."""
+    captured = {}
+
+    def fake_sync(*a, **k):
+        captured.update(k.get("options", {}))
+
+    monkeypatch.setattr(run_mod, "sync_snapshots", fake_sync)
+
+    target_config = MagicMock()
+    target_config.compress = "none"
+    target_config.rate_limit = None
+    target_config.ssh_sudo = False
+    target_config.path = "raw:///mnt/x"
+
+    ok = run_mod._transfer_to_target(
+        MagicMock(),
+        MagicMock(),
+        target_config,
+        MagicMock(),
+        True,
+        space_options={"check_space": False, "force": True},
+    )
+    assert ok is True
+    assert captured["check_space"] is False
+    assert captured["force"] is True
+
+
+def test_backup_snapper_volume_merges_space_options(monkeypatch):
+    """The snapper 'run' path builds a SEPARATE options dict from _transfer_to_target;
+    it too must merge the space flags. Mutation guard: removing ``**(space_options or
+    {})`` from _backup_snapper_volume's options dict (or _backup_volume failing to
+    forward space_options) drops check_space/force here and fails this."""
+    from btrfs_backup_ng.snapper.scanner import SnapperConfig
+
+    captured: dict = {}
+
+    def fake_sync(*a, **k):
+        captured.update(k.get("options", {}))
+        return 1
+
+    # _backup_snapper_volume imports sync_snapper_snapshots locally from core.operations,
+    # so patch it at its origin module (not on cli.run).
+    monkeypatch.setattr(ops, "sync_snapper_snapshots", fake_sync)
+    monkeypatch.setattr(
+        run_mod.endpoint, "choose_endpoint", lambda *a, **k: MagicMock(_is_remote=False)
+    )
+
+    volume = VolumeConfig(path="/", snapshot_prefix="root-")
+    volume.source = "snapper"  # type: ignore[attr-defined]
+    volume.snapper = MagicMock(config_name="root")  # type: ignore[attr-defined]
+    volume.targets = [TargetConfig(path="/mnt/backup")]
+    config = Config(global_config=GlobalConfig(), volumes=[volume])
+
+    with patch("btrfs_backup_ng.snapper.SnapperScanner") as mock_scanner_cls:
+        scanner = MagicMock()
+        scanner.find_config_for_path.return_value = SnapperConfig(
+            name="root", subvolume=Path("/")
+        )
+        mock_scanner_cls.return_value = scanner
+        run_mod._backup_snapper_volume(
+            volume, config, space_options={"check_space": False, "force": True}
+        )
+
+    assert captured["check_space"] is False
+    assert captured["force"] is True
+
+
+def test_execute_transfer_merges_space_options(monkeypatch, tmp_path):
+    """The 'transfer' subcommand builds its own options dict inline; it must merge the
+    space flags too. Mutation guard: removing ``**space_options_from_args(args)`` from
+    execute_transfer's transfer_options fails this."""
+    data = tmp_path / "data"
+    (data / ".snapshots").mkdir(parents=True)
+    volume = VolumeConfig(
+        path=str(data),
+        snapshot_prefix="data-",
+        snapshot_dir=".snapshots",
+        targets=[TargetConfig(path="/mnt/backup")],
+    )
+    config = Config(global_config=GlobalConfig(), volumes=[volume])
+
+    captured: dict = {}
+    monkeypatch.setattr(
+        transfer_mod,
+        "sync_snapshots",
+        lambda *a, **k: captured.update(k.get("options", {})),
+    )
+    monkeypatch.setattr(
+        transfer_mod, "find_config_file", lambda *a, **k: str(tmp_path / "c.toml")
+    )
+    monkeypatch.setattr(transfer_mod, "load_config", lambda *a, **k: (config, []))
+    ep = MagicMock()
+    ep.list_snapshots.return_value = [MagicMock()]
+    monkeypatch.setattr(transfer_mod.endpoint, "choose_endpoint", lambda *a, **k: ep)
+
+    args = MagicMock()
+    args.config = None
+    args.volume = None
+    args.dry_run = False
+    args.compress = None
+    args.rate_limit = None
+    args.no_check_space = True
+    args.force = False
+    args.safety_margin = 10.0
+
+    transfer_mod.execute_transfer(args)
+    assert captured["check_space"] is False  # --no-check-space took effect
+
+
+def test_transfer_to_target_without_space_options_is_safe(monkeypatch):
+    """A None space_options must not crash and must not inject space keys (so the
+    send-side defaults apply)."""
+    captured = {}
+    monkeypatch.setattr(
+        run_mod, "sync_snapshots", lambda *a, **k: captured.update(k.get("options", {}))
+    )
+    tc = MagicMock()
+    tc.compress = "none"
+    tc.rate_limit = None
+    tc.ssh_sudo = False
+    tc.path = "raw:///x"
+    run_mod._transfer_to_target(MagicMock(), MagicMock(), tc, MagicMock(), True)
+    assert "check_space" not in captured  # send-side default (True) governs
+
+
+# --- the send-side contract the flags rely on --------------------------------
+
+
+def _spy_send_snapshot(monkeypatch, options):
+    """Drive send_snapshot far enough to observe the preflight decision, then abort the
+    actual send. Returns the _verify_destination_space spy."""
+    spy = MagicMock()
+    monkeypatch.setattr(ops, "_verify_destination_space", spy)
+    monkeypatch.setattr(ops, "_ensure_destination_exists", lambda *a, **k: None)
+    monkeypatch.setattr(ops, "_cleanup_processes", lambda *a, **k: None)
+
+    snap = MagicMock()
+    snap.get_path.return_value = "/x"
+    snap.endpoint.send.side_effect = OSError("stop after preflight decision")
+    dest = MagicMock()
+    dest.config = {"path": "/dest"}
+
+    with pytest.raises(__util__.SnapshotTransferError):
+        ops.send_snapshot(snap, dest, options=options)
+    return spy
+
+
+def test_send_snapshot_skips_preflight_when_check_space_false(monkeypatch):
+    """check_space=False must SKIP the space preflight (this is what --no-check-space
+    ultimately buys). Mutation guard: changing the ``if check_space and not force``
+    gate so it ignores check_space makes the spy fire and fails this."""
+    spy = _spy_send_snapshot(monkeypatch, {"check_space": False})
+    spy.assert_not_called()
+
+
+def test_send_snapshot_skips_preflight_when_forced(monkeypatch):
+    spy = _spy_send_snapshot(monkeypatch, {"check_space": True, "force": True})
+    spy.assert_not_called()
+
+
+def test_send_snapshot_runs_preflight_by_default(monkeypatch):
+    """The default (no flags) still runs the preflight -- no regression."""
+    spy = _spy_send_snapshot(monkeypatch, {})
+    spy.assert_called_once()


### PR DESCRIPTION
## Summary
The `run` and `transfer` subcommands define `--no-check-space`, `--force`, and `--safety-margin`, but the transfer options they built never carried those values — so `send_snapshot` always defaulted to `check_space=True`/`force=False` and the destination space preflight ran regardless. **The flags were dead**: there was no working way to override the check.

This bit **raw targets hardest** — a raw target's size estimate is deliberately conservative, so the preflight refused transfers that fit. Backing up **30 MB of real data** to a target with **47 MB free** was estimated at **130 MB** and blocked ("0 succeeded, 1 failed"), with `--no-check-space` and `--force` both silently ignored.

## Fix
A small `space_options_from_args()` helper maps the parsed flags to `{check_space, force, safety_margin}`, merged into the transfer options at **every** construction site:
- native run path (`execute_run → _backup_volume → _transfer_to_target`),
- snapper run path (`execute_run → _backup_volume → _backup_snapper_volume`),
- transfer subcommand (`execute_transfer`).

`send_snapshot` already honored these keys — they simply never arrived. With no flags the behavior is unchanged (the check still runs), and `--safety-margin`'s default matches the previous hardcoded default, so only an explicit override changes anything (no regression).

## Empirical proof (real hardware)
- Default run: over-estimate blocks (130 MiB vs 47 MiB free) → "0 succeeded, 1 failed".
- `run --no-check-space`: check **skipped** → completes, lands a byte-complete **31 MB** stream + sidecar.
- `run --force`: same — bypasses and completes.

## Adversarial review
Completeness / correctness / test-adequacy lenses, each with an adversarial verify pass. Completeness and correctness found nothing (all three send paths confirmed threaded; both parsers define the flags; no margin regression). The two surviving findings were **untested construction sites** — the snapper run path and the transfer subcommand — each mutation-proven unguarded; both are now closed with mutation-verified tests.

## Testing
`tests/test_space_flags.py` — 11 tests. Every threading site (native, snapper, transfer) and the send-side gate are **mutation-verified**. Full suite **2337 passed**; ruff / ruff-format@0.15.22 / mypy clean.