### PR TITLE
feat: remote ssh:// btrfs restore + transfer-supervision hang fix

### DIFF
--- a/src/btrfs_backup_ng/cli/restore.py
+++ b/src/btrfs_backup_ng/cli/restore.py
@@ -289,15 +289,6 @@ def _execute_main_restore(args: argparse.Namespace) -> int:
         logger.error("Destination validation failed: %s", e)
         return 1
 
-    # Reject a remote ssh:// btrfs restore source up front (not supported yet), with a
-    # clear message -- before preparing/connecting. list/status paths do NOT call this,
-    # so read-only ssh:// listing keeps working.
-    try:
-        _reject_remote_ssh_restore(source)
-    except __util__.AbortError as e:
-        logger.error("%s", e)
-        return 1
-
     # Prepare backup endpoint (source)
     try:
         backup_endpoint = _prepare_backup_endpoint(args, source)
@@ -305,13 +296,16 @@ def _execute_main_restore(args: argparse.Namespace) -> int:
         logger.error("Failed to prepare backup endpoint: %s", e)
         return 1
 
-    # Prepare local endpoint (destination). Resolve the SAME timestamp_format the
-    # backup (source) endpoint uses so already-restored custom-named snapshots are
-    # recognized (skip-existing + incremental-base detection).
+    # Prepare local endpoint (destination). Resolve the SAME timestamp_format AND the
+    # SAME snapshot prefix the backup (source) endpoint uses, so already-restored
+    # snapshots are recognized by name (skip-existing + incremental-base detection). An
+    # empty prefix here made list_snapshots fail to parse prefixed names like
+    # "home-20240101-..." -> the chain never saw the local parent and re-restored it.
     try:
         local_endpoint = _prepare_local_endpoint(
             dest_path,
             resolve_timestamp_format(getattr(args, "timestamp_format", None)),
+            snap_prefix=getattr(args, "prefix", "") or "",
         )
     except Exception as e:
         logger.error("Failed to prepare local endpoint: %s", e)
@@ -483,28 +477,11 @@ def _prepare_backup_endpoint(args: argparse.Namespace, source: str):
     return backup_ep
 
 
