### PR TITLE
fix: Persist retention locks across runs (R3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### Snapshots you still need are no longer deleted after an interrupted backup
+
+When a backup transfer fails or is interrupted partway, btrfs-backup-ng marks the source
+snapshot (and the parent it builds on) as "still needed" so cleanup won't remove it before
+the backup can be retried. That mark was being written to disk but **never read back on the
+next run**, so the next cleanup saw the snapshot as unneeded and could delete it — breaking
+the incremental chain the unfinished backup depended on. The mark is now read back and
+honored across runs, so a snapshot a pending or failed transfer needs survives cleanup
+until the transfer actually completes.
+
+Related hardening to the same lock file:
+
+- **Cleanup now refuses to delete anything if the lock file is unreadable or corrupt**,
+  with a clear message, rather than guessing everything is unneeded and pruning a snapshot
+  it can no longer tell is protected.
+- The lock file is now written **atomically and crash-safely** (temporary file, flush to
+  disk, atomic rename, directory flush), so an interrupted write can't leave a half-written
+  file that later reads as "nothing is protected."
+- Updates to the lock file are **serialized**, so backing up to several targets at once (or
+  two runs overlapping) can no longer clobber each other's marks.
+
 ## [0.8.5] - 2026-07-22
 
 This release makes **raw backups first-class** — a raw backup now carries everything

--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -1234,9 +1234,18 @@ def sync_snapshots(
 
     destination_snapshots = destination_endpoint.list_snapshots()
 
-    # Clear locks for this destination
+    # Reconcile this destination's locks against reality (R3). A lock pins a source
+    # snapshot so retention cannot prune it while a transfer to this destination still
+    # needs it. Clear the lock only for snapshots CONFIRMED present on the destination --
+    # the transfer succeeded, so the lock has done its job. KEEP the lock for a snapshot
+    # not yet on the destination: a prior transfer failed or is pending and still depends
+    # on it. This is presence-based, not time-based, so a long outage can never cause a
+    # needed snapshot to be pruned.
     destination_id = destination_endpoint.get_id()
+    destination_names = {s.get_name() for s in destination_snapshots}
     for snap in source_snapshots:
+        if snap.get_name() not in destination_names:
+            continue  # not yet on the destination -> keep any lock
         if destination_id in snap.locks:
             source_endpoint.set_lock(snap, destination_id, False)
         if destination_id in snap.parent_locks:

--- a/src/btrfs_backup_ng/endpoint/common.py
+++ b/src/btrfs_backup_ng/endpoint/common.py
@@ -67,6 +67,9 @@ class Endpoint:
 
         self.btrfs_flags = ["-vv"] if self.config["btrfs_debug"] else []
         self.__cached_snapshots: List[Any] | None = None
+        # Set True when the lock file could not be read (corrupt/permission); retention
+        # then refuses to delete so a still-needed locked snapshot is never pruned.
+        self._locks_read_failed = False
 
         for key, value in kwargs.items():
             self.config[key] = value
@@ -343,12 +346,49 @@ class Endpoint:
                     time_format=matched_fmt,
                 )
                 snapshots.append(snapshot)
+        # R3: load persisted retention locks back onto the snapshots. set_lock writes them
+        # to the lock file, but nothing read them back, so a snapshot kept locked after a
+        # failed transfer looked unlocked on the next run and retention could prune a
+        # snapshot a failed/pending transfer still needs.
+        self._load_locks_into(snapshots)
         snapshots.sort()
         self.__cached_snapshots = snapshots
         logger.debug(
             "Populated snapshot cache of %r with %d items.", self, len(snapshots)
         )
         return list(snapshots)
+
+    def _load_locks_into(self, snapshots: List[Any]) -> None:
+        """Populate each snapshot's in-memory lock sets from the persisted lock file.
+
+        Locks are keyed by ``get_name()`` (see ``set_lock``). A damaged or unreadable
+        lock file must never abort the whole listing (that would also stop new snapshots),
+        so it lists as unlocked but sets ``_locks_read_failed`` -- retention then refuses
+        to delete anything (fail-safe) rather than silently pruning a still-needed
+        snapshot it can no longer see is locked."""
+        try:
+            lock_dict = self._read_locks()
+            self._locks_read_failed = False
+        except Exception as e:  # noqa: BLE001 - never abort a listing on a bad lock file
+            # A corrupt/unreadable lock file must NOT silently become "no locks": that
+            # would let retention prune a snapshot a pending transfer still needs. Keep
+            # listing (so backups continue) but flag the failure so retention refuses to
+            # delete anything until an operator repairs or removes the lock file.
+            self._locks_read_failed = True
+            logger.error(
+                "Lock file %s is unreadable/corrupt (%s); snapshots will list as "
+                "unlocked and retention will REFUSE to delete until it is repaired or "
+                "removed.",
+                self._get_lock_file_path(),
+                e,
+            )
+            return
+        for snap in snapshots:
+            entry = lock_dict.get(snap.get_name())
+            if not entry:
+                continue
+            snap.locks = set(entry.get("locks", []))
+            snap.parent_locks = set(entry.get("parent_locks", []))
 
     def set_lock(
         self, snapshot: Any, lock_id: Any, lock_state: bool, parent: bool = False
@@ -368,16 +408,29 @@ class Endpoint:
             (snapshot.parent_locks if parent else snapshot.locks).add(lock_id)
         else:
             (snapshot.parent_locks if parent else snapshot.locks).discard(lock_id)
-        lock_dict = {}
-        for _snapshot in self.list_snapshots():
-            snap_entry = {}
-            if _snapshot.locks:
-                snap_entry["locks"] = list(_snapshot.locks)
-            if _snapshot.parent_locks:
-                snap_entry["parent_locks"] = list(_snapshot.parent_locks)
-            if snap_entry:
-                lock_dict[_snapshot.get_name()] = snap_entry
-        self._write_locks(lock_dict)
+        # Read-modify-write against the AUTHORITATIVE on-disk lock file, serialized by a
+        # FileLock so concurrent parallel-target transfers (multiple threads sharing this
+        # source endpoint) and concurrent processes cannot lose each other's updates. The
+        # previous rebuild-from-cache dropped a lock written after this run's cache was
+        # populated (last-writer-wins) and could lose the mutation entirely on a cache
+        # miss. We only touch THIS snapshot's entry; every other snapshot's locks come
+        # straight from disk, so a concurrent writer's locks survive.
+        guard = str(self._get_lock_file_path()) + ".guard"
+        with FileLock(guard):
+            # _read_locks raises on a corrupt file: abort loudly rather than overwrite
+            # (which would silently discard locks we could not read).
+            lock_dict = self._read_locks()
+            name = snapshot.get_name()
+            entry: Dict[str, Any] = {}
+            if snapshot.locks:
+                entry["locks"] = list(snapshot.locks)
+            if snapshot.parent_locks:
+                entry["parent_locks"] = list(snapshot.parent_locks)
+            if entry:
+                lock_dict[name] = entry
+            else:
+                lock_dict.pop(name, None)
+            self._write_locks(lock_dict)
         logger.debug(
             "Lock state for %s and lock_id %s changed to %s (parent = %s)",
             snapshot,
@@ -403,6 +456,14 @@ class Endpoint:
 
     def delete_snapshots(self, snapshots: List[Any], **kwargs: Any) -> None:
         """Delete the given snapshots (subvolumes)."""
+        if getattr(self, "_locks_read_failed", False):
+            logger.error(
+                "Refusing to delete snapshots: the lock file is unreadable/corrupt, so "
+                "locked (still-needed) snapshots cannot be identified. Repair or remove "
+                "%s and retry.",
+                self._get_lock_file_path(),
+            )
+            return
         for snapshot in snapshots:
             if snapshot.locks or snapshot.parent_locks:
                 logger.info("Skipping locked snapshot: %s", snapshot)
@@ -439,6 +500,14 @@ class Endpoint:
         Delete old snapshots, keeping only the most recent `keep` unlocked snapshots.
         """
         snapshots = self.list_snapshots()
+        if getattr(self, "_locks_read_failed", False):
+            logger.error(
+                "Refusing to delete old snapshots: the lock file is unreadable/corrupt, "
+                "so locked (still-needed) snapshots cannot be identified. Repair or "
+                "remove %s and retry.",
+                self._get_lock_file_path(),
+            )
+            return
         unlocked = [s for s in snapshots if not s.locks and not s.parent_locks]
         if keep <= 0 or len(unlocked) <= keep:
             logger.debug(
@@ -832,10 +901,39 @@ class Endpoint:
 
     def _write_locks(self, lock_dict: Dict[str, Any]) -> None:
         path = self._get_lock_file_path()
+        data = __util__.write_locks(lock_dict)
+        tmp = path.with_name(path.name + ".tmp")
         try:
             logger.debug("Writing lock file: %s", path)
-            with open(path, "w", encoding="utf-8") as f:
-                f.write(__util__.write_locks(lock_dict))
+            # Atomic: write a temp file, fsync it, then os.replace over the target, so a
+            # crash mid-write can never leave a half-written / corrupt lock file (which
+            # would then be misread as "no locks" and let retention prune a locked
+            # snapshot). O_NOFOLLOW|O_EXCL refuse a planted symlink or a stale temp at what
+            # is often a root-owned path; a leftover temp from a prior crash is cleared
+            # first.
+            with contextlib.suppress(OSError):
+                os.unlink(tmp)
+            fd = os.open(
+                str(tmp),
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                0o600,
+            )
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(data)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(str(tmp), str(path))
+            # fsync the parent directory so the rename itself is durable: the content
+            # fsync above does not guarantee the new directory entry survives a crash, and
+            # a lost rename would silently drop the locks R3 exists to persist.
+            with contextlib.suppress(OSError):
+                dfd = os.open(str(path.parent), os.O_RDONLY)
+                try:
+                    os.fsync(dfd)
+                finally:
+                    os.close(dfd)
         except OSError as e:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp)
             logger.error("Error on writing lock file %s: %s", path, e)
             raise __util__.AbortError

--- a/tests/test_r3_lock_persistence.py
+++ b/tests/test_r3_lock_persistence.py
@@ -1,0 +1,361 @@
+"""R3: retention locks must persist across runs (source-side lock persistence).
+
+A transfer locks the source snapshot it needs (and its incremental parent) by the
+destination's id, so retention cannot prune a snapshot a failed or pending transfer still
+depends on. ``set_lock`` wrote those locks to ``<path>/.btrfs-backup-ng.locks`` but nothing
+ever read them back onto ``snapshot.locks``. So on the *next* run every snapshot looked
+unlocked and ``delete_old_snapshots`` / ``delete_snapshots`` -- whose lock-skipping guards
+were correct but inert -- could delete a snapshot the next incremental send required.
+
+R3 has three parts, each pinned below:
+
+1. Read-back: ``Endpoint.list_snapshots`` loads persisted locks onto the snapshots it
+   returns (``_load_locks_into``), so the retention guards actually see the locks.
+2. Presence-based reconcile: ``sync_snapshots`` clears a destination's lock only for a
+   source snapshot CONFIRMED present on that destination; a snapshot not yet on the
+   destination keeps its lock (a prior transfer failed / is pending). No time-boxing, so a
+   long outage can never drop a still-needed lock.
+3. Atomic write: ``_write_locks`` writes a temp file, fsyncs, and ``os.replace``s it over
+   the target, so a crash mid-write cannot leave a half-written lock file (which would be
+   misread as "no locks"). O_NOFOLLOW|O_EXCL refuse a planted symlink at the temp path.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+import btrfs_backup_ng.core.operations as ops
+from btrfs_backup_ng import __util__
+from btrfs_backup_ng.endpoint.local import LocalEndpoint
+
+
+def _local(path, source="/src"):
+    path.mkdir(parents=True, exist_ok=True)
+    return LocalEndpoint(
+        config={
+            "path": path,
+            "source": source,
+            "snapshot_folder": ".snapshots",
+            "snap_prefix": "home-",
+        }
+    )
+
+
+def _snap_named(ep, path, stamp):
+    """A Snapshot whose name is ``home-<stamp>`` (stamp = ``%Y%m%d-%H%M%S``)."""
+    return __util__.Snapshot(
+        path,
+        "home-",
+        ep,
+        time_obj=time.strptime(stamp, "%Y%m%d-%H%M%S"),
+        time_format="%Y%m%d-%H%M%S",
+    )
+
+
+def _fake_snap(name, locks=None, parent_locks=None):
+    s = MagicMock()
+    s.locks = set(locks or ())
+    s.parent_locks = set(parent_locks or ())
+    s.get_name.return_value = name
+    return s
+
+
+def _endpoints(source_snaps, dest_snaps=()):
+    src = MagicMock()
+    src.list_snapshots.return_value = list(source_snaps)
+    src.get_id.return_value = "dest-1"
+    dst = MagicMock()
+    dst.get_id.return_value = "dest-1"
+    dst.list_snapshots.return_value = list(dest_snaps)
+    return src, dst
+
+
+# --------------------------------------------------------------------------- #
+# 1. Read-back
+# --------------------------------------------------------------------------- #
+def test_load_locks_into_maps_persisted_locks(tmp_path):
+    """``_load_locks_into`` copies the on-disk lock entry onto the matching snapshot by
+    name; snapshots with no entry stay unlocked. Mutation guard: deleting the
+    ``snap.locks = ...`` / ``snap.parent_locks = ...`` assignments fails this."""
+    ep = _local(tmp_path)
+    a = _snap_named(ep, tmp_path, "20240101-000000")
+    b = _snap_named(ep, tmp_path, "20240102-000000")
+    ep._write_locks({a.get_name(): {"locks": ["dx"], "parent_locks": ["dy"]}})
+
+    ep._load_locks_into([a, b])
+
+    assert a.locks == {"dx"}
+    assert a.parent_locks == {"dy"}
+    assert b.locks == set()
+    assert b.parent_locks == set()
+
+
+def test_list_snapshots_loads_persisted_locks(tmp_path):
+    """``list_snapshots`` wires the read-back in, so callers (retention) see the locks.
+    Mutation guard: removing the ``_load_locks_into(snapshots)`` call in list_snapshots
+    makes the loaded snapshot come back unlocked and fails this."""
+    ep = _local(tmp_path)
+    (tmp_path / "home-20240101-000000").mkdir()
+    (tmp_path / "home-20240102-000000").mkdir()
+    ep._write_locks({"home-20240101-000000": {"locks": ["dest-1"]}})
+
+    listed = {s.get_name(): s for s in ep.list_snapshots(flush_cache=True)}
+
+    assert listed["home-20240101-000000"].locks == {"dest-1"}
+    assert listed["home-20240102-000000"].locks == set()
+
+
+def test_lock_persists_across_endpoint_instances(tmp_path):
+    """The R3 core: a lock set in one run is visible in the next (a fresh endpoint =
+    a new process). Mutation guard: no read-back -> the second instance sees it
+    unlocked."""
+    ep1 = _local(tmp_path)
+    (tmp_path / "home-20240101-000000").mkdir()
+    s = {x.get_name(): x for x in ep1.list_snapshots()}["home-20240101-000000"]
+    ep1.set_lock(s, "dest-1", True)
+
+    ep2 = _local(tmp_path)  # simulate a new run
+    s2 = {x.get_name(): x for x in ep2.list_snapshots()}["home-20240101-000000"]
+    assert "dest-1" in s2.locks
+
+
+def test_corrupt_lock_file_treated_as_unlocked_not_abort(tmp_path):
+    """A damaged lock file must degrade to "no locks" (warn) rather than abort the whole
+    listing. Mutation guard: dropping the try/except in _load_locks_into lets
+    _read_locks' AbortError propagate and fails this (raises instead of returning)."""
+    ep = _local(tmp_path)
+    (tmp_path / "home-20240101-000000").mkdir()
+    (tmp_path / ep.config["lock_file_name"]).write_text("{ not valid json")
+
+    snaps = ep.list_snapshots(flush_cache=True)
+
+    assert len(snaps) == 1
+    assert snaps[0].locks == set()
+
+
+# --------------------------------------------------------------------------- #
+# 2. Presence-based reconcile (in sync_snapshots)
+# --------------------------------------------------------------------------- #
+def test_reconcile_clears_lock_when_present_on_destination(monkeypatch):
+    """A snapshot confirmed present on the destination has done its job -> clear the
+    lock. Mutation guard: making the reconcile a no-op (never clear) fails this."""
+    monkeypatch.setattr(
+        "btrfs_backup_ng.core.planning.plan_transfers", lambda *a, **k: []
+    )
+    snap = _fake_snap("snap-1", locks=["dest-1"], parent_locks=["dest-1"])
+    present = _fake_snap("snap-1")  # same NAME on the destination
+    src, dst = _endpoints([snap], dest_snaps=[present])
+
+    ops.sync_snapshots(src, dst)
+
+    src.set_lock.assert_any_call(snap, "dest-1", False)
+    src.set_lock.assert_any_call(snap, "dest-1", False, parent=True)
+
+
+def test_reconcile_keeps_lock_when_absent_from_destination(monkeypatch):
+    """A snapshot NOT yet on the destination (a failed / pending transfer) keeps its
+    lock across runs, so retention cannot prune it. Mutation guard: reverting to the
+    unconditional blanket-clear (no presence check) clears this lock and fails the
+    test."""
+    monkeypatch.setattr(
+        "btrfs_backup_ng.core.planning.plan_transfers", lambda *a, **k: []
+    )
+    snap = _fake_snap("snap-1", locks=["dest-1"])
+    other = _fake_snap("snap-2")  # destination has a DIFFERENT snapshot
+    src, dst = _endpoints([snap], dest_snaps=[other])
+
+    ops.sync_snapshots(src, dst)
+
+    clears = [
+        c for c in src.set_lock.call_args_list if c.args[:3] == (snap, "dest-1", False)
+    ]
+    assert clears == []
+
+
+# --------------------------------------------------------------------------- #
+# 3. End-to-end: a persisted lock survives retention across runs
+# --------------------------------------------------------------------------- #
+def test_persisted_lock_survives_retention_across_runs(tmp_path, monkeypatch):
+    """The whole point of R3: lock the oldest snapshot in run 1; in run 2 a fresh
+    endpoint must NOT prune it even though keep-count would otherwise. Mutation guard:
+    removing the read-back makes the locked snapshot look unlocked -> it gets deleted ->
+    this fails."""
+    names = [
+        "home-20240101-000000",  # oldest -- will be locked
+        "home-20240102-000000",
+        "home-20240103-000000",  # newest
+    ]
+
+    # Run 1: create snapshots and lock the oldest for dest-1.
+    ep1 = _local(tmp_path)
+    for n in names:
+        (tmp_path / n).mkdir()
+    listed = {s.get_name(): s for s in ep1.list_snapshots()}
+    ep1.set_lock(listed["home-20240101-000000"], "dest-1", True)
+
+    # Run 2: brand-new endpoint reads the lock back from disk.
+    ep2 = _local(tmp_path)
+    deleted: list[str] = []
+    monkeypatch.setattr(
+        ep2,
+        "_exec_command",
+        lambda spec, **k: deleted.append(str(spec["command"][3][0])),
+    )
+
+    ep2.delete_old_snapshots(keep=1)
+
+    # The locked oldest must survive; the older UNLOCKED one is the one pruned.
+    assert not any("home-20240101-000000" in d for d in deleted)
+    assert any("home-20240102-000000" in d for d in deleted)
+
+
+def test_delete_snapshots_skips_persisted_lock(tmp_path, monkeypatch):
+    """An explicit delete of a locked snapshot is skipped once the lock is read back.
+    Mutation guard: no read-back -> the snapshot is unlocked -> it gets deleted."""
+    ep1 = _local(tmp_path)
+    (tmp_path / "home-20240101-000000").mkdir()
+    locked = {s.get_name(): s for s in ep1.list_snapshots()}["home-20240101-000000"]
+    ep1.set_lock(locked, "dest-1", True)
+
+    ep2 = _local(tmp_path)
+    deleted: list[str] = []
+    monkeypatch.setattr(
+        ep2,
+        "_exec_command",
+        lambda spec, **k: deleted.append(str(spec["command"][3][0])),
+    )
+    target = {s.get_name(): s for s in ep2.list_snapshots()}["home-20240101-000000"]
+
+    ep2.delete_snapshots([target])
+
+    assert deleted == []  # locked -> skipped, no btrfs delete issued
+
+
+# --------------------------------------------------------------------------- #
+# 4. Atomic write
+# --------------------------------------------------------------------------- #
+def test_write_locks_is_atomic_and_leaves_no_temp(tmp_path):
+    """A successful write commits the final file and leaves no temp behind."""
+    ep = _local(tmp_path)
+    ep._write_locks({"home-x": {"locks": ["d1"]}})
+
+    assert (tmp_path / ep.config["lock_file_name"]).exists()
+    assert not (tmp_path / (ep.config["lock_file_name"] + ".tmp")).exists()
+    assert ep._read_locks() == {"home-x": {"locks": ["d1"]}}
+
+
+def test_write_locks_replaces_stale_temp(tmp_path):
+    """A leftover temp file from a prior crash must not block the next write (O_EXCL
+    would raise). Mutation guard: dropping the stale-temp unlink makes the O_EXCL create
+    raise FileExistsError -> AbortError -> this fails."""
+    ep = _local(tmp_path)
+    stale = tmp_path / (ep.config["lock_file_name"] + ".tmp")
+    stale.write_text("stale garbage from a prior crash")
+
+    ep._write_locks({"home-x": {"locks": ["d1"]}})
+
+    assert ep._read_locks() == {"home-x": {"locks": ["d1"]}}
+    assert not stale.exists()
+
+
+# --------------------------------------------------------------------------- #
+# 5. Concurrency: set_lock is a read-modify-write against the on-disk file
+# --------------------------------------------------------------------------- #
+def test_set_lock_preserves_concurrent_locks_on_other_snapshots(tmp_path):
+    """set_lock must not clobber a lock another run persisted for a DIFFERENT snapshot.
+    It reads the authoritative on-disk state and updates only its own snapshot's entry.
+    Mutation guard: reverting set_lock to rebuild lock_dict from the (stale) snapshot
+    cache drops the concurrently-written lock and fails the first assertion."""
+    ep = _local(tmp_path)
+    (tmp_path / "home-20240102-000000").mkdir()
+    snap_y = {s.get_name(): s for s in ep.list_snapshots()}["home-20240102-000000"]
+
+    # Simulate another run/process persisting a lock for a snapshot this run's cache
+    # does not know about.
+    ep._write_locks({"home-20240101-000000": {"locks": ["dest-A"]}})
+
+    ep.set_lock(snap_y, "dest-B", True)
+
+    persisted = ep._read_locks()
+    assert persisted.get("home-20240101-000000", {}).get("locks") == ["dest-A"]
+    assert "dest-B" in persisted.get("home-20240102-000000", {}).get("locks", [])
+
+
+def test_set_lock_aborts_on_corrupt_lock_file_without_clobber(tmp_path):
+    """A corrupt lock file must abort set_lock (loud) rather than overwrite it -- an
+    overwrite would silently discard locks we could not read. Mutation guard: making
+    set_lock read defensively (swallow the error and write anyway) fails this."""
+    ep = _local(tmp_path)
+    corrupt = "{ this is not valid json"
+    (tmp_path / ep.config["lock_file_name"]).write_text(corrupt)
+    snap = _snap_named(ep, tmp_path, "20240102-000000")
+
+    with pytest.raises(__util__.AbortError):
+        ep.set_lock(snap, "dest-1", True)
+
+    # The unreadable file is preserved intact for operator repair.
+    assert (tmp_path / ep.config["lock_file_name"]).read_text() == corrupt
+
+
+# --------------------------------------------------------------------------- #
+# 6. Fail-safe: a corrupt lock file must halt retention, not silently prune
+# --------------------------------------------------------------------------- #
+def test_retention_refuses_to_delete_on_corrupt_lock_file(tmp_path, monkeypatch):
+    """delete_old_snapshots must NOT prune when the lock file is corrupt: it cannot tell
+    which snapshots are protected, so deleting risks losing a still-needed one. Mutation
+    guard: removing the _locks_read_failed guard in delete_old_snapshots prunes the
+    excess and fails this."""
+    ep = _local(tmp_path)
+    for n in [
+        "home-20240101-000000",
+        "home-20240102-000000",
+        "home-20240103-000000",
+    ]:
+        (tmp_path / n).mkdir()
+    (tmp_path / ep.config["lock_file_name"]).write_text("{ corrupt lock file")
+
+    deleted: list[str] = []
+    monkeypatch.setattr(
+        ep,
+        "_exec_command",
+        lambda spec, **k: deleted.append(str(spec["command"][3][0])),
+    )
+
+    ep.delete_old_snapshots(keep=1)
+
+    assert deleted == []  # fail-safe: nothing pruned while locks are unknowable
+
+
+def test_delete_snapshots_refuses_on_corrupt_lock_file(tmp_path, monkeypatch):
+    """The explicit delete path is guarded too. Mutation guard: removing the
+    _locks_read_failed guard in delete_snapshots deletes the target and fails this."""
+    ep = _local(tmp_path)
+    (tmp_path / "home-20240101-000000").mkdir()
+    (tmp_path / ep.config["lock_file_name"]).write_text("{ corrupt")
+    target = ep.list_snapshots()[0]  # sets the corrupt-lock flag
+
+    deleted: list[str] = []
+    monkeypatch.setattr(ep, "_exec_command", lambda spec, **k: deleted.append("x"))
+
+    ep.delete_snapshots([target])
+
+    assert deleted == []
+
+
+def test_write_locks_does_not_clobber_through_symlinked_temp(tmp_path):
+    """A symlink planted at the temp path must not be followed to clobber its target.
+    Mutation guard: opening the temp with a plain ``open(tmp, 'w')`` (no O_NOFOLLOW /
+    no unlink) follows the symlink and overwrites the victim -> this fails."""
+    ep = _local(tmp_path)
+    victim = tmp_path / "victim"
+    victim.write_text("precious")
+    planted = tmp_path / (ep.config["lock_file_name"] + ".tmp")
+    planted.symlink_to(victim)
+
+    ep._write_locks({"home-x": {"locks": ["d1"]}})
+
+    assert victim.read_text() == "precious"  # untouched
+    assert ep._read_locks() == {"home-x": {"locks": ["d1"]}}


### PR DESCRIPTION
## What & why

Audit root **R3 (lock persistence)**. A transfer locks the source snapshot it needs (and its incremental parent) by the destination's id so retention cannot prune a snapshot a failed or pending transfer still depends on. `set_lock` wrote those locks to `<path>/.btrfs-backup-ng.locks` but **nothing ever read them back** onto `snapshot.locks` — so on the next run every snapshot looked unlocked and `delete_old_snapshots` / `delete_snapshots` (whose lock-skipping guards were correct but *inert*) could delete a snapshot the next incremental send required, breaking the chain.

## Changes

- **Read-back** — `Endpoint.list_snapshots` now loads persisted locks onto the snapshots it returns, so the retention guards actually see them.
- **Presence-based reconcile** — `sync_snapshots` clears a destination's lock only for a source snapshot *confirmed present* on that destination; a snapshot not yet on the destination keeps its lock. No time-boxing, so a long outage can't drop a still-needed lock.
- **Concurrency-safe `set_lock`** — now a read-modify-write against the authoritative on-disk file, serialized by a `FileLock`, so concurrent `parallel_targets` transfers and overlapping runs can't clobber each other's locks (last-writer-wins), and a stale cache can't drop the mutation.
- **Atomic, crash-safe `_write_locks`** — temp file + fsync + `os.replace` + **parent-directory fsync**; `O_NOFOLLOW|O_EXCL` against a planted symlink / stale temp.
- **Fail-safe retention** — a corrupt/unreadable lock file no longer silently degrades to keep-count pruning; retention **refuses to delete** (loud error) until it's repaired or removed.

## Review & verification

- 4-lens adversarial review (correctness / security / durability / regression): 14 findings raised, 5 confirmed after adversarial re-verification and all addressed here (dir fsync, `set_lock` disk read-modify-write + FileLock, corrupt-file fail-safe). The timestamp-format-skew finding is *safe-direction* (over-retention) and a separate subsystem — noted, not pulled into R3.
- **15 mutation-verified** unit tests (`tests/test_r3_lock_persistence.py`); full suite green (2368 passed).
- **Proven on real btrfs**: cross-process read-back + retention (real `btrfs subvolume delete`), full CLI failure→lock→fresh-process read-back→retry→reconcile-clear, corrupt-file fail-safe, and the reconcile clearing a persisted lock against a **remote ssh btrfs destination**.

Follows R1 (#17) / R2 (#18) toward the 0.9.0 reliability release. Changelog under `[Unreleased]`.