### PR TITLE
chore: Release 0.8.5 — raw backups first-class + reliability hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,80 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.5] - 2026-07-22
+
+This release makes **raw backups first-class** — a raw backup now carries everything
+needed to list, check, and restore it, and there are commands to manage raw backups
+directly — and hardens reliability across the board, including a fix for **standard
+btrfs restores**, which were broken.
+
+### Security
+
+#### An openssl cipher of "none" (or an AEAD mode) could write a plaintext raw backup labelled as encrypted
+
+Continuing the plaintext-exposure class fixed in 0.8.4 (GHSA-vr25-6vrh-869j, CWE-311/312):
+a raw target configured with `openssl_cipher = "none"` — or with an AEAD mode such as
+`*-gcm` that `openssl enc` cannot actually use — would previously pass a syntactic check
+and could write a stream that was **not encrypted** while the backup was recorded as
+encrypted. The cipher is now validated by *meaning*, not just shape: `none`, AEAD modes,
+and ciphers the local `openssl` does not support are rejected up front with a clear error,
+at backup time and again at restore time. If you use raw-target encryption, verify your
+existing backups are genuine ciphertext (see `raw verify` and, for remediation, `raw
+encrypt`).
+
+### Added
+
+- **Raw backups are now self-describing and self-checking.** Every raw backup writes an
+  authoritative sidecar (`.meta`) recording its compression, encryption, cipher, size,
+  and a checksum of the exact bytes written — so a backup can be listed, integrity-checked,
+  and restored without guessing from the filename. New backups need no manual backfill.
+- **New `raw` command family** for managing raw backups directly:
+  - `raw list` — list raw backups at a `raw://` or `raw+ssh://` target.
+  - `raw verify` — recompute each backup's checksum and report ok / corrupt / error.
+  - `raw backfill-metadata` — write authoritative sidecars for older sidecar-less streams.
+  - `raw encrypt` — encrypt existing plaintext raw backups in place (remediation for the
+    0.8.4 issue), with a live decrypt-to-identical proof before anything is removed, and
+    honest documentation that a plain delete does not physically erase data on
+    copy-on-write filesystems or SSDs.
+- **Restore from a `raw+ssh://` backup** (streamed back over ssh; decrypt/decompress happen
+  locally so secrets never leave the host), plus a preflight that checks the needed tools
+  are installed before a transfer starts.
+- `--no-check-space`, `--force`, and `--safety-margin` now actually take effect for `run`
+  and `transfer` (previously parsed but ignored), so a conservative space estimate on a
+  raw target can be overridden.
+
+### Fixed
+
+- **btrfs restore now works — local AND remote.** Restoring a native btrfs backup was
+  broken (it failed immediately with an internal "source hasn't been set" error). Local
+  btrfs restores — full and incremental — now work and are verified byte-identical, and
+  restore from a *remote* `ssh://` btrfs source works too: the stream is read back over
+  ssh, and full, `--all`, and incremental top-up restores were all verified byte-identical
+  against a real remote btrfs host.
+- **Transfers no longer hang on a failed or interrupted stream.** The send/receive
+  supervisor could block for up to an hour when the receiving side exited early (e.g. the
+  subvolume already exists, or the disk is full) and the sending side did not notice; it
+  now terminates cleanly and reports the failure. Fixed for local btrfs, ssh, and raw.
+- **Compressed raw backups are restorable.** Compression is recorded in the sidecar, so a
+  compressed raw backup can be decompressed on restore instead of failing.
+- A failed transfer can no longer report success, and a partial/incomplete backup is no
+  longer published as complete or left behind to be mistaken for a good backup.
+- A raw backup is verified against its recorded checksum before it is restored, so silent
+  corruption is caught rather than written back.
+- A raw backup that used an unknown compression or encryption method, or needs a tool that
+  is not installed, now fails with a clear message instead of silently producing a corrupt
+  restore or a raw traceback.
+- A damaged or unreadable raw sidecar warns and falls back to the filename instead of being
+  silently dropped, and one bad sidecar no longer hides the healthy backups beside it.
+- A `raw+ssh://` target that cannot be reached is reported as an error, not as "no backups".
+- **Every failure is delivered as a clear, plain-language message** with a suggested next
+  step, and the tool no longer prints a raw Python traceback: unexpected errors are shown as
+  one line (with `--debug` for the full trace), a same-second snapshot name collision is
+  explained instead of surfacing btrfs's misleading "Read-only file system", and command
+  failures carry the real reason.
+- A per-target lock serializes concurrent raw operations (backup / prune / backfill /
+  encrypt) on a local raw target so they cannot corrupt each other.
+
 ## [0.8.4] - 2026-07-19
 
 ### Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ where = ["src"]
 
 [project]
 name = "btrfs-backup-ng"
-version = "0.8.4"
+version = "0.8.5"
 description = "Complete btrfs backup solution with automated snapshots, incremental transfers, restore functionality, snapper integration, and systemd scheduling"
 authors = [{ name = "Michael Berry", email = "trismegustis@gmail.com" }]
 license = { file = "LICENSE" }


### PR DESCRIPTION
## 0.8.5 release prep (version bump + CHANGELOG) — for your review before the GitHub Release

Bumps `version` 0.8.4 → 0.8.5 and adds the 0.8.5 CHANGELOG entry. **This PR does not publish** — merging it just lands the version/notes; you cut the GitHub Release (→ PyPI via trusted publishing) when ready.

### What 0.8.5 contains (all already merged to master, adversarially reviewed + mutation-tested + hardware-proven)
- **Raw backups become first-class** (PRs #21–#32): authoritative always-written `.meta` sidecar, atomic `.part`+commit, sealed ciphertext checksum, the `raw list/verify/backfill-metadata/encrypt` command family, `raw+ssh://` restore, and a per-target lock.
- **Security**: openssl `none`/AEAD plaintext-masquerade hardening (GHSA-vr25-6vrh-869j / CWE-311/312 class) — validated by *meaning*, not shape, at backup and restore.
- **Reliability & error-UX hardening (T1–T9)**: transfer-success contract, partial-cleanup, restore integrity verify, tool preflight, loud failures for unknown algo/missing tool, damaged-sidecar surfacing, unreachable-raw+ssh-not-empty, no bare tracebacks / plain-language errors, and `--no-check-space`/`--force`/`--safety-margin` actually taking effect.
- **Native btrfs restore fix** (PR #42): local restore (full + incremental) was broken ("source hasn't been set", pre-existing in 0.8.4) — now works, byte-identical. Remote `ssh://` btrfs restore **fails fast with a clear message** (known limitation; remote-aware ssh restore + SSH enumeration + a test-mock-degeneracy audit are scheduled for the next release).

### Verification
Final composed 0.8.4→master adversarial review: **0 release blockers**. Full real-hardware functionality test: byte-identical round-trips on `raw://` (plaintext + openssl), `raw+ssh://` (cross-machine to a Mac), and local btrfs (full + incremental). Full suite **2345** green; ruff / ruff-format@0.15.22 / mypy clean.

### Release checklist (yours to action after merge)
- [ ] Merge this PR.
- [ ] Create GitHub Release `v0.8.5` → `release.yml` trusted-publishing to PyPI.
- [ ] Verify PyPI serves 0.8.5 (wheel + sdist) + fresh-venv `__version__` check.
- [ ] (Follow-up) GHSA note for the openssl `none`/AEAD hardening as a second instance of the plaintext-masquerade class.