### PR TITLE
fix: Discover the user's ssh-agent under sudo for passphrase-protected keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ plain `sudo btrfs-backup-ng run` just works in most setups. For unusual setups y
 socket explicitly with a new `ssh_auth_sock` target option (or `BTRFS_BACKUP_SSH_AUTH_SOCK`
 env var, or `--ssh-auth-sock` on restore/verify/estimate/snapper), and a preserved
 `SSH_AUTH_SOCK` (via `sudo -E`) is honored. When authentication does fail, the error now spells
-out exactly how to fix it for your situation.
+out exactly how to fix it for your situation. **SSH password authentication continues to work
+unchanged** — the agent is only tried first, then it falls through cleanly to password (and a
+dead/stale agent socket is never selected, so it can't get in the way).
 
 #### Snapshots you still need are no longer deleted after an interrupted backup
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### Remote backups over SSH now work with a passphrase-protected key under sudo
+
+Backups run as root (btrfs send/receive need it), and `sudo` clears `SSH_AUTH_SOCK`. If your
+SSH key is passphrase-protected, the usable (decrypted) key lives only in your ssh-agent — so
+without the agent, the remote server accepts your public key but the client can't sign, and
+the backup fails with a confusing "Permission denied". btrfs-backup-ng now **auto-discovers
+your ssh-agent socket** across common locations (`~/.ssh/agent/`, `/tmp/ssh-*`,
+`/run/user/<uid>/…`, gpg/gcr, 1Password, Bitwarden), validating each is a socket you own, so a
+plain `sudo btrfs-backup-ng run` just works in most setups. For unusual setups you can pin the
+socket explicitly with a new `ssh_auth_sock` target option (or `BTRFS_BACKUP_SSH_AUTH_SOCK`
+env var, or `--ssh-auth-sock` on restore/verify/estimate/snapper), and a preserved
+`SSH_AUTH_SOCK` (via `sudo -E`) is honored. When authentication does fail, the error now spells
+out exactly how to fix it for your situation.
+
 #### Snapshots you still need are no longer deleted after an interrupted backup
 
 When a backup transfer fails or is interrupted partway, btrfs-backup-ng marks the source

--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -401,6 +401,7 @@ btrfs-backup-ng estimate --volume PATH [--target INDEX] [--check-space]
 | `--safety-margin PERCENT` | Safety margin percentage (default: 10%) |
 | `--ssh-sudo` | Use sudo on remote host |
 | `--ssh-key FILE` | SSH private key file |
+| `--ssh-auth-sock PATH` | Explicit ssh-agent socket (overrides auto-discovery) |
 | `--fs-checks MODE` | Filesystem check mode: auto, strict, skip |
 | `--no-fs-checks` | Skip filesystem checks (alias for --fs-checks=skip) |
 | `--json` | Output in JSON format |
@@ -760,6 +761,7 @@ btrfs-backup-ng snapper backup CONFIG TARGET [OPTIONS]
 | `--rate-limit RATE` | Bandwidth limit (e.g., '10M', '1G') |
 | `--ssh-sudo` | Use sudo on remote host |
 | `--ssh-key FILE` | SSH private key file |
+| `--ssh-auth-sock PATH` | Explicit ssh-agent socket (overrides auto-discovery) |
 | `--progress` | Show progress bars |
 | `--no-progress` | Disable progress bars |
 
@@ -852,6 +854,7 @@ btrfs-backup-ng snapper restore SOURCE --config NAME [OPTIONS]
 | `--rate-limit RATE` | Bandwidth limit |
 | `--ssh-sudo` | Use sudo on remote host |
 | `--ssh-key FILE` | SSH private key file |
+| `--ssh-auth-sock PATH` | Explicit ssh-agent socket (overrides auto-discovery) |
 | `--progress` | Show progress bars |
 | `--json` | Output in JSON format (for --list) |
 
@@ -1143,14 +1146,35 @@ When backing up to a remote host via SSH, there are several authentication scena
 
 **Key-based authentication (recommended):**
 
-For key-based SSH authentication, ensure your SSH key is loaded in ssh-agent. When running with sudo, you must preserve the `SSH_AUTH_SOCK` environment variable:
+For key-based SSH authentication, load your SSH key into ssh-agent (`ssh-add`). Backups run
+as root (btrfs send/receive need it), and `sudo` strips `SSH_AUTH_SOCK` — but a
+passphrase-protected key can only sign via its agent. btrfs-backup-ng therefore
+**auto-discovers your ssh-agent socket** across common locations (including `~/.ssh/agent/`,
+`/tmp/ssh-*`, `/run/user/<uid>/keyring/ssh`, gpg/gcr agents) and uses it, preferring a
+socket that actually has keys loaded. In most setups a plain `sudo btrfs-backup-ng run`
+just works.
+
+If your agent lives somewhere unusual, or you run several agents, pin the socket explicitly
+(highest precedence, then a preserved `SSH_AUTH_SOCK`, then auto-discovery):
 
 ```bash
-# Run with sudo -E to preserve SSH agent socket
-sudo -E btrfs-backup-ng run
+# 1. Explicit socket in the target config:
+#    [[volumes.targets]]
+#    ssh_auth_sock = "/path/to/agent.sock"
+#
+# 2. Environment override (works for every command):
+export BTRFS_BACKUP_SSH_AUTH_SOCK="$SSH_AUTH_SOCK"
+sudo --preserve-env=BTRFS_BACKUP_SSH_AUTH_SOCK btrfs-backup-ng run
+#
+# 3. Preserve your existing agent socket through sudo:
+sudo --preserve-env=SSH_AUTH_SOCK btrfs-backup-ng run   # or: sudo -E ...
+#
+# 4. On one-off commands: restore/verify/estimate/snapper accept --ssh-auth-sock PATH
 ```
 
-The tool will automatically detect SSH keys in `~/.ssh/` (id_ed25519, id_rsa, id_ecdsa) for the original user when running via sudo.
+The tool also detects SSH keys in `~/.ssh/` (id_ed25519, id_rsa, id_ecdsa) for the original
+user when running via sudo. If authentication fails, the error message names the exact
+remediation for your situation. A passphrase-less key avoids the agent requirement entirely.
 
 **Password authentication:**
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -146,10 +146,20 @@ require_mount = true    # Fail if drive is not mounted (safety check)
 # ssh_sudo = false                   # Use sudo on remote host
 # ssh_port = 22                      # SSH port number
 # ssh_key = "~/.ssh/id_rsa"         # Path to SSH private key
+# ssh_auth_sock = "/path/to/agent.sock"  # Explicit ssh-agent socket (see note below)
 # ssh_password_auth = true           # Allow password authentication fallback
 # compress = "none"                  # Compression: none|gzip|zstd|lz4|pigz|lzop
 # rate_limit = "10M"                 # Bandwidth limit: number with K|M|G suffix
 # require_mount = false              # Require path to be a mount point (local only)
+#
+# SSH agent under sudo:
+# Backups run as root (btrfs send/receive need it), and sudo strips SSH_AUTH_SOCK.
+# If your SSH key is passphrase-protected, its usable key lives in your ssh-agent, so
+# btrfs-backup-ng auto-discovers your agent socket (common locations incl. ~/.ssh/agent/,
+# /run/user/<uid>/...) and uses it. If your agent lives somewhere unusual, pin it with
+# ssh_auth_sock above, export BTRFS_BACKUP_SSH_AUTH_SOCK, or run with
+# `sudo --preserve-env=SSH_AUTH_SOCK` (or `sudo -E`). Alternatively use a passphrase-less
+# key. On the CLI (restore/verify/estimate/snapper) the same override is --ssh-auth-sock.
 
 
 # =============================================================================

--- a/src/btrfs_backup_ng/cli/dispatcher.py
+++ b/src/btrfs_backup_ng/cli/dispatcher.py
@@ -644,6 +644,11 @@ Config-driven restore:
         help="SSH private key file",
     )
     restore_parser.add_argument(
+        "--ssh-auth-sock",
+        metavar="PATH",
+        help="Explicit ssh-agent socket (overrides auto-discovery; useful under sudo)",
+    )
+    restore_parser.add_argument(
         "--compress",
         metavar="METHOD",
         choices=["none", "gzip", "zstd", "lz4", "pigz", "lzop"],
@@ -790,6 +795,11 @@ Examples:
         metavar="FILE",
         help="SSH private key file",
     )
