### PR TITLE
fix: restore native btrfs backups again (local); fail loud on remote ssh

### DIFF
--- a/src/btrfs_backup_ng/cli/restore.py
+++ b/src/btrfs_backup_ng/cli/restore.py
@@ -289,6 +289,15 @@ def _execute_main_restore(args: argparse.Namespace) -> int:
         logger.error("Destination validation failed: %s", e)
         return 1
 
+    # Reject a remote ssh:// btrfs restore source up front (not supported yet), with a
+    # clear message -- before preparing/connecting. list/status paths do NOT call this,
+    # so read-only ssh:// listing keeps working.
+    try:
+        _reject_remote_ssh_restore(source)
+    except __util__.AbortError as e:
+        logger.error("%s", e)
+        return 1
+
     # Prepare backup endpoint (source)
     try:
         backup_endpoint = _prepare_backup_endpoint(args, source)
@@ -472,6 +481,27 @@ def _prepare_backup_endpoint(args: argparse.Namespace, source: str):
     backup_ep.prepare()
 
     return backup_ep
+
+
+def _reject_remote_ssh_restore(source: str) -> None:
+    """Fail fast if a RESTORE would pull from a remote ssh:// btrfs source.
+
+    A native btrfs SSHEndpoint runs ``btrfs send`` and reads/writes the lock file
+    LOCALLY, so it cannot stream a snapshot back from the remote host -- a real remote
+    source would otherwise fail late with a misleading local-path error. Raise a clear,
+    actionable message instead. The check is by URL scheme, matching how the endpoint is
+    chosen: only ``ssh://`` (native btrfs over ssh) is rejected. ``raw+ssh://`` (its own
+    scheme -> SSHRawEndpoint) DOES support remote restore, and ``raw://`` / local btrfs
+    are unaffected -- none of those start with ``ssh://``. Called ONLY on the restore
+    path, so ``restore --list`` / ``--status`` of an ssh:// target keep working."""
+    if source.startswith("ssh://"):
+        raise __util__.AbortError(
+            f"Restoring a native btrfs backup directly from a remote ssh:// source "
+            f"({source}) is not supported yet -- the snapshot has to be read on the "
+            "machine that stores it. Options: restore on that machine; or copy/mount "
+            "the backup locally and restore from a local path; or use a raw+ssh:// "
+            "backup, which does support remote restore."
+        )
 
 
 def _prepare_local_endpoint(dest_path: Path, timestamp_format: str | None = None):

--- a/src/btrfs_backup_ng/endpoint/common.py
+++ b/src/btrfs_backup_ng/endpoint/common.py
@@ -198,11 +198,20 @@ class Endpoint:
                 self.add_snapshot(snapshot)
         return snapshot
 
-    @require_source
     def send(
         self, snapshot: Any, parent: Any = None, clones: Optional[List[Any]] = None
     ) -> Any:
-        """Call 'btrfs send' for the given snapshot and return its Popen object."""
+        """Call 'btrfs send' for the given snapshot and return its Popen object.
+
+        NOT ``@require_source``: this sends the GIVEN ``snapshot`` by its own path and
+        never reads ``config["source"]``. The restore path deliberately swaps endpoints
+        and calls send() on the BACKUP endpoint (which has no source) to stream a stored
+        snapshot back -- requiring a source aborted native btrfs restore. Creating a NEW
+        snapshot (``snapshot()``) still requires a source; sending an existing one does
+        not. NB: the base implementation runs ``btrfs send`` LOCALLY, so it serves LOCAL
+        btrfs restore; a remote ssh:// restore source is gated in the restore CLI until
+        SSHEndpoint gains a remote-aware send.
+        """
         cmd = self._build_send_command(snapshot, parent=parent, clones=clones)
         # Suppress stderr ("At subvol" messages) - they're just informational
         return self._exec_command(
@@ -341,11 +350,20 @@ class Endpoint:
         )
         return list(snapshots)
 