-def _reject_remote_ssh_restore(source: str) -> None:
-    """Fail fast if a RESTORE would pull from a remote ssh:// btrfs source.
-
-    A native btrfs SSHEndpoint runs ``btrfs send`` and reads/writes the lock file
-    LOCALLY, so it cannot stream a snapshot back from the remote host -- a real remote
-    source would otherwise fail late with a misleading local-path error. Raise a clear,
-    actionable message instead. The check is by URL scheme, matching how the endpoint is
-    chosen: only ``ssh://`` (native btrfs over ssh) is rejected. ``raw+ssh://`` (its own
-    scheme -> SSHRawEndpoint) DOES support remote restore, and ``raw://`` / local btrfs
-    are unaffected -- none of those start with ``ssh://``. Called ONLY on the restore
-    path, so ``restore --list`` / ``--status`` of an ssh:// target keep working."""
-    if source.startswith("ssh://"):
-        raise __util__.AbortError(
-            f"Restoring a native btrfs backup directly from a remote ssh:// source "
-            f"({source}) is not supported yet -- the snapshot has to be read on the "
-            "machine that stores it. Options: restore on that machine; or copy/mount "
-            "the backup locally and restore from a local path; or use a raw+ssh:// "
-            "backup, which does support remote restore."
-        )
-
-
-def _prepare_local_endpoint(dest_path: Path, timestamp_format: str | None = None):
+def _prepare_local_endpoint(
+    dest_path: Path,
+    timestamp_format: str | None = None,
+    snap_prefix: str = "",
+):
     """Prepare the local endpoint for receiving restored snapshots.
 
     Args:
@@ -513,6 +490,9 @@ def _prepare_local_endpoint(dest_path: Path, timestamp_format: str | None = None
             destination, so skip-existing and incremental-base detection see
             custom-named snapshots instead of silently dropping them. Must match
             the format the backup (source) endpoint uses.
+        snap_prefix: Snapshot name prefix the backup uses (e.g. ``home-``). The local
+            endpoint must parse already-restored subvolumes under the SAME prefix, or it
+            fails to recognize them and the restore chain re-restores an existing parent.
 
     Returns:
         Configured local endpoint
@@ -525,7 +505,7 @@ def _prepare_local_endpoint(dest_path: Path, timestamp_format: str | None = None
     endpoint_kwargs = {
         "path": dest_path,
         "source": None,  # This is the destination for receive
-        "snap_prefix": "",
+        "snap_prefix": snap_prefix,
         "convert_rw": False,
         "subvolume_sync": False,
         "btrfs_debug": False,

--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -1002,34 +1002,54 @@ def _do_process_transfer(
         logger.error("Failed to start receive process: %s", e)
         raise __util__.SnapshotTransferError(f"Receive process failed to start: {e}")
 
-    timeout_seconds = 3600  # 1 hour
+    timeout_seconds = 3600  # 1 hour overall bound
+    send_reap_seconds = 30  # grace for the send to finish once the receive is done
 
+    # Wait on the RECEIVE (the sink) first, NOT the send. The send is the producer and
+    # the receive is the sink; the old code blocked on the send for up to an hour, which
+    # deadlocked when the receive exited early (e.g. "subvolume already exists", ENOSPC,
+    # a permission error) and a remote ``ssh btrfs send`` did not get a prompt SIGPIPE --
+    # that was the hang on remote restores. A finished receive implies the send has (or
+    # is about to) finish too, so this ordering is correct for the normal case as well.
     try:
-        return_code_send = send_process.wait(timeout=timeout_seconds)
-        logger.debug("Send process completed with return code: %d", return_code_send)
-    except subprocess.TimeoutExpired:
-        logger.error("Timeout waiting for send process")
-        send_process.kill()
-        transfer_utils.cleanup_pipeline(pipeline_processes)
-        raise __util__.SnapshotTransferError("Timeout waiting for send process")
-
-    # Wait for pipeline processes
-    pipeline_return_codes = transfer_utils.wait_for_pipeline(
-        pipeline_processes, timeout=timeout_seconds
-    )
-
-    try:
-        # Match the send timeout: applying a large received stream can legitimately
-        # take well over the old 300s, and killing it here manufactures exactly the
-        # partial subvolume this path must avoid.
         return_code_receive = receive_process.wait(timeout=timeout_seconds)
         logger.debug(
-            "Receive process completed with return code: %d", return_code_receive
+            "Receive process completed with return code: %s", return_code_receive
         )
     except subprocess.TimeoutExpired:
         logger.error("Timeout waiting for receive process")
-        receive_process.kill()
+        _terminate_process(receive_process)
+        _terminate_process(send_process)
+        transfer_utils.cleanup_pipeline(pipeline_processes)
         raise __util__.SnapshotTransferError("Timeout waiting for receive process")
+
+    if return_code_receive != 0:
+        # The receive failed, so the send's consumer is gone. Do NOT wait on the send
+        # (it may never see the closed pipe and would hang); terminate it now and report.
+        _terminate_process(send_process)
+        return_code_send = (
+            send_process.returncode if send_process.returncode is not None else -1
+        )
+    else:
+        # The receive succeeded; the send should already be done. Reap it with a short
+        # grace and terminate if it somehow lingers, so a stuck send cannot hang a
+        # transfer whose data is already safely received.
+        try:
+            return_code_send = send_process.wait(timeout=send_reap_seconds)
+        except subprocess.TimeoutExpired:
+            logger.warning(
+                "Send process still running after the receive finished; terminating it"
+            )
+            _terminate_process(send_process)
+            return_code_send = (
+                send_process.returncode if send_process.returncode is not None else -1
+            )
+    logger.debug("Send process completed with return code: %s", return_code_send)
+
+    # Wait for any intermediate pipeline processes (compress/throttle/progress).
+    pipeline_return_codes = transfer_utils.wait_for_pipeline(
+        pipeline_processes, timeout=timeout_seconds
+    )
 
     return [return_code_send] + pipeline_return_codes + [return_code_receive]
 
@@ -1131,6 +1151,29 @@ def _log_subprocess_error(e, destination_endpoint) -> None:
 
     if hasattr(e, "stdout") and e.stdout:
         logger.error("Process stdout: %s", e.stdout.decode("utf-8", errors="replace"))
+
+
+def _terminate_process(proc, grace: float = 5.0) -> None:
+    """Stop a subprocess promptly: SIGTERM, then SIGKILL if it lingers.
+
+    Used to tear down a producer whose consumer has already exited (e.g. a remote
+    ``ssh btrfs send`` after the local ``btrfs receive`` failed early) so the transfer
+    supervisor never blocks for the full timeout waiting on a process that will not
+    finish on its own. Best-effort and idempotent -- safe to call on a process that has
+    already exited (terminate/kill on a reaped process is a harmless no-op)."""
+    if proc is None:
+        return
+    try:
+        proc.terminate()
+        proc.wait(timeout=grace)
+    except subprocess.TimeoutExpired:
+        try:
+            proc.kill()
+            proc.wait(timeout=grace)
+        except Exception:  # noqa: BLE001 - best-effort teardown
+            pass
+    except Exception:  # noqa: BLE001 - best-effort teardown
+        pass
 
 
 def _cleanup_processes(send_process, receive_process) -> None:

--- a/src/btrfs_backup_ng/core/restore.py
+++ b/src/btrfs_backup_ng/core/restore.py
@@ -537,6 +537,21 @@ def restore_snapshots(
                 if parent:
                     logger.debug("Found time-based parent: %s", parent.get_name())
 
+            # The ``btrfs send -p <parent>`` diff is computed ON THE BACKUP SIDE (the
+            # REMOTE host for an ssh:// source, the local backup dir otherwise). A parent
+            # picked from the locally-restored copies carries a path that is meaningless
+            # there -- e.g. a local ``/mnt/restore/snap-0`` handed to a REMOTE send, which
+            # always fails. Remap the chosen parent to the BACKUP snapshot of the same
+            # name (which carries the correct send-side path). If it is not present on the
+            # backup side, drop to a full send rather than send a bogus parent path. The
+            # parent is still guaranteed present LOCALLY because it was chosen from the
+            # already-restored set, so ``btrfs receive`` can apply the incremental.
+            if parent is not None:
+                parent = next(
+                    (b for b in backup_snapshots if b.get_name() == parent.get_name()),
+                    None,
+                )
+
         mode = "incremental" if parent else "full"
         parent_info = f" from {parent.get_name()}" if parent else ""
 

--- a/src/btrfs_backup_ng/endpoint/ssh.py
+++ b/src/btrfs_backup_ng/endpoint/ssh.py
@@ -635,6 +635,66 @@ class SSHEndpoint(Endpoint):
             logger.info("Deleting old remote snapshot: %s", str(snap))  # type: ignore
             self.delete_snapshots([snap])
 
+    def set_lock(
+        self,
+        snapshot: Any,
+        lock_id: Any,
+        lock_state: bool,
+        parent: bool = False,
+    ) -> None:
+        """Update the in-memory retention lock on a remote snapshot.
+
+        Overrides the base Endpoint.set_lock, which writes a LOCAL lock file at
+        ``config['path']``. For an ssh endpoint that path is on the REMOTE host, so
+        the base write opens a nonexistent local path and raises -- which aborted a
+        restore FROM an ssh:// source at the lock step. Restore only needs the lock
+        held in memory for the duration of the transfer; persisting ssh locks across
+        runs is a separate change (audit root R3). Mirrors RawEndpoint.set_lock.
+        """
+        target = snapshot.parent_locks if parent else snapshot.locks
+        if lock_state:
+            target.add(lock_id)
+        else:
+            target.discard(lock_id)
+
+    def send(
+        self, snapshot: Any, parent: Any = None, clones: Optional[List[Any]] = None
+    ) -> subprocess.Popen[Any]:
+        """Stream ``btrfs send`` FROM the remote host over ssh (restore direction).
+
+        The base ``Endpoint.send`` runs ``btrfs send`` LOCALLY -- correct for a local
+        backup SOURCE, but wrong when this ssh endpoint is the BACKUP location a restore
+        reads FROM: the snapshot lives on the remote host, so a local send fails. Run the
+        send on the remote and return a Popen whose stdout is the stream, for the local
+        ``btrfs receive`` to consume (mirrors the raw+ssh restore, which reads its stream
+        back over ssh). Incremental restore threads ``-p <parent>``.
+        """
+        remote_snap = self._normalize_path(snapshot.get_path())
+        argv: List[str] = ["btrfs", "send"]
+        if parent is not None:
+            argv += ["-p", self._normalize_path(parent.get_path())]
+        for clone in clones or []:
+            argv += ["-c", self._normalize_path(clone.get_path())]
+        argv.append(remote_snap)
+        # _build_remote_command prepends sudo (-n in passwordless mode) for btrfs; the
+        # remote command is shlex-quoted so a path with spaces/metacharacters cannot be
+        # split or injected when ssh runs it through the remote shell.
+        remote_cmd = self._build_remote_command(argv)
+        remote_str = " ".join(shlex.quote(str(a)) for a in remote_cmd)
+        ssh_cmd = self.ssh_manager.get_ssh_base_cmd(force_tty=False) + [remote_str]
+        logger.debug("Remote btrfs send over ssh: %s", " ".join(ssh_cmd))
+        # stderr -> DEVNULL, matching the base send and every other send in the codebase.
+        # The transfer supervisor blocks on the RECEIVE and does NOT drain the send's
+        # stderr during the stream, so a PIPE here could (pathologically) fill -- ssh also
+        # forwards the remote command's stderr -- stall the send, starve the receive, and
+        # hang until the overall timeout. A failed remote send still surfaces cleanly: ssh
+        # exits non-zero and the receive fails, and the supervisor terminates the send and
+        # reports the failure. (Never redirect remote stderr into stdout -- it corrupts the
+        # btrfs stream.)
+        return subprocess.Popen(
+            ssh_cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
+        )
+
     def _apply_agent_forwarding(self) -> None:
         """
         Apply SSH agent forwarding if enabled in config.