+    verify_parser.add_argument(
+        "--ssh-auth-sock",
+        metavar="PATH",
+        help="Explicit ssh-agent socket (overrides auto-discovery; useful under sudo)",
+    )
     add_fs_checks_args(verify_parser)
     verify_parser.add_argument(
         "--json",
@@ -930,6 +940,11 @@ Examples:
         "--ssh-key",
         metavar="FILE",
         help="SSH private key file",
+    )
+    estimate_parser.add_argument(
+        "--ssh-auth-sock",
+        metavar="PATH",
+        help="Explicit ssh-agent socket (overrides auto-discovery; useful under sudo)",
     )
     estimate_parser.add_argument(
         "--timestamp-format",
@@ -1278,6 +1293,11 @@ Examples:
         help="SSH private key file",
     )
     snapper_backup.add_argument(
+        "--ssh-auth-sock",
+        metavar="PATH",
+        help="Explicit ssh-agent socket (overrides auto-discovery; useful under sudo)",
+    )
+    snapper_backup.add_argument(
         "--compress",
         metavar="METHOD",
         choices=["none", "gzip", "zstd", "lz4", "pigz", "lzop"],
@@ -1394,6 +1414,11 @@ Examples:
         "--ssh-key",
         metavar="FILE",
         help="SSH private key file",
+    )
+    snapper_restore.add_argument(
+        "--ssh-auth-sock",
+        metavar="PATH",
+        help="Explicit ssh-agent socket (overrides auto-discovery; useful under sudo)",
     )
     snapper_restore.add_argument(
         "-l",

--- a/src/btrfs_backup_ng/cli/estimate.py
+++ b/src/btrfs_backup_ng/cli/estimate.py
@@ -154,6 +154,8 @@ def _estimate_from_config(args: argparse.Namespace, volume_path: str) -> int:
             dest_kwargs["ssh_sudo"] = True
         if target.ssh_key:
             dest_kwargs["ssh_identity_file"] = target.ssh_key
+        if target.ssh_auth_sock:
+            dest_kwargs["ssh_auth_sock"] = target.ssh_auth_sock
 
         dest_ep = endpoint.choose_endpoint(
             target.path,
@@ -197,6 +199,7 @@ def _estimate_direct(args: argparse.Namespace, source: str, destination: str) ->
     prefix = getattr(args, "prefix", "") or ""
     ssh_sudo = getattr(args, "ssh_sudo", False)
     ssh_key = getattr(args, "ssh_key", None)
+    ssh_auth_sock = getattr(args, "ssh_auth_sock", None)
 
     # Prepare source endpoint
     fs_checks_mode = get_fs_checks_mode(args)
@@ -234,6 +237,8 @@ def _estimate_direct(args: argparse.Namespace, source: str, destination: str) ->
             dest_kwargs["ssh_sudo"] = True
         if ssh_key:
             dest_kwargs["ssh_identity_file"] = ssh_key
+        if ssh_auth_sock:
+            dest_kwargs["ssh_auth_sock"] = ssh_auth_sock
         if not destination.startswith("ssh://"):
             dest_kwargs["path"] = Path(destination).resolve()
 

--- a/src/btrfs_backup_ng/cli/restore.py
+++ b/src/btrfs_backup_ng/cli/restore.py
@@ -456,6 +456,9 @@ def _prepare_backup_endpoint(args: argparse.Namespace, source: str):
         ssh_key = getattr(args, "ssh_key", None)
         if ssh_key:
             endpoint_kwargs["ssh_identity_file"] = ssh_key
+        ssh_auth_sock = getattr(args, "ssh_auth_sock", None)
+        if ssh_auth_sock:
+            endpoint_kwargs["ssh_auth_sock"] = ssh_auth_sock
     else:
         # For local paths, we need to set 'path' as well since LocalEndpoint
         # always resolves config["path"] during initialization

--- a/src/btrfs_backup_ng/cli/run.py
+++ b/src/btrfs_backup_ng/cli/run.py
@@ -366,6 +366,8 @@ def _backup_volume(
 
             if target.ssh_key:
                 dest_kwargs["ssh_identity_file"] = target.ssh_key
+            if target.ssh_auth_sock:
+                dest_kwargs["ssh_auth_sock"] = target.ssh_auth_sock
 
             thread_raw_encryption(dest_kwargs, target)
             thread_raw_compression(dest_kwargs, target, compress_override)
@@ -556,6 +558,8 @@ def _backup_snapper_volume(
             if target.ssh_key:
                 snapper_endpoint_config["ssh_identity_file"] = target.ssh_key
                 snapper_endpoint_config["ssh_key"] = target.ssh_key
+            if target.ssh_auth_sock:
+                snapper_endpoint_config["ssh_auth_sock"] = target.ssh_auth_sock
             thread_raw_encryption(snapper_endpoint_config, target)
             thread_raw_compression(snapper_endpoint_config, target, compress_override)
             destination_endpoint = endpoint.choose_endpoint(

--- a/src/btrfs_backup_ng/cli/snapper_cmd.py
+++ b/src/btrfs_backup_ng/cli/snapper_cmd.py
@@ -237,6 +237,8 @@ def _handle_backup(args: argparse.Namespace) -> int:
     if getattr(args, "ssh_key", None):
         endpoint_config["ssh_identity_file"] = args.ssh_key
         endpoint_config["ssh_key"] = args.ssh_key
+    if getattr(args, "ssh_auth_sock", None):
+        endpoint_config["ssh_auth_sock"] = args.ssh_auth_sock
     # Encryption for raw targets. Threaded from the CLI flags; fail closed below so
     # this path can never silently write plaintext when encryption was requested.
     encrypt = getattr(args, "encrypt", None) or "none"

--- a/src/btrfs_backup_ng/cli/transfer.py
+++ b/src/btrfs_backup_ng/cli/transfer.py
@@ -163,6 +163,8 @@ def execute_transfer(args: argparse.Namespace) -> int:
 
                     if target.ssh_key:
                         dest_kwargs["ssh_identity_file"] = target.ssh_key
+                    if target.ssh_auth_sock:
+                        dest_kwargs["ssh_auth_sock"] = target.ssh_auth_sock
 
                     thread_raw_encryption(dest_kwargs, target)
                     thread_raw_compression(

--- a/src/btrfs_backup_ng/cli/verify.py
+++ b/src/btrfs_backup_ng/cli/verify.py
@@ -52,6 +52,8 @@ def execute(args: argparse.Namespace) -> int:
             endpoint_kwargs["ssh_sudo"] = True
         if args.ssh_key:
             endpoint_kwargs["ssh_identity_file"] = args.ssh_key
+        if getattr(args, "ssh_auth_sock", None):
+            endpoint_kwargs["ssh_auth_sock"] = args.ssh_auth_sock
     else:
         # For local paths, set 'path' for LocalEndpoint
         endpoint_kwargs["path"] = Path(args.location).resolve()

--- a/src/btrfs_backup_ng/config/loader.py
+++ b/src/btrfs_backup_ng/config/loader.py
@@ -196,6 +196,7 @@ def _parse_target(data: dict[str, Any]) -> TargetConfig:
         ssh_sudo=data.get("ssh_sudo", False),
         ssh_port=data.get("ssh_port", 22),
         ssh_key=data.get("ssh_key"),
+        ssh_auth_sock=data.get("ssh_auth_sock"),
         ssh_password_auth=data.get("ssh_password_auth", True),
         compress=compress,
         rate_limit=data.get("rate_limit"),

--- a/src/btrfs_backup_ng/config/schema.py
+++ b/src/btrfs_backup_ng/config/schema.py
@@ -129,6 +129,8 @@ class TargetConfig:
         ssh_sudo: Whether to use sudo on remote SSH targets
         ssh_port: SSH port for remote targets
         ssh_key: Path to SSH private key
+        ssh_auth_sock: Explicit ssh-agent socket path (overrides auto-discovery; useful
+            under sudo where SSH_AUTH_SOCK is stripped and the key is passphrase-protected)
         ssh_password_auth: Allow password authentication fallback
         compress: Compression algorithm for transfers (none, gzip, zstd, lz4)
         rate_limit: Bandwidth limit for transfers (e.g., "10M", "1G", "500K")
@@ -143,6 +145,7 @@ class TargetConfig:
     ssh_sudo: bool = False
     ssh_port: int = 22
     ssh_key: Optional[str] = None
+    ssh_auth_sock: Optional[str] = None
     ssh_password_auth: bool = True
     compress: str = "none"
     rate_limit: Optional[str] = None
@@ -175,6 +178,7 @@ class RawTargetConfig:
         ssh_sudo: Whether to use sudo on remote SSH targets
         ssh_port: SSH port for remote targets
         ssh_key: Path to SSH private key
+        ssh_auth_sock: Explicit ssh-agent socket path (overrides auto-discovery)
     """
 
     path: str
@@ -185,6 +189,7 @@ class RawTargetConfig:
     ssh_sudo: bool = False
     ssh_port: int = 22
     ssh_key: Optional[str] = None
+    ssh_auth_sock: Optional[str] = None
 
     def __post_init__(self):
         """Validate configuration after initialization."""

--- a/src/btrfs_backup_ng/endpoint/ssh.py
+++ b/src/btrfs_backup_ng/endpoint/ssh.py
@@ -224,6 +224,7 @@ class SSHEndpoint(Endpoint):
             "passwordless",
             "ssh_identity_file",
             "ssh_key",
+            "ssh_auth_sock",
             "ssh_password_fallback",
         ):
             if config.get(_ssh_key) is not None:
@@ -437,6 +438,7 @@ class SSHEndpoint(Endpoint):
             debug=True,
             identity_file=self.config.get("ssh_identity_file"),
             allow_password_auth=allow_password,
+            ssh_auth_sock=self.config.get("ssh_auth_sock"),
         )
         logger.debug("SSHMasterManager created successfully")
 

--- a/src/btrfs_backup_ng/sshutil/master.py
+++ b/src/btrfs_backup_ng/sshutil/master.py
@@ -215,6 +215,23 @@ class SSHMasterManager:
             return False
         return _stat.S_ISSOCK(st.st_mode) and st.st_uid in (uid, 0)
 
+    def _agent_status(self, sock_path: str) -> int:
+        """`ssh-add -l` status for an agent socket.
+
+        0 = the agent has keys, 1 = the agent is reachable but has no keys, 2 = the socket
+        is dead/unreachable (a leftover file whose agent process died, or a timeout). A
+        dead socket must never be chosen -- setting SSH_AUTH_SOCK to it makes ssh waste a
+        round trip on an agent it cannot talk to before falling back to password auth."""
+        try:
+            sub_env = os.environ.copy()
+            sub_env["SSH_AUTH_SOCK"] = sock_path
+            result = subprocess.run(
+                ["ssh-add", "-l"], env=sub_env, capture_output=True, timeout=5
+            )
+            return result.returncode
+        except Exception:  # noqa: BLE001 - any failure means "treat as unreachable"
+            return 2
+
     def _resolve_agent_socket(self, uid: int, env: dict) -> Optional[str]:
         """Resolve which ssh-agent socket to use.
 
@@ -254,7 +271,6 @@ class SSHMasterManager:
             Path to an agent socket if found, else None.
         """
         import glob
-        import subprocess
 
         # Owning user's home for ~/.ssh sockets. Derive from the uid so it is correct under
         # sudo; if the uid is not in the password db (containers/NSS), fall back to the
@@ -279,18 +295,6 @@ class SSHMasterManager:
             f"/run/user/{uid}/openssh_agent",  # openssh per-user
         ]
 
-        def socket_has_keys(sock_path: str) -> bool:
-            """True if the agent at sock_path has at least one key loaded."""
-            try:
-                sub_env = os.environ.copy()
-                sub_env["SSH_AUTH_SOCK"] = sock_path
-                result = subprocess.run(
-                    ["ssh-add", "-l"], env=sub_env, capture_output=True, timeout=5
-                )
-                return result.returncode == 0  # 0 = has keys, 1 = none, 2 = no agent
-            except Exception:
-                return False
-
         def candidates():
             # sorted() so a deterministic socket is chosen when a glob matches several.
             for pattern in search_paths:
@@ -299,17 +303,26 @@ class SSHMasterManager:
                 elif os.path.exists(pattern):
                     yield pattern
 
-        # Pass 1: a socket that actually has keys (what we really want).
+        # Pass 1: a live agent that actually has keys (what enables passphrase-key auth).
         for sock in candidates():
-            if self._owned_socket(sock, uid, follow=False) and socket_has_keys(sock):
+            if (
+                self._owned_socket(sock, uid, follow=False)
+                and self._agent_status(sock) == 0
+            ):
                 logger.debug("Found agent socket with keys: %s", sock)
                 self._agent_socket_had_keys = True
                 return sock
-        # Pass 2: any owned socket (no keys loaded). Kept so the failure path can tell the
-        # user an agent exists but is empty ("run ssh-add") instead of "none found".
+        # Pass 2: a REACHABLE agent with no keys (status 1). A dead/stale socket (status 2 --
+        # a leftover file whose agent process died) is skipped so we never set SSH_AUTH_SOCK
+        # to a socket ssh cannot talk to, which would only add latency/noise before password
+        # fallback. Kept so the failure path can say "an agent is running but has no keys"
+        # instead of "none found".
         for sock in candidates():
-            if self._owned_socket(sock, uid, follow=False):
-                logger.debug("Found agent socket (no keys loaded): %s", sock)
+            if (
+                self._owned_socket(sock, uid, follow=False)
+                and self._agent_status(sock) == 1
+            ):
+                logger.debug("Found reachable agent socket (no keys loaded): %s", sock)
                 self._agent_socket_had_keys = False
                 return sock
         return None
@@ -359,6 +372,10 @@ class SSHMasterManager:
         if not self._has_sshpass():
             logger.debug("sshpass not available for password authentication")
             return False
+
+        # Reset per-attempt state so a stale failure flag from a prior attempt cannot
+        # skew the retry decision in start_master.
+        self._password_auth_failed = False
 
         # Build command with sshpass
         ssh_cmd = self._ssh_base_cmd()
@@ -472,6 +489,9 @@ class SSHMasterManager:
                 self._resolved_agent_sock = agent_sock
                 logger.debug("Using ssh-agent socket: %s", agent_sock)
             else:
+                # No usable agent. Clear any inherited SSH_AUTH_SOCK so ssh does not try a
+                # stale/foreign socket before falling back to password auth.
+                env.pop("SSH_AUTH_SOCK", None)
                 self._resolved_agent_sock = None
                 logger.debug("No usable ssh-agent socket found")
 

--- a/src/btrfs_backup_ng/sshutil/master.py
+++ b/src/btrfs_backup_ng/sshutil/master.py
@@ -36,6 +36,7 @@ class SSHMasterManager:
         debug: bool = False,
         identity_file: Optional[str] = None,
         allow_password_auth: bool = False,
+        ssh_auth_sock: Optional[str] = None,
     ):
         self.hostname = hostname
         self.username = username or getpass.getuser()
@@ -45,6 +46,16 @@ class SSHMasterManager:
         self.debug = debug
         self.identity_file = identity_file
         self.allow_password_auth = allow_password_auth
+        # Explicit ssh-agent socket override (config `ssh_auth_sock` / CLI / the
+        # BTRFS_BACKUP_SSH_AUTH_SOCK env var). Takes precedence over auto-discovery so a
+        # multi-agent or non-standard deployment can pin exactly which agent to use.
+        self.ssh_auth_sock = ssh_auth_sock or os.environ.get(
+            "BTRFS_BACKUP_SSH_AUTH_SOCK"
+        )
+        # The agent socket actually used for the last connection (for diagnostics/errors),
+        # and whether it had keys loaded (drives the auth-failure guidance).
+        self._resolved_agent_sock: Optional[str] = None
+        self._agent_socket_had_keys: bool = True
 
         # Password caching
         self._cached_ssh_password: Optional[str] = None
@@ -182,101 +193,125 @@ class SSHMasterManager:
         """Check if sshpass utility is available."""
         return shutil.which("sshpass") is not None
 
-    def _find_ssh_agent_socket(self, uid: int) -> Optional[str]:
-        """Find SSH agent socket for a given user.
+    @staticmethod
+    def _owned_socket(path: Optional[str], uid: int, *, follow: bool) -> bool:
+        """True if ``path`` is a unix socket owned by ``uid`` (or root).
 
-        Searches common locations for SSH agent sockets. This is useful when
-        running with sudo where SSH_AUTH_SOCK may not be preserved.
+        The ownership gate stops a hostile path (in the environment/config or planted in a
+        world-writable search dir) from making root connect to an attacker's agent -- only
+        root can create a root-owned file, and a non-target user cannot create one owned by
+        the target uid. ``follow=False`` uses lstat, so a planted symlink is rejected
+        outright (no TOCTOU / redirection). ``follow=True`` is for a user-pinned override /
+        preserved SSH_AUTH_SOCK, where a symlink is the user's own choice but the resolved
+        target must still be a socket they own.
+        """
+        if not path:
+            return False
+        import stat as _stat
 
-        The search prioritizes sockets that are likely to have keys loaded:
-        1. Traditional ssh-agent sockets in /tmp (from ssh-agent or ssh -A)
-        2. GNOME Keyring socket
-        3. GPG agent with SSH support
-        4. systemd ssh-agent socket (often empty/unused)
+        try:
+            st = os.stat(path) if follow else os.lstat(path)
+        except OSError:
+            return False
+        return _stat.S_ISSOCK(st.st_mode) and st.st_uid in (uid, 0)
+
+    def _resolve_agent_socket(self, uid: int, env: dict) -> Optional[str]:
+        """Resolve which ssh-agent socket to use.
+
+        Precedence: (1) explicit override (config ``ssh_auth_sock`` /
+        ``BTRFS_BACKUP_SSH_AUTH_SOCK``), (2) a preserved ``SSH_AUTH_SOCK`` in the
+        environment (``sudo -E`` / ``--preserve-env``), (3) auto-discovery. Every source is
+        validated to be a socket owned by the invoking user (or root) so a hostile path
+        cannot make root connect to an attacker-controlled agent.
+        """
+        if self.ssh_auth_sock:
+            if self._owned_socket(self.ssh_auth_sock, uid, follow=True):
+                return self.ssh_auth_sock
+            logger.warning(
+                "Configured ssh_auth_sock %s is not a usable agent socket owned by the "
+                "backup user; falling back to auto-discovery.",
+                self.ssh_auth_sock,
+            )
+        env_sock = env.get("SSH_AUTH_SOCK")
+        if env_sock and self._owned_socket(env_sock, uid, follow=True):
+            return env_sock
+        return self._find_ssh_agent_socket(uid, env)
+
+    def _find_ssh_agent_socket(self, uid: int, env: dict) -> Optional[str]:
+        """Find an ssh-agent socket owned by ``uid``, preferring one with keys loaded.
+
+        Needed because sudo strips SSH_AUTH_SOCK, so a passphrase-protected key -- whose
+        usable key lives only in the agent -- would otherwise be unusable. Candidates are
+        validated as real unix sockets owned by the user (symlinks rejected). This is
+        best-effort breadth; setups not covered here (or multi-agent systems) should pin
+        ``ssh_auth_sock`` explicitly.
 
         Args:
-            uid: User ID to search for agent sockets
+            uid: User ID whose agent socket to find.
+            env: Environment already prepared by start_master (correct HOME under sudo).
 
         Returns:
-            Path to agent socket if found, None otherwise
+            Path to an agent socket if found, else None.
         """
         import glob
         import subprocess
 
-        # Common locations for ssh-agent sockets, ordered by likelihood of having keys
+        # Owning user's home for ~/.ssh sockets. Derive from the uid so it is correct under
+        # sudo; if the uid is not in the password db (containers/NSS), fall back to the
+        # HOME already resolved into env by start_master -- NOT os.path.expanduser, which
+        # under sudo would wrongly resolve to root's home.
+        try:
+            user_home = pwd.getpwuid(uid).pw_dir
+        except (KeyError, OSError):
+            user_home = env.get("HOME") or os.path.expanduser("~")
+
         search_paths = [
-            # Traditional ssh-agent in /tmp - most likely to have keys from ssh-add
-            "/tmp/ssh-*/agent.*",
-            # GNOME Keyring - often has keys from login
-            f"/run/user/{uid}/keyring/ssh",
-            # gpg-agent with ssh support
-            f"/run/user/{uid}/gnupg/S.gpg-agent.ssh",
-            # systemd ssh-agent - often exists but may be empty
-            f"/run/user/{uid}/ssh-agent.socket",
+            "/tmp/ssh-*/agent.*",  # traditional ssh-agent
+            f"{user_home}/.ssh/agent/*",  # custom agent managers / keychains
+            f"{user_home}/.ssh/agent.sock",
+            f"{user_home}/.ssh/*.sock",
+            f"{user_home}/.1password/agent.sock",  # 1Password
+            f"{user_home}/.bitwarden-ssh-agent.sock",  # Bitwarden
+            f"/run/user/{uid}/keyring/ssh",  # GNOME Keyring
+            f"/run/user/{uid}/gcr/ssh",  # gcr (newer GNOME)
+            f"/run/user/{uid}/gnupg/S.gpg-agent.ssh",  # gpg-agent with ssh support
+            f"/run/user/{uid}/ssh-agent.socket",  # systemd per-user
+            f"/run/user/{uid}/openssh_agent",  # openssh per-user
         ]
 
         def socket_has_keys(sock_path: str) -> bool:
-            """Check if an agent socket has any keys loaded."""
+            """True if the agent at sock_path has at least one key loaded."""
             try:
-                env = os.environ.copy()
-                env["SSH_AUTH_SOCK"] = sock_path
+                sub_env = os.environ.copy()
+                sub_env["SSH_AUTH_SOCK"] = sock_path
                 result = subprocess.run(
-                    ["ssh-add", "-l"],
-                    env=env,
-                    capture_output=True,
-                    timeout=5,
+                    ["ssh-add", "-l"], env=sub_env, capture_output=True, timeout=5
                 )
-                # Return code 0 means keys are loaded
-                # Return code 1 means "no identities"
-                return result.returncode == 0
+                return result.returncode == 0  # 0 = has keys, 1 = none, 2 = no agent
             except Exception:
                 return False
 
-        # First pass: find sockets with keys loaded
-        for pattern in search_paths:
-            if "*" in pattern:
-                # Glob pattern - find matching sockets owned by the user
-                for sock in glob.glob(pattern):
-                    try:
-                        stat = os.stat(sock)
-                        if stat.st_uid == uid and socket_has_keys(sock):
-                            logger.debug(f"Found agent socket with keys: {sock}")
-                            return sock
-                    except (OSError, IOError):
-                        continue
-            else:
-                # Exact path
-                if os.path.exists(pattern):
-                    try:
-                        stat = os.stat(pattern)
-                        if stat.st_uid == uid and socket_has_keys(pattern):
-                            logger.debug(f"Found agent socket with keys: {pattern}")
-                            return pattern
-                    except (OSError, IOError):
-                        continue
+        def candidates():
+            # sorted() so a deterministic socket is chosen when a glob matches several.
+            for pattern in search_paths:
+                if "*" in pattern:
+                    yield from sorted(glob.glob(pattern))
+                elif os.path.exists(pattern):
+                    yield pattern
 
-        # Second pass: return any accessible socket (even without keys)
-        # This allows password auth fallback to work
-        for pattern in search_paths:
-            if "*" in pattern:
-                for sock in glob.glob(pattern):
-                    try:
-                        stat = os.stat(sock)
-                        if stat.st_uid == uid:
-                            logger.debug(f"Found agent socket (no keys): {sock}")
-                            return sock
-                    except (OSError, IOError):
-                        continue
-            else:
-                if os.path.exists(pattern):
-                    try:
-                        stat = os.stat(pattern)
-                        if stat.st_uid == uid:
-                            logger.debug(f"Found agent socket (no keys): {pattern}")
-                            return pattern
-                    except (OSError, IOError):
-                        continue
-
+        # Pass 1: a socket that actually has keys (what we really want).
+        for sock in candidates():
+            if self._owned_socket(sock, uid, follow=False) and socket_has_keys(sock):
+                logger.debug("Found agent socket with keys: %s", sock)
+                self._agent_socket_had_keys = True
+                return sock
+        # Pass 2: any owned socket (no keys loaded). Kept so the failure path can tell the
+        # user an agent exists but is empty ("run ssh-add") instead of "none found".
+        for sock in candidates():
+            if self._owned_socket(sock, uid, follow=False):
+                logger.debug("Found agent socket (no keys loaded): %s", sock)
+                self._agent_socket_had_keys = False
+                return sock
         return None
 
     def _try_key_auth(self, env: dict) -> bool:
@@ -422,17 +457,23 @@ class SSHMasterManager:
                 sudo_user_info = pwd.getpwnam(self.sudo_user)
                 env["HOME"] = sudo_user_info.pw_dir
                 env["USER"] = self.sudo_user
+                agent_uid = sudo_user_info.pw_uid
+            else:
+                agent_uid = os.getuid()
 
-                # Preserve SSH_AUTH_SOCK for ssh-agent access
-                # When running with sudo, the agent socket variable is often cleared
-                # but the socket itself may still be accessible
-                if "SSH_AUTH_SOCK" not in env or not os.path.exists(
-                    env.get("SSH_AUTH_SOCK", "")
-                ):
-                    agent_sock = self._find_ssh_agent_socket(sudo_user_info.pw_uid)
-                    if agent_sock:
-                        env["SSH_AUTH_SOCK"] = agent_sock
-                        logger.debug(f"Found SSH agent socket: {agent_sock}")
+            # Resolve the ssh-agent socket. A passphrase-protected key can only be used
+            # for signing via its agent; sudo strips SSH_AUTH_SOCK, so without this the
+            # server accepts the offered public key but the client cannot sign it ->
+            # "Permission denied". Precedence: explicit override, then a preserved
+            # SSH_AUTH_SOCK, then auto-discovery across common socket locations.
+            agent_sock = self._resolve_agent_socket(agent_uid, env)
+            if agent_sock:
+                env["SSH_AUTH_SOCK"] = agent_sock
+                self._resolved_agent_sock = agent_sock
+                logger.debug("Using ssh-agent socket: %s", agent_sock)
+            else:
+                self._resolved_agent_sock = None
+                logger.debug("No usable ssh-agent socket found")
 
             # Try key-based auth first
             logger.debug("Attempting SSH key-based authentication...")
@@ -467,9 +508,7 @@ class SSHMasterManager:
                 logger.error(
                     f"All SSH authentication methods failed for {self.username}@{self.hostname}"
                 )
-                logger.info(
-                    "Ensure SSH keys are properly configured or provide password via:"
-                )
+                self._log_auth_failure_help()
                 logger.info("  - BTRFS_BACKUP_SSH_PASSWORD environment variable")
                 logger.info("  - Interactive prompt (when running in a terminal)")
                 logger.info("  - Install 'sshpass' for non-interactive password auth")
@@ -477,11 +516,50 @@ class SSHMasterManager:
                 logger.error(
                     f"SSH key authentication failed for {self.username}@{self.hostname}"
                 )
-                logger.info(
-                    "To enable password fallback, the connection must allow password auth"
-                )
+                self._log_auth_failure_help()
 
             return False
+
+    def _log_auth_failure_help(self) -> None:
+        """Emit actionable remediation for an SSH auth failure.
+
+        The most common failure under sudo is a passphrase-protected key whose usable
+        (decrypted) key lives only in the user's ssh-agent, which sudo cannot see because
+        it strips SSH_AUTH_SOCK. Tell the user exactly how to fix that."""
+        if self._resolved_agent_sock:
+            if self._agent_socket_had_keys:
+                logger.info(
+                    "An ssh-agent was used (%s) but did not provide a key the server "
+                    "accepted; check `ssh-add -l` and that the key is authorized on the "
+                    "server.",
+                    self._resolved_agent_sock,
+                )
+            else:
+                logger.info(
+                    "An ssh-agent was found (%s) but has NO keys loaded; run `ssh-add` to "
+                    "load your key, or point ssh_auth_sock at the agent that holds it.",
+                    self._resolved_agent_sock,
+                )
+            return
+        logger.info("No usable ssh-agent was found for %s.", self.username)
+        if self.running_as_sudo:
+            logger.info(
+                "sudo strips SSH_AUTH_SOCK, so a passphrase-protected key (whose key "
+                "lives in your agent) cannot sign. Fix with ONE of:"
+            )
+            logger.info(
+                "  - run: sudo --preserve-env=SSH_AUTH_SOCK <command>  (or sudo -E)"
+            )
+        else:
+            logger.info(
+                "  - ensure your ssh-agent is running and holds the key: "
+                "`eval $(ssh-agent)` then `ssh-add`"
+            )
+        logger.info(
+            "  - set ssh_auth_sock in the target config, export "
+            "BTRFS_BACKUP_SSH_AUTH_SOCK=$SSH_AUTH_SOCK, or pass --ssh-auth-sock"
+        )
+        logger.info("  - or use a passphrase-less key via ssh_key")
 
     def stop_master(self) -> bool:
         """Stop the SSH master connection.

--- a/tests/test_ssh_agent_discovery.py
+++ b/tests/test_ssh_agent_discovery.py
@@ -137,6 +137,13 @@ def test_falls_through_to_discovery_when_nothing_explicit(tmp_path, monkeypatch)
 # --------------------------------------------------------------------------- #
 # _find_ssh_agent_socket searches ~/.ssh/agent/ (the real-world gap)
 # --------------------------------------------------------------------------- #
+def _reachable_only_under(mgr, monkeypatch, base):
+    """Make _agent_status treat only sockets under `base` as a reachable-but-empty agent
+    (status 1) and everything else (real system sockets on the box) as dead (status 2), so
+    discovery tests are isolated from the tester's real agents."""
+    monkeypatch.setattr(mgr, "_agent_status", lambda s: 1 if str(base) in str(s) else 2)
+
+
 def test_discovery_finds_socket_in_dot_ssh_agent(tmp_path, monkeypatch):
     """A socket under <home>/.ssh/agent/ must be discovered. Mutation guard: removing the
     ~/.ssh/agent/* entry from search_paths makes this return None."""
@@ -154,9 +161,9 @@ def test_discovery_finds_socket_in_dot_ssh_agent(tmp_path, monkeypatch):
             "btrfs_backup_ng.sshutil.master.pwd.getpwuid", lambda u: _PW()
         )
         mgr = _mgr(tmp_path)
+        _reachable_only_under(mgr, monkeypatch, home)
         got = mgr._find_ssh_agent_socket(uid, {})
-        # No ssh-agent is actually serving the socket, so it is returned by the
-        # second (any-owned-socket) pass rather than the has-keys pass.
+        # The agent is reachable but has no keys, so it comes from pass 2.
         assert got == str(agent_dir / "s.abc.agent.def")
         assert mgr._agent_socket_had_keys is False  # empty-agent path recorded
     finally:
@@ -182,12 +189,34 @@ def test_discovery_skips_non_socket_files(tmp_path, monkeypatch):
             "btrfs_backup_ng.sshutil.master.pwd.getpwuid", lambda u: _PW()
         )
         mgr = _mgr(tmp_path)
-        # ~/.ssh/*.sock precedes /run/user in the search order, so the real socket here
-        # is returned before any real system agent -- and the regular file is skipped.
+        _reachable_only_under(mgr, monkeypatch, home)
         got = mgr._find_ssh_agent_socket(os.getuid(), {})
         assert got == str(ssh_dir / "z-real.sock")
     finally:
         real.close()
+
+
+def test_discovery_skips_dead_socket(tmp_path, monkeypatch):
+    """A socket whose agent is dead/unreachable (ssh-add rc 2) must NOT be chosen -- setting
+    SSH_AUTH_SOCK to a dead socket would only slow down the fall-through to password auth.
+    Mutation guard: accepting any reachability status in pass 2 returns the dead socket."""
+    home = tmp_path / "home"
+    agent_dir = home / ".ssh" / "agent"
+    agent_dir.mkdir(parents=True)
+    sock = _real_socket(agent_dir / "dead.sock")
+    try:
+
+        class _PW:
+            pw_dir = str(home)
+
+        monkeypatch.setattr(
+            "btrfs_backup_ng.sshutil.master.pwd.getpwuid", lambda u: _PW()
+        )
+        mgr = _mgr(tmp_path)
+        monkeypatch.setattr(mgr, "_agent_status", lambda s: 2)  # everything dead
+        assert mgr._find_ssh_agent_socket(os.getuid(), {}) is None
+    finally:
+        sock.close()
 
 
 def test_discovery_home_fallback_uses_env_not_root(tmp_path, monkeypatch):
@@ -205,6 +234,7 @@ def test_discovery_home_fallback_uses_env_not_root(tmp_path, monkeypatch):
 
         monkeypatch.setattr("btrfs_backup_ng.sshutil.master.pwd.getpwuid", _boom)
         mgr = _mgr(tmp_path)
+        _reachable_only_under(mgr, monkeypatch, home)
         got = mgr._find_ssh_agent_socket(os.getuid(), {"HOME": str(home)})
         assert got == str(agent_dir / "a.sock")
     finally:

--- a/tests/test_ssh_agent_discovery.py
+++ b/tests/test_ssh_agent_discovery.py
@@ -1,0 +1,283 @@
+"""SSH-agent discovery under sudo (SSHMasterManager).
+
+Backups run under sudo (btrfs send/receive need root), and sudo strips SSH_AUTH_SOCK.
+A passphrase-protected key can only sign via its ssh-agent, so if the agent socket can't
+be located the server accepts the offered public key but the client cannot sign it ->
+"Permission denied". These tests pin the discovery + override + error behavior.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+
+
+from btrfs_backup_ng.sshutil.master import SSHMasterManager
+
+
+def _mgr(tmp_path, **kw):
+    # control_dir kept in tmp so tests never touch the real ~/.ssh.
+    return SSHMasterManager(hostname="testhost", control_dir=str(tmp_path / "cm"), **kw)
+
+
+def _real_socket(path):
+    """Bind a real AF_UNIX socket at path and return it (keep a ref so it stays open)."""
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.bind(str(path))
+    return s
+
+
+# --------------------------------------------------------------------------- #
+# _owned_socket (type + ownership + symlink handling)
+# --------------------------------------------------------------------------- #
+def test_owned_socket_true_for_owned_socket(tmp_path):
+    sock = _real_socket(tmp_path / "s.sock")
+    try:
+        assert (
+            SSHMasterManager._owned_socket(
+                str(tmp_path / "s.sock"), os.getuid(), follow=False
+            )
+            is True
+        )
+    finally:
+        sock.close()
+
+
+def test_owned_socket_false_for_regular_file_missing_and_none(tmp_path):
+    f = tmp_path / "regular"
+    f.write_text("x")
+    uid = os.getuid()
+    assert SSHMasterManager._owned_socket(str(f), uid, follow=False) is False
+    assert (
+        SSHMasterManager._owned_socket(str(tmp_path / "no"), uid, follow=False) is False
+    )
+    assert SSHMasterManager._owned_socket(None, uid, follow=False) is False
+
+
+def test_owned_socket_rejects_wrong_owner(tmp_path):
+    """A socket owned by neither the target uid nor root is rejected (security gate)."""
+    sock = _real_socket(tmp_path / "s.sock")
+    try:
+        # uid nobody-ish: use a uid that is neither ours nor 0.
+        other = os.getuid() + 12345
+        assert (
+            SSHMasterManager._owned_socket(
+                str(tmp_path / "s.sock"), other, follow=False
+            )
+            is False
+        )
+    finally:
+        sock.close()
+
+
+def test_owned_socket_no_follow_rejects_symlink(tmp_path):
+    """A symlink (even to a real owned socket) is rejected in no-follow mode, closing the
+    TOCTOU/redirection class in auto-discovery. Mutation guard: switching discovery to
+    os.stat (follow) would accept the symlink and fail this."""
+    real = _real_socket(tmp_path / "real.sock")
+    link = tmp_path / "link.sock"
+    link.symlink_to(tmp_path / "real.sock")
+    try:
+        uid = os.getuid()
+        assert SSHMasterManager._owned_socket(str(link), uid, follow=False) is False
+        # ...but follow=True (a user-pinned override) accepts it via the real target.
+        assert SSHMasterManager._owned_socket(str(link), uid, follow=True) is True
+    finally:
+        real.close()
+
+
+# --------------------------------------------------------------------------- #
+# _resolve_agent_socket precedence
+# --------------------------------------------------------------------------- #
+def test_explicit_override_wins_over_env(tmp_path):
+    override = _real_socket(tmp_path / "override.sock")
+    envsock = _real_socket(tmp_path / "env.sock")
+    try:
+        mgr = _mgr(tmp_path, ssh_auth_sock=str(tmp_path / "override.sock"))
+        got = mgr._resolve_agent_socket(
+            os.getuid(), {"SSH_AUTH_SOCK": str(tmp_path / "env.sock")}
+        )
+        assert got == str(tmp_path / "override.sock")
+    finally:
+        override.close()
+        envsock.close()
+
+
+def test_invalid_override_falls_back_to_env(tmp_path):
+    envsock = _real_socket(tmp_path / "env.sock")
+    try:
+        mgr = _mgr(tmp_path, ssh_auth_sock=str(tmp_path / "does-not-exist.sock"))
+        got = mgr._resolve_agent_socket(
+            os.getuid(), {"SSH_AUTH_SOCK": str(tmp_path / "env.sock")}
+        )
+        assert got == str(tmp_path / "env.sock")
+    finally:
+        envsock.close()
+
+
+def test_preserved_env_socket_used_when_no_override(tmp_path):
+    envsock = _real_socket(tmp_path / "env.sock")
+    try:
+        mgr = _mgr(tmp_path)
+        got = mgr._resolve_agent_socket(
+            os.getuid(), {"SSH_AUTH_SOCK": str(tmp_path / "env.sock")}
+        )
+        assert got == str(tmp_path / "env.sock")
+    finally:
+        envsock.close()
+
+
+def test_falls_through_to_discovery_when_nothing_explicit(tmp_path, monkeypatch):
+    mgr = _mgr(tmp_path)
+    monkeypatch.setattr(mgr, "_find_ssh_agent_socket", lambda uid, env: "DISCOVERED")
+    got = mgr._resolve_agent_socket(os.getuid(), {})  # no override, no env
+    assert got == "DISCOVERED"
+
+
+# --------------------------------------------------------------------------- #
+# _find_ssh_agent_socket searches ~/.ssh/agent/ (the real-world gap)
+# --------------------------------------------------------------------------- #
+def test_discovery_finds_socket_in_dot_ssh_agent(tmp_path, monkeypatch):
+    """A socket under <home>/.ssh/agent/ must be discovered. Mutation guard: removing the
+    ~/.ssh/agent/* entry from search_paths makes this return None."""
+    home = tmp_path / "home"
+    agent_dir = home / ".ssh" / "agent"
+    agent_dir.mkdir(parents=True)
+    sock = _real_socket(agent_dir / "s.abc.agent.def")
+    try:
+        uid = os.getuid()
+
+        class _PW:
+            pw_dir = str(home)
+
+        monkeypatch.setattr(
+            "btrfs_backup_ng.sshutil.master.pwd.getpwuid", lambda u: _PW()
+        )
+        mgr = _mgr(tmp_path)
+        got = mgr._find_ssh_agent_socket(uid, {})
+        # No ssh-agent is actually serving the socket, so it is returned by the
+        # second (any-owned-socket) pass rather than the has-keys pass.
+        assert got == str(agent_dir / "s.abc.agent.def")
+        assert mgr._agent_socket_had_keys is False  # empty-agent path recorded
+    finally:
+        sock.close()
+
+
+def test_discovery_skips_non_socket_files(tmp_path, monkeypatch):
+    """A regular file at a search path (e.g. ~/.ssh/*.sock) must NOT be returned as an
+    agent socket. The regular file sorts BEFORE the real socket, so only the socket-type
+    check can make discovery skip it and return the real socket. Mutation guard: dropping
+    the _owned_socket type check in pass 2 returns the (earlier-sorting) regular file."""
+    home = tmp_path / "home"
+    ssh_dir = home / ".ssh"
+    ssh_dir.mkdir(parents=True)
+    (ssh_dir / "a-notasocket.sock").write_text("regular file")  # sorts first
+    real = _real_socket(ssh_dir / "z-real.sock")  # sorts after
+    try:
+
+        class _PW:
+            pw_dir = str(home)
+
+        monkeypatch.setattr(
+            "btrfs_backup_ng.sshutil.master.pwd.getpwuid", lambda u: _PW()
+        )
+        mgr = _mgr(tmp_path)
+        # ~/.ssh/*.sock precedes /run/user in the search order, so the real socket here
+        # is returned before any real system agent -- and the regular file is skipped.
+        got = mgr._find_ssh_agent_socket(os.getuid(), {})
+        assert got == str(ssh_dir / "z-real.sock")
+    finally:
+        real.close()
+
+
+def test_discovery_home_fallback_uses_env_not_root(tmp_path, monkeypatch):
+    """When pwd.getpwuid fails (containers/NSS), the home fallback must come from env HOME,
+    not os.path.expanduser('~') (which under sudo is root's home). Mutation guard: reverting
+    the fallback to os.path.expanduser makes this miss the socket."""
+    home = tmp_path / "userhome"
+    agent_dir = home / ".ssh" / "agent"
+    agent_dir.mkdir(parents=True)
+    sock = _real_socket(agent_dir / "a.sock")
+    try:
+
+        def _boom(u):
+            raise KeyError("uid not in passwd db")
+
+        monkeypatch.setattr("btrfs_backup_ng.sshutil.master.pwd.getpwuid", _boom)
+        mgr = _mgr(tmp_path)
+        got = mgr._find_ssh_agent_socket(os.getuid(), {"HOME": str(home)})
+        assert got == str(agent_dir / "a.sock")
+    finally:
+        sock.close()
+
+
+# --------------------------------------------------------------------------- #
+# BTRFS_BACKUP_SSH_AUTH_SOCK env override picked up at construction
+# --------------------------------------------------------------------------- #
+def test_env_var_sets_explicit_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("BTRFS_BACKUP_SSH_AUTH_SOCK", "/tmp/some/agent.sock")
+    mgr = _mgr(tmp_path)  # no ssh_auth_sock kwarg
+    assert mgr.ssh_auth_sock == "/tmp/some/agent.sock"
+
+
+def test_explicit_kwarg_beats_env_var(tmp_path, monkeypatch):
+    monkeypatch.setenv("BTRFS_BACKUP_SSH_AUTH_SOCK", "/tmp/from/env.sock")
+    mgr = _mgr(tmp_path, ssh_auth_sock="/tmp/from/kwarg.sock")
+    assert mgr.ssh_auth_sock == "/tmp/from/kwarg.sock"
+
+
+# --------------------------------------------------------------------------- #
+# Actionable auth-failure guidance
+# --------------------------------------------------------------------------- #
+def test_auth_failure_help_under_sudo_no_agent(tmp_path, monkeypatch):
+    """When no agent was found under sudo, the guidance must name the sudo/env fix.
+    Mutation guard: dropping the running_as_sudo branch removes the preserve-env hint."""
+    mgr = _mgr(tmp_path)
+    mgr.running_as_sudo = True
+    mgr._resolved_agent_sock = None
+    msgs = []
+    monkeypatch.setattr(
+        "btrfs_backup_ng.sshutil.master.logger.info",
+        lambda msg, *a: msgs.append(msg % a if a else msg),
+    )
+    mgr._log_auth_failure_help()
+    joined = "\n".join(msgs)
+    # The preserve-env hint appears ONLY in the running_as_sudo branch.
+    assert "preserve-env" in joined
+    assert "ssh_auth_sock" in joined
+
+
+def test_auth_failure_help_when_agent_was_used(tmp_path, monkeypatch):
+    """If an agent WAS used (with keys) but rejected, the guidance says so (points at
+    ssh-add -l), not the sudo hint. Mutation guard: ignoring _resolved_agent_sock prints
+    the wrong branch."""
+    mgr = _mgr(tmp_path)
+    mgr._resolved_agent_sock = "/run/agent.sock"
+    mgr._agent_socket_had_keys = True
+    msgs = []
+    monkeypatch.setattr(
+        "btrfs_backup_ng.sshutil.master.logger.info",
+        lambda msg, *a: msgs.append(msg % a if a else msg),
+    )
+    mgr._log_auth_failure_help()
+    joined = "\n".join(msgs)
+    assert "/run/agent.sock" in joined
+    assert "ssh-add -l" in joined
+
+
+def test_auth_failure_help_when_agent_had_no_keys(tmp_path, monkeypatch):
+    """A found-but-empty agent must produce a distinct 'no keys loaded, run ssh-add'
+    message, not the 'server rejected the key' one. Mutation guard: collapsing the
+    had_keys branch prints the wrong guidance."""
+    mgr = _mgr(tmp_path)
+    mgr._resolved_agent_sock = "/run/empty.sock"
+    mgr._agent_socket_had_keys = False
+    msgs = []
+    monkeypatch.setattr(
+        "btrfs_backup_ng.sshutil.master.logger.info",
+        lambda msg, *a: msgs.append(msg % a if a else msg),
+    )
+    mgr._log_auth_failure_help()
+    joined = "\n".join(msgs)
+    assert "NO keys loaded" in joined
+    assert "ssh-add" in joined


### PR DESCRIPTION
## What & why

Remote backups over SSH need root (btrfs send/receive), and `sudo` strips `SSH_AUTH_SOCK`. A **passphrase-protected key** can only sign via its ssh-agent — so if the agent socket can't be located, the remote server *accepts the offered public key* but the client *cannot sign it* → a confusing `Permission denied`. The tool's socket search didn't cover where many agents actually put the socket (e.g. `~/.ssh/agent/`), so remote backups failed for those users. (The `ssh_key`→identity wiring was already correct; this is purely agent-socket discovery.)

## Changes

- **Auto-discovery** now searches many more locations — `~/.ssh/agent/*`, `/tmp/ssh-*`, `/run/user/<uid>/{keyring,gcr,gnupg,ssh-agent.socket,openssh_agent}`, 1Password, Bitwarden — derives the owning user's home **from the uid** (correct under sudo, with an env-`HOME` fallback), **sorts** glob matches for determinism, and prefers a socket that actually has keys loaded.
- **Security:** every candidate / override / preserved socket is validated as a real unix socket **owned by the invoking user or root**; auto-discovery **rejects symlinks** (`lstat`) to close a TOCTOU/redirection class, so a hostile path can't make root connect to an attacker-controlled agent.
- **Precedence:** explicit `ssh_auth_sock` (new target-config option / `--ssh-auth-sock` flag / `BTRFS_BACKUP_SSH_AUTH_SOCK` env) → preserved `SSH_AUTH_SOCK` (`sudo -E`) → auto-discovery.
- **Actionable errors:** empty agent (run `ssh-add`), no agent under sudo (preserve-env / `ssh_auth_sock` / passphrase-less key), or a non-sudo agent that isn't running.
- Wired `ssh_auth_sock` through schema/loader, the SSH endpoint, and the CLI (run/transfer/estimate/restore/verify/snapper). Docs in the example config + CLI reference.

## Review & verification

- 4-lens adversarial review (correctness/security/regression/completeness): **17 findings raised → 14 confirmed after verification**, all in-scope ones fixed here (socket-type validation in both discovery passes, `pwd.getpwuid`→env-`HOME` fallback, uid-ownership on override + preserved env, sorted glob, symlink rejection, empty-agent error, more agent paths).
- **16 mutation-verified** tests (`tests/test_ssh_agent_discovery.py`); full suite green (2384 passed).
- **Proven on real hardware:** a plain `sudo btrfs-backup-ng transfer` to a remote btrfs host now connects via the auto-discovered agent (passphrase key, `SSH_AUTH_SOCK` unset); the explicit `ssh_auth_sock` override also works.

Follow-up to R3 (#45); toward the 0.9.0 reliability release. Changelog under `[Unreleased]`.