-    @require_source
     def set_lock(
         self, snapshot: Any, lock_id: Any, lock_state: bool, parent: bool = False
     ) -> None:
-        """Add or remove the given lock from ``snapshot`` and update the lock file."""
+        """Add or remove the given lock from ``snapshot`` and update the lock file.
+
+        NOT ``@require_source``: a lock lives at the endpoint's ``path`` (the backup
+        location), not at a source subvolume. During a restore this is called on the
+        BACKUP endpoint -- which correctly has no ``source`` -- to lock the snapshot
+        being restored against deletion. Requiring a source here aborted native btrfs
+        restore at the lock step before any bytes moved; raw endpoints already override
+        set_lock without the guard. Removing it fully enables LOCAL btrfs restore;
+        restore from a remote ssh:// btrfs source is separately gated in the restore CLI
+        (base send/lock run locally, so a real remote source can't be streamed back yet).
+        """
         if lock_state:
             (snapshot.parent_locks if parent else snapshot.locks).add(lock_id)
         else:
@@ -792,13 +810,15 @@ class Endpoint:
             )
             raise __util__.AbortError from e
 
-    @require_source
     def _get_lock_file_path(self) -> Path:
+        # Lock file lives at the endpoint's path (backup location), not a source.
         if self.config["path"] is None:
-            raise ValueError
-        return self.config["path"] / str(self.config["lock_file_name"])
+            raise ValueError("path hasn't been set")
+        # Coerce to Path: LocalEndpoint resolves ``path`` to a Path, but SSH endpoints
+        # keep it as a str, so ``path / name`` raised TypeError ('str' / 'str') on a
+        # restore FROM an ssh:// btrfs backup (which sets a lock on the ssh endpoint).
+        return Path(self.config["path"]) / str(self.config["lock_file_name"])
 
-    @require_source
     def _read_locks(self) -> Dict[str, Any]:
         path = self._get_lock_file_path()
         try:
@@ -810,7 +830,6 @@ class Endpoint:
             logger.error("Error on reading lock file %s: %s", path, e)
             raise __util__.AbortError
 
-    @require_source
     def _write_locks(self, lock_dict: Dict[str, Any]) -> None:
         path = self._get_lock_file_path()
         try:

--- a/tests/test_native_restore_lock.py
+++ b/tests/test_native_restore_lock.py
@@ -1,0 +1,146 @@
+"""Native btrfs restore must not be blocked by mis-scoped source guards.
+
+Restoring a snapshot swaps endpoints: it sets a lock on, and calls ``send()`` of, the
+BACKUP endpoint -- which legitimately has no ``source``. Two mistakes in
+``endpoint/common.py`` aborted native btrfs restore before any byte moved:
+
+1. ``@require_source`` was applied to the lock-persistence methods and ``send()``, none
+   of which read ``config["source"]`` -- they use ``config["path"]``. The backup
+   endpoint has no source, so the guard raised "source hasn't been set".
+2. ``_get_lock_file_path`` did ``config["path"] / name``; SSHEndpoint keeps ``path`` as
+   a str (LocalEndpoint resolves it to Path), so building the lock path raised
+   ``TypeError: unsupported operand type(s) for /: 'str' and 'str'``.
+
+Raw endpoints were always immune (they override ``set_lock`` decorator-free and their
+``send`` reads a stream). Removing the guards + coercing the path fully enable LOCAL
+btrfs restore. Restore from a REMOTE ssh:// btrfs source is a separate matter: the base
+``send``/lock run locally, so it cannot stream a snapshot back from the remote host --
+the restore CLI now rejects it up front with a clear message (also pinned here) until a
+remote-aware ssh send lands. These tests pin the local-restore fixes and that guard.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from btrfs_backup_ng import __util__
+from btrfs_backup_ng.endpoint.local import LocalEndpoint
+from btrfs_backup_ng.endpoint.ssh import SSHEndpoint
+
+
+def _local(tmp_path, source=None):
+    return LocalEndpoint(
+        config={
+            "path": tmp_path,
+            "source": source,
+            "snapshot_folder": ".snapshots",
+            "snap_prefix": "home-",
+        }
+    )
+
+
+def _snap(ep, tmp_path):
+    return __util__.Snapshot(tmp_path, "home-", ep)
+
+
+def test_set_lock_without_source_does_not_raise(tmp_path):
+    """The backup endpoint (no source) must be lockable during a restore. Mutation
+    guard: re-adding ``@require_source`` to set_lock makes this raise 'source hasn't
+    been set'."""
+    ep = _local(tmp_path, source=None)
+    snap = _snap(ep, tmp_path)
+    ep.set_lock(snap, "restore:abc", True)  # must not raise
+    assert "restore:abc" in snap.locks
+    # A real lock file is persisted at the backup path (not in-memory only, unlike raw).
+    assert (tmp_path / ".btrfs-backup-ng.locks").exists()
+    ep.set_lock(snap, "restore:abc", False)
+    assert "restore:abc" not in snap.locks
+
+
+def test_send_without_source_reaches_exec(tmp_path, monkeypatch):
+    """send() of a backup endpoint (no source) must proceed to run btrfs send, not be
+    blocked by a source guard. Mutation guard: re-adding ``@require_source`` to send()
+    makes this raise before reaching _exec_command."""
+    ep = _local(tmp_path, source=None)
+    snap = _snap(ep, tmp_path)
+    sentinel = object()
+    monkeypatch.setattr(ep, "_exec_command", lambda *a, **k: sentinel)
+    assert ep.send(snap) is sentinel  # got past the (removed) guard to the real send
+
+
+def test_read_write_locks_without_source_round_trip(tmp_path):
+    """The lock read/write helpers work off ``path``, not ``source``. Mutation guard:
+    re-adding ``@require_source`` to _read_locks/_write_locks raises here."""
+    ep = _local(tmp_path, source=None)
+    ep._write_locks({"home-20240101": {"locks": ["restore:1"]}})
+    assert ep._read_locks() == {"home-20240101": {"locks": ["restore:1"]}}
+
+
+def test_ssh_endpoint_str_path_lock_file(tmp_path):
+    """A real SSHEndpoint keeps ``path`` as a str, which broke ``path / name`` with a
+    TypeError. Build one (no connection happens at construction) and confirm the lock
+    path resolves. Mutation guard: reverting ``Path(self.config["path"])`` to
+    ``self.config["path"]`` raises TypeError ('str' / 'str') here."""
+    from pathlib import Path
+
+    ep = SSHEndpoint(hostname="backup-host", config={"path": "/remote/backup"})
+    assert isinstance(ep.config["path"], str)  # SSHEndpoint does NOT resolve to Path
+    result = ep._get_lock_file_path()
+    assert isinstance(result, Path)
+    assert result == Path("/remote/backup") / ep.config["lock_file_name"]
+
+
+def test_snapshot_still_requires_source(tmp_path):
+    """Guard against over-removal: creating a NEW snapshot genuinely needs a source, so
+    ``snapshot()`` must still reject a source-less endpoint."""
+    ep = _local(tmp_path, source=None)
+    with pytest.raises(ValueError, match="source hasn't been set"):
+        ep.snapshot()
+
+
+def test_remote_ssh_native_restore_source_fails_fast():
+    """Restoring a native btrfs backup from a remote ssh:// source is not supported yet
+    (SSHEndpoint runs send/lock locally). The restore path must reject it up front with a
+    clear, actionable message -- NOT let it die later with a misleading local-path error.
+    Mutation guard: neutering the ``source.startswith('ssh://')`` check drops the raise."""
+    from btrfs_backup_ng.cli.restore import _reject_remote_ssh_restore
+
+    with pytest.raises(__util__.AbortError, match="not supported yet"):
+        _reject_remote_ssh_restore("ssh://user@backup-host:/backups/data")
+
+
+def test_reject_does_not_block_raw_ssh_or_raw_or_local():
+    """The reject must be scoped to the ``ssh://`` scheme only: raw+ssh:// (which DOES
+    support remote restore), raw://, and local paths must NOT be rejected."""
+    from btrfs_backup_ng.cli.restore import _reject_remote_ssh_restore
+
+    for source in (
+        "raw+ssh://user@backup-host:/backups/data",
+        "raw:///mnt/backup",
+        "/mnt/backup/data",
+    ):
+        _reject_remote_ssh_restore(source)  # must not raise
+
+
+def test_ssh_list_path_is_not_rejected_wiring(monkeypatch):
+    """The reject fires on RESTORE but must NOT touch ``restore --list ssh://...`` (a
+    read-only op that works). This pins the CALLER WIRING, not just the pure function: a
+    future change routing the reject through _execute_list (or a shared helper both
+    restore and list call) would silently break ssh:// listing. Mutation guard: adding a
+    ``_reject_remote_ssh_restore(source)`` call into _execute_list trips the sentinel."""
+    import btrfs_backup_ng.cli.restore as restore_mod
+
+    def _must_not_call(*a, **k):
+        raise AssertionError("reject must NOT be invoked on the list path")
+
+    monkeypatch.setattr(restore_mod, "_reject_remote_ssh_restore", _must_not_call)
+    monkeypatch.setattr(
+        restore_mod, "_prepare_backup_endpoint", lambda *a, **k: object()
+    )
+    monkeypatch.setattr(restore_mod, "list_remote_snapshots", lambda *a, **k: [])
+
+    args = argparse.Namespace(source="ssh://user@backup-host:/backups/data")
+    rc = restore_mod._execute_list(args)
+    assert rc == 0  # listed (empty) cleanly -- NOT rejected with exit 1


### PR DESCRIPTION
## Summary
Restoring from a **native btrfs backup** failed before a single byte moved — `source hasn't been set` — a **pre-existing break present in 0.8.4** (raw restores were unaffected). Found during the 0.8.5 final hardware functionality test.

## Root cause (endpoint/common.py)
Two mistakes in shared endpoint code, both hit only on the restore path (which swaps roles and treats the **backup** endpoint as the sender):
1. `@require_source` was applied to `set_lock`, `send`, `_read_locks`, `_write_locks`, `_get_lock_file_path` — **none reads `config["source"]`; they use `config["path"]`**. The backup endpoint legitimately has no source, so the guard aborted at the lock step. `RawEndpoint` already overrides `set_lock` without the guard, which is why raw restores kept working. Removed the guard from those 5 (kept on `snapshot()`, which *does* create from a source).
2. `_get_lock_file_path` did `path / name` assuming a `Path`; SSHEndpoint keeps `path` as a `str` → `TypeError`. Coerced with `Path(...)`.

## Remote ssh:// restore — fail loud (Option 1)
A native ssh endpoint runs `btrfs send`/lock **locally**, so it cannot stream a snapshot back from a remote host. Rather than fail late with a misleading local-path error, the restore path now **rejects a remote `ssh://` source up front** with a clear, actionable message (restore on that machine; copy/mount locally; or use `raw+ssh://`, which supports remote restore). Scoped to the **actual restore only** — `restore --list`/`--status` of an `ssh://` target keep working; `raw+ssh://`, `raw://`, and local are unaffected. A remote-aware ssh restore is planned for a follow-up (post-0.8.5).

## Proven on real hardware (byte-identical)
- Local btrfs **full** restore + **incremental** (`restore --all` over a parent chain).
- Remote `ssh://` restore now **fails fast and clean** (no traceback); `ssh://` listing still works.
- `raw://` and `raw+ssh://` restores unaffected.

## Review & tests
Adversarial review across regression / completeness / guard-scope / test-adequacy (it caught an over-broad guard placement — since fixed — and an unpinned list-path wiring — now pinned). **8 mutation-verified tests** (guard removals incl. `_read_locks` independently, path coercion, remote-ssh reject, and the list-path wiring). Full suite **2345**; ruff / ruff-format@0.15.22 / mypy clean.