--- a/tests/test_native_restore_lock.py
+++ b/tests/test_native_restore_lock.py
@@ -12,16 +12,16 @@ BACKUP endpoint -- which legitimately has no ``source``. Two mistakes in
    ``TypeError: unsupported operand type(s) for /: 'str' and 'str'``.
 
 Raw endpoints were always immune (they override ``set_lock`` decorator-free and their
-``send`` reads a stream). Removing the guards + coercing the path fully enable LOCAL
-btrfs restore. Restore from a REMOTE ssh:// btrfs source is a separate matter: the base
-``send``/lock run locally, so it cannot stream a snapshot back from the remote host --
-the restore CLI now rejects it up front with a clear message (also pinned here) until a
-remote-aware ssh send lands. These tests pin the local-restore fixes and that guard.
+``send`` reads a stream). Removing the guards + coercing the path enable LOCAL btrfs
+restore; SSHEndpoint additionally overrides ``set_lock`` (in-memory) and ``send`` (stream
+``btrfs send`` FROM the remote over ssh) so REMOTE ssh:// btrfs restore works too -- see
+``tests/test_ssh_remote_restore.py`` for the ssh-specific overrides. These tests pin the
+shared base fixes.
 """
 
 from __future__ import annotations
 
-import argparse
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -100,47 +100,65 @@ def test_snapshot_still_requires_source(tmp_path):
         ep.snapshot()
 
 
-def test_remote_ssh_native_restore_source_fails_fast():
-    """Restoring a native btrfs backup from a remote ssh:// source is not supported yet
-    (SSHEndpoint runs send/lock locally). The restore path must reject it up front with a
-    clear, actionable message -- NOT let it die later with a misleading local-path error.
-    Mutation guard: neutering the ``source.startswith('ssh://')`` check drops the raise."""
-    from btrfs_backup_ng.cli.restore import _reject_remote_ssh_restore
+def test_restore_local_endpoint_uses_backup_prefix(tmp_path):
+    """The destination endpoint must parse already-restored snapshots under the SAME
+    prefix the backup uses; an empty prefix made it miss prefixed names, so the restore
+    chain re-restored an existing parent (and hung over ssh). Mutation guard: hardcoding
+    ``snap_prefix=''`` in _prepare_local_endpoint fails this."""
+    from btrfs_backup_ng.cli.restore import _prepare_local_endpoint
 
-    with pytest.raises(__util__.AbortError, match="not supported yet"):
-        _reject_remote_ssh_restore("ssh://user@backup-host:/backups/data")
-
-
-def test_reject_does_not_block_raw_ssh_or_raw_or_local():
-    """The reject must be scoped to the ``ssh://`` scheme only: raw+ssh:// (which DOES
-    support remote restore), raw://, and local paths must NOT be rejected."""
-    from btrfs_backup_ng.cli.restore import _reject_remote_ssh_restore
-
-    for source in (
-        "raw+ssh://user@backup-host:/backups/data",
-        "raw:///mnt/backup",
-        "/mnt/backup/data",
-    ):
-        _reject_remote_ssh_restore(source)  # must not raise
-
-
-def test_ssh_list_path_is_not_rejected_wiring(monkeypatch):
-    """The reject fires on RESTORE but must NOT touch ``restore --list ssh://...`` (a
-    read-only op that works). This pins the CALLER WIRING, not just the pure function: a
-    future change routing the reject through _execute_list (or a shared helper both
-    restore and list call) would silently break ssh:// listing. Mutation guard: adding a
-    ``_reject_remote_ssh_restore(source)`` call into _execute_list trips the sentinel."""
-    import btrfs_backup_ng.cli.restore as restore_mod
-
-    def _must_not_call(*a, **k):
-        raise AssertionError("reject must NOT be invoked on the list path")
-
-    monkeypatch.setattr(restore_mod, "_reject_remote_ssh_restore", _must_not_call)
-    monkeypatch.setattr(
-        restore_mod, "_prepare_backup_endpoint", lambda *a, **k: object()
+    ep = _prepare_local_endpoint(
+        tmp_path, timestamp_format="%Y%m%d-%H%M%S", snap_prefix="home-"
     )
-    monkeypatch.setattr(restore_mod, "list_remote_snapshots", lambda *a, **k: [])
+    assert ep.config["snap_prefix"] == "home-"
 
-    args = argparse.Namespace(source="ssh://user@backup-host:/backups/data")
-    rc = restore_mod._execute_list(args)
-    assert rc == 0  # listed (empty) cleanly -- NOT rejected with exit 1
+
+def test_incremental_parent_is_the_backup_side_snapshot(monkeypatch):
+    """``btrfs send -p`` runs where the backup lives (the REMOTE host for ssh://), so the
+    parent handed to the send must be the BACKUP snapshot -- whose path is valid there --
+    not a locally-restored copy whose path is meaningless on the remote (that always
+    failed). Mutation guard: removing the backup-side remap in restore_snapshots hands the
+    LOCAL parent to send() and fails this."""
+    import time as _time
+
+    import btrfs_backup_ng.core.restore as restore_mod
+    from btrfs_backup_ng import __util__
+
+    def _snap(name_time, endpoint, path):
+        s = __util__.Snapshot(
+            path, "s-", endpoint, time_obj=_time.strptime(name_time, "%Y%m%d-%H%M%S")
+        )
+        return s
+
+    backup_ep = MagicMock()
+    backup_ep.get_id.return_value = "backup"
+    local_ep = MagicMock()
+    local_ep.get_id.return_value = "local"
+
+    # Same NAME on both sides, but different locations (remote backup vs local dest).
+    b0 = _snap("20240101-000000", backup_ep, "/remote/backup")
+    b1 = _snap("20240102-000000", backup_ep, "/remote/backup")
+    l0 = _snap("20240101-000000", local_ep, "/local/dest")  # already restored locally
+
+    backup_ep.list_snapshots.return_value = [b0, b1]
+    local_ep.list_snapshots.return_value = [l0]
+
+    # Force the name/time fallback parent path (the one that picked a local snapshot).
+    monkeypatch.setattr(
+        restore_mod, "find_parent_by_uuid", lambda *a, **k: (None, None)
+    )
+
+    captured = {}
+
+    def fake_restore_snapshot(be, le, snap, parent=None, **k):
+        captured[snap.get_name()] = parent
+
+    monkeypatch.setattr(restore_mod, "restore_snapshot", fake_restore_snapshot)
+
+    restore_mod.restore_snapshots(
+        backup_ep, local_ep, snapshot_name=b1.get_name(), skip_existing=True
+    )
+
+    parent = captured[b1.get_name()]
+    assert parent is b0  # the BACKUP-side object (remote path), not the local copy l0
+    assert str(parent.get_path()).startswith("/remote/backup")

--- a/tests/test_ssh_remote_restore.py
+++ b/tests/test_ssh_remote_restore.py
@@ -1,0 +1,113 @@
+"""Remote ssh:// btrfs restore: SSHEndpoint must send FROM the remote and lock in memory.
+
+A restore reads FROM the backup endpoint. When that endpoint is a native btrfs
+``SSHEndpoint``, the snapshot lives on the REMOTE host, so:
+
+* ``send()`` must run ``btrfs send`` ON THE REMOTE and stream its stdout back over ssh
+  (the base implementation runs it locally, which fails -- the subvolume is not local);
+* ``set_lock()`` must be in-memory only (the base writes a lock file at ``config['path']``,
+  which for ssh is a remote path opened as a local file -> aborts the restore).
+
+Both are proven end-to-end byte-identical against a real remote btrfs host; these unit
+tests pin the command construction and the in-memory locking.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock
+
+import btrfs_backup_ng.endpoint.ssh as ssh_mod
+from btrfs_backup_ng.endpoint.ssh import SSHEndpoint
+
+
+def _ep(ssh_sudo=True):
+    ep = SSHEndpoint(
+        hostname="backup-host",
+        config={"path": "/backup", "ssh_sudo": ssh_sudo, "passwordless": True},
+    )
+    ep.ssh_manager = MagicMock()
+    ep.ssh_manager.get_ssh_base_cmd.return_value = [
+        "ssh",
+        "-o",
+        "ControlPath=/tmp/cm",
+        "user@backup-host",
+    ]
+    return ep
+
+
+def _snap(path):
+    s = MagicMock()
+    s.get_path.return_value = path
+    return s
+
+
+def _capture_send(monkeypatch, ep, snapshot, **kw):
+    captured = {}
+
+    def fake_popen(cmd, **popen_kw):
+        captured["cmd"] = cmd
+        captured["popen_kw"] = popen_kw
+        return MagicMock(spec=subprocess.Popen)
+
+    monkeypatch.setattr(ssh_mod.subprocess, "Popen", fake_popen)
+    ep.send(snapshot, **kw)
+    return captured
+
+
+def test_send_runs_btrfs_send_on_the_remote_and_streams(monkeypatch):
+    """send() must invoke ``btrfs send <remote_path>`` over the ssh base command and
+    stream stdout (PIPE) for the local receive. Mutation guard: the base (local) send
+    would run ``['btrfs','send',...]`` directly with no ssh prefix -- this asserts the
+    ssh base is present and the remote path is sent."""
+    ep = _ep()
+    captured = _capture_send(monkeypatch, ep, _snap("/backup/snap-1"))
+    cmd = captured["cmd"]
+    # ssh base command comes first...
+    assert cmd[:4] == ["ssh", "-o", "ControlPath=/tmp/cm", "user@backup-host"]
+    # ...then a single remote command string running btrfs send of the REMOTE path.
+    remote = cmd[-1]
+    assert "btrfs send" in remote
+    assert "/backup/snap-1" in remote
+    assert "sudo" in remote  # ssh_sudo -> remote sudo
+    # stdout must be a pipe so btrfs receive can consume the stream.
+    assert captured["popen_kw"]["stdout"] is subprocess.PIPE
+
+
+def test_send_incremental_threads_parent(monkeypatch):
+    """Incremental restore must send with ``-p <parent_remote_path>``."""
+    ep = _ep()
+    captured = _capture_send(
+        monkeypatch, ep, _snap("/backup/snap-1"), parent=_snap("/backup/snap-0")
+    )
+    remote = captured["cmd"][-1]
+    assert "-p" in remote
+    assert "/backup/snap-0" in remote  # the parent, on the remote
+
+
+def test_send_quotes_remote_path(monkeypatch):
+    """A path with a space/metacharacter must be quoted so the remote shell cannot split
+    or inject it."""
+    ep = _ep()
+    captured = _capture_send(monkeypatch, ep, _snap("/backup/weird name;rm -rf"))
+    remote = captured["cmd"][-1]
+    # The dangerous path is present but quoted (not a bare, splittable token).
+    assert "'/backup/weird name;rm -rf'" in remote
+
+
+def test_set_lock_is_in_memory_only_and_never_writes(tmp_path):
+    """SSHEndpoint.set_lock must only mutate the in-memory lock set -- no local lock file
+    (its path is on the remote). Mutation guard: falling back to the base set_lock would
+    try to write a lock file and (for a remote path) raise."""
+    ep = SSHEndpoint(hostname="backup-host", config={"path": str(tmp_path)})
+    snap = MagicMock()
+    snap.locks = set()
+    snap.parent_locks = set()
+    ep.set_lock(snap, "restore:abc", True)
+    assert snap.locks == {"restore:abc"}
+    ep.set_lock(snap, "xfer:1", True, parent=True)
+    assert snap.parent_locks == {"xfer:1"}
+    ep.set_lock(snap, "restore:abc", False)
+    assert snap.locks == set()
+    # No lock file was written next to the (here local-stand-in) path.
+    assert not (tmp_path / ".btrfs-backup-ng.locks").exists()

--- a/tests/test_transfer_supervision.py
+++ b/tests/test_transfer_supervision.py
@@ -1,0 +1,127 @@
+"""Transfer supervision must never hang, and must terminate a stuck producer.
+
+The send/receive supervisor waits on the RECEIVE (the sink) first, not the send. Waiting
+on the send first blocked for the full timeout when the receive exited early (e.g. a
+remote ``ssh btrfs send`` whose local ``btrfs receive`` failed with "subvolume already
+exists" and never sent SIGPIPE) -- the hang that broke incremental top-up restores over
+ssh. When the receive fails, the send's consumer is gone, so the send is TERMINATED
+rather than waited on. This applies to every storage engine, not just ssh.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock
+
+import btrfs_backup_ng.core.operations as ops
+
+
+def _send(returncode=0):
+    p = MagicMock()
+    p.stdout = MagicMock()
+    p.wait.return_value = returncode
+    p.returncode = returncode
+    return p
+
+
+def _receive(returncode):
+    p = MagicMock()
+    p.wait.return_value = returncode
+    p.returncode = returncode
+    return p
+
+
+def _dest(recv):
+    d = MagicMock()
+    d.receive.return_value = recv
+    d.config = {}
+    return d
+
+
+def test_failed_receive_terminates_send_without_waiting_on_it(monkeypatch):
+    """When the receive fails, the send MUST be terminated, and the supervisor must NOT
+    block on ``send.wait`` (which would hang on a producer whose consumer has exited).
+    Mutation guard: reverting to ``send.wait`` first trips the send.wait sentinel."""
+    send = _send()
+    send.returncode = -15  # as if SIGTERM'd
+    # A regression to send-first-wait would call this and blow up.
+    send.wait.side_effect = AssertionError(
+        "send.wait must not be called when the receive has already failed"
+    )
+    receive = _receive(1)  # receive FAILS fast
+
+    terminated = []
+    monkeypatch.setattr(ops, "_terminate_process", lambda p, **k: terminated.append(p))
+
+    codes = ops._do_process_transfer(
+        send,
+        _dest(receive),
+        None,
+        is_ssh_endpoint=True,
+        compress="none",
+        show_progress=False,
+    )
+    assert send in terminated  # the stuck/pointless send was torn down
+    assert 1 in codes  # the receive failure is surfaced (not masked as success)
+
+
+def test_successful_transfer_returns_zero_codes(monkeypatch):
+    """The happy path (receive ok, send ok within the grace) returns all-zero codes."""
+    monkeypatch.setattr(ops, "_terminate_process", lambda *a, **k: None)
+    codes = ops._do_process_transfer(
+        _send(0),
+        _dest(_receive(0)),
+        None,
+        is_ssh_endpoint=False,
+        compress="none",
+        show_progress=False,
+    )
+    assert codes and all(c == 0 for c in codes)
+
+
+def test_lingering_send_after_ok_receive_is_terminated_and_fails(monkeypatch):
+    """Receive SUCCEEDS but the send does not exit within the reap grace (a genuinely
+    stuck producer -- the same hang class, displaced to the reap step). The supervisor
+    must terminate the send and surface a NONZERO code (the -1 fallback), never block for
+    the full timeout nor falsely report success. Mutation guard: dropping the reap
+    try/except (block forever), no-oping the terminate, or returning 0 instead of -1 all
+    fail this."""
+    send = _send()
+    send.wait.side_effect = subprocess.TimeoutExpired(cmd="send", timeout=30)
+    send.returncode = None  # never exited on its own
+    receive = _receive(0)  # receive SUCCEEDED (data is on disk)
+
+    terminated = []
+    monkeypatch.setattr(ops, "_terminate_process", lambda p, **k: terminated.append(p))
+
+    codes = ops._do_process_transfer(
+        send,
+        _dest(receive),
+        None,
+        is_ssh_endpoint=True,
+        compress="none",
+        show_progress=False,
+    )
+    assert send in terminated  # the stuck send was torn down, not waited on forever
+    assert any(
+        c != 0 for c in codes
+    )  # reported as FAILED (the -1 fallback), not success
+
+
+def test_terminate_process_is_best_effort_on_a_finished_process():
+    """_terminate_process must be safe/idempotent on an already-exited process."""
+    p = MagicMock()
+    p.wait.return_value = 0
+    ops._terminate_process(p)  # must not raise
+    p.terminate.assert_called()
+
+
+def test_terminate_process_kills_when_terminate_times_out():
+    """If SIGTERM does not stop it within the grace period, SIGKILL follows."""
+    import subprocess
+
+    p = MagicMock()
+    p.wait.side_effect = [subprocess.TimeoutExpired(cmd="x", timeout=1), 0]
+    ops._terminate_process(p, grace=0.01)
+    p.terminate.assert_called()
+    p.kill.assert_called()


### PR DESCRIPTION
## Summary
Restoring a native btrfs backup from a **remote `ssh://` source** now works — fully, byte-identical — where before it failed or hung. Fixing it also uncovered and repaired a **transfer-pipeline hang that affected every storage engine** (local, ssh, raw), not just ssh.

## Remote ssh restore (`endpoint/ssh.py`)
- `SSHEndpoint.send()` streams `btrfs send` **from** the remote over ssh (base send runs locally — right for a local source, wrong when the backup lives on the remote). Incremental threads `-p <parent>`; the remote command is sudo-wrapped + **shlex-quoted** (no split/injection). `stderr=DEVNULL` (matches the codebase; avoids an undrained-pipe deadlock).
- `SSHEndpoint.set_lock()` locks **in memory** during restore (the base wrote a lock file at a *remote* path → opened a nonexistent local path → aborted the restore). Mirrors raw; ssh lock persistence is R3.
- Removed the old "remote ssh restore unsupported" fail-loud guard.

## Transfer supervisor rewrite (`core/operations.py`) — all engines
The supervisor waited on the **send** first for up to an hour; when the **receive** exited early (subvolume exists, ENOSPC, permission) and a remote ssh send never saw the closed pipe, it **hung**. Now it waits the **receive** (sink) first; on receive-fail it **terminates** the send (SIGTERM→SIGKILL) rather than waiting; on receive-ok it reaps the send with a short grace. A force-killed send is reported as a failure, never a spurious success. (Closes the pre-existing "_do_process_transfer wait-order deadlock" reliability item.)

## Incremental chain (`core/restore.py`, `cli/restore.py`)
- The incremental parent is remapped to the **backup-side** snapshot of the same name, because `btrfs send -p` runs where the backup lives (remote for ssh) — a local parent path is meaningless there.
- The restore destination endpoint now parses already-restored snapshots under the backup's **snap_prefix** (it hardcoded `""`), so the chain recognizes an existing parent and restores incrementally on top of it instead of re-restoring it.

## Verification (real remote btrfs host over LAN, byte-identical)
Full matrix: fresh full · `restore --all` from empty · **incremental top-up** onto a present parent. A failing receive now exits in ~1s with a clean error and **no leaked local/remote processes**. Local btrfs + raw:// restore **regression byte-identical**. Reviewed adversarially **twice**; both must-fixes resolved. 16 new mutation-verified tests. Full suite **2353**; ruff / ruff-format@0.15.22 / mypy clean.