### PR TITLE
refactor(core): unify transfer planning on UUID correspondence (R4 Phase 2)

### DIFF
--- a/src/btrfs_backup_ng/core/__init__.py
+++ b/src/btrfs_backup_ng/core/__init__.py
@@ -6,7 +6,7 @@ monolithic __main__.py, organized into focused modules.
 
 from .execution import execute_parallel, run_task
 from .operations import send_snapshot, sync_snapshots
-from .planning import plan_transfers
+from .planning import plan_transfer_sequence, snapshots_present_on
 
 # Error classification and retry framework
 from .errors import (
@@ -75,7 +75,8 @@ __all__ = [
     # Operations
     "send_snapshot",
     "sync_snapshots",
-    "plan_transfers",
+    "plan_transfer_sequence",
+    "snapshots_present_on",
     "run_task",
     "execute_parallel",
     # Errors

--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -1218,33 +1218,30 @@ def sync_snapshots(
         SnapshotTransferError: if any planned snapshot failed to transfer. The
             exception carries the TransferResult as ``err.result``.
     """
-    from .planning import plan_transfers
+    from .planning import plan_transfer_sequence, snapshots_present_on
 
     logger.info(__util__.log_heading(f"  To {destination_endpoint} ..."))
 
-    # List all source snapshots
-    all_source_snapshots = source_endpoint.list_snapshots()
+    # List all source snapshots. flush_cache forces a fresh, ENRICHED enumeration (uuid /
+    # received_uuid via `subvolume show`): a stale cache populated by a prior list -- then
+    # appended to by snapshot()/add_snapshot(), which stores an UNENRICHED snapshot -- would
+    # otherwise feed empty-uuid snapshots to the correspondence-based planner/reconcile,
+    # silently degrading every transfer to a full send. The planner's identity must never
+    # depend on cache-population order.
+    source_snapshots = source_endpoint.list_snapshots(flush_cache=True)
 
-    if snapshot is None:
-        source_snapshots = all_source_snapshots
-        snapshots_to_transfer = None
-    else:
-        source_snapshots = all_source_snapshots
-        snapshots_to_transfer = [snapshot]
-
-    destination_snapshots = destination_endpoint.list_snapshots()
-
-    # Reconcile this destination's locks against reality (R3). A lock pins a source
-    # snapshot so retention cannot prune it while a transfer to this destination still
-    # needs it. Clear the lock only for snapshots CONFIRMED present on the destination --
-    # the transfer succeeded, so the lock has done its job. KEEP the lock for a snapshot
-    # not yet on the destination: a prior transfer failed or is pending and still depends
-    # on it. This is presence-based, not time-based, so a long outage can never cause a
-    # needed snapshot to be pruned.
+    # Reconcile this destination's locks against reality (R3), using the SAME presence
+    # authority as the planner (correspondence: uuid for btrfs, name for raw) so the two
+    # can never disagree. A lock pins a source snapshot so retention cannot prune it while
+    # a transfer to this destination still needs it. Clear the lock only for snapshots
+    # CONFIRMED present on the destination; KEEP it for one not yet there (a prior transfer
+    # failed/pending). Presence-based, not time-based -- a long outage never prunes a
+    # needed snapshot; and a re-created snapshot (same name, new uuid) is correctly "not
+    # present", so its lock is not cleared by a name coincidence.
+    present_names = snapshots_present_on(source_snapshots, destination_endpoint)
     destination_id = destination_endpoint.get_id()
-    destination_names = {s.get_name() for s in destination_snapshots}
     for snap in source_snapshots:
-        if snap.get_name() not in destination_names:
+        if snap.get_name() not in present_names:
             continue  # not yet on the destination -> keep any lock
         if destination_id in snap.locks:
             source_endpoint.set_lock(snap, destination_id, False)
@@ -1252,34 +1249,33 @@ def sync_snapshots(
             source_endpoint.set_lock(snap, destination_id, False, parent=True)
 
     logger.debug("Source snapshots found: %d", len(source_snapshots))
-    logger.debug("Destination snapshots found: %d", len(destination_snapshots))
 
-    # Plan transfers
-    if snapshots_to_transfer is not None:
-        to_transfer = [
-            snap for snap in snapshots_to_transfer if snap not in destination_snapshots
-        ]
-    else:
-        to_transfer = plan_transfers(
-            source_snapshots, destination_snapshots, keep_num_backups
-        )
+    # Plan: the single authority decides what to transfer, in what order, and with which
+    # (correspondence-verified) parent -- so a `send -p` is only emitted for a parent the
+    # destination actually holds.
+    plan = plan_transfer_sequence(
+        source_snapshots,
+        destination_endpoint,
+        no_incremental=no_incremental,
+        keep_num_backups=keep_num_backups,
+        only=snapshot,
+    )
 
-    if not to_transfer:
+    if not plan:
         logger.info("No snapshots need to be transferred.")
         return TransferResult()
 
-    logger.info("Going to transfer %d snapshot(s):", len(to_transfer))
-    for snap in to_transfer:
-        logger.info("  %s", snap)
+    logger.info("Going to transfer %d snapshot(s):", len(plan))
+    for snap, parent in plan:
+        logger.info(
+            "  %s%s", snap, f" (parent {parent.get_name()})" if parent else " (full)"
+        )
 
-    # Execute transfers
+    # Execute the plan (dumb executor -- no parent/ordering decisions here).
     result = _execute_transfers(
         source_endpoint,
         destination_endpoint,
-        source_snapshots,
-        destination_snapshots,
-        to_transfer,
-        no_incremental,
+        plan,
         options,
         **kwargs,
     )
@@ -1400,51 +1396,23 @@ def _cleanup_partial_raw_stream(destination_endpoint) -> None:
 def _execute_transfers(
     source_endpoint,
     destination_endpoint,
-    source_snapshots,
-    destination_snapshots,
-    to_transfer,
-    no_incremental,
+    plan,
     options,
     **kwargs,
 ) -> TransferResult:
-    """Execute the actual snapshot transfers.
+    """Execute a pre-computed transfer plan -- a dumb executor.
 
-    Returns a TransferResult recording which snapshots were verified onto the
-    destination and which failed. Locks are released and the snapshot registered
-    at the destination only for verified successes; a failed snapshot is kept
-    locked and recorded in ``result.failed`` (never silently dropped).
+    ``plan`` is a list of ``(snapshot, parent_or_None)`` pairs from
+    ``planning.plan_transfer_sequence``; ALL ordering and parent decisions were made there.
+    This function only moves bytes and manages the lock lifecycle: it locks the snapshot
+    (and its parent), sends, and on a verified success releases the locks and registers the
+    snapshot at the destination; a failed snapshot is kept locked and recorded in
+    ``result.failed`` (never silently dropped), and any partial artifact is cleaned.
     """
     destination_id = destination_endpoint.get_id()
     result = TransferResult()
 
-    while to_transfer:
-        if no_incremental:
-            best_snapshot = to_transfer[-1]
-            parent = None
-        else:
-            # Find snapshots present on destination for incremental.
-            # `snap in destination_snapshots` relies on the DESTINATION element's
-            # __eq__: for a raw target that is RawSnapshot.__eq__ (name-based),
-            # which is how a source btrfs snapshot is matched to its raw backup.
-            # Do NOT rewrite as `snap == d` -- that invokes the source Snapshot's
-            # prefix+time_obj __eq__, which never matches a raw snapshot and would
-            # silently degrade every backup-to-raw to a full send.
-            present_snapshots = [
-                snap
-                for snap in source_snapshots
-                if snap in destination_snapshots and snap.get_name() not in snap.locks
-            ]
-
-            def key(s):
-                p = s.find_parent(present_snapshots)
-                if p is None:
-                    return float("inf")
-                d = source_snapshots.index(s) - source_snapshots.index(p)
-                return -d if d < 0 else d
-
-            best_snapshot = min(to_transfer, key=key)
-            parent = best_snapshot.find_parent(present_snapshots)
-
+    for best_snapshot, parent in plan:
         # Set locks
         source_endpoint.set_lock(best_snapshot, destination_id, True)
         if parent:
@@ -1487,9 +1455,6 @@ def _execute_transfers(
                 destination_endpoint, best_snapshot.get_name()
             )
             _cleanup_partial_raw_stream(destination_endpoint)
-
-        to_transfer.remove(best_snapshot)
-        logger.debug("%d snapshots left to transfer", len(to_transfer))
 
     # Report honestly: a "complete!" banner must not print when a transfer failed.
     if result.failed:

--- a/src/btrfs_backup_ng/core/planning.py
+++ b/src/btrfs_backup_ng/core/planning.py
@@ -1,7 +1,14 @@
-"""Transfer planning and snapshot management logic.
+"""Transfer planning: decide what to transfer, in what order, and with which parent.
 
-Handles planning which snapshots need to be transferred and
-managing corrupt/locked snapshots.
+This is the single authority for the backup transfer plan. Presence on the destination and
+incremental-parent validity are decided STRICTLY by ``destination_endpoint.correspondent_of``
+-- the btrfs ``received_uuid``/``uuid`` correspondence (or name, for raw targets, where the
+override makes name the native identity), NEVER the on-disk name, which can collide (a
+re-created snapshot reuses the name but has a new uuid). There is deliberately no name-based
+fallback for btrfs: identity comes from uuids that enumeration sudo-escalates to read (see
+``Endpoint._load_subvolume_ids_into``), so a missing uuid is an enrichment problem to fix at
+the source, not a reason to dilute the planner back into name matching. The executor
+(``core.operations._execute_transfers``) only runs the plan this module produces.
 """
 
 import logging
@@ -9,87 +16,81 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def plan_transfers(
-    source_snapshots: list,
-    destination_snapshots: list,
-    keep_num_backups: int = 0,
-) -> list:
-    """Plan which snapshots need to be transferred.
+def snapshots_present_on(source_snapshots, destination_endpoint):
+    """Return the set of source-snapshot *names* already present on the destination.
+
+    Presence is decided purely by correspondence -- ``received_uuid == uuid`` for btrfs,
+    name for raw -- via the polymorphic ``correspondent_of`` (which never raises; a listing
+    failure yields None -> absent). This is the shared presence authority used by both the
+    transfer planner and the R3 lock reconcile, so the two can never disagree. A re-created
+    snapshot (same name, new uuid) is correctly absent, never a name coincidence.
+    """
+    return {
+        s.get_name()
+        for s in source_snapshots
+        if destination_endpoint.correspondent_of(s) is not None
+    }
+
+
+def plan_transfer_sequence(
+    source_snapshots,
+    destination_endpoint,
+    *,
+    no_incremental=False,
+    keep_num_backups=0,
+    only=None,
+):
+    """Build the ordered transfer plan ``[(snapshot, parent_or_None)]``.
 
     Args:
-        source_snapshots: List of snapshots at source
-        destination_snapshots: List of snapshots at destination
-        keep_num_backups: Number of backups to consider (0 = all)
+        source_snapshots: All snapshots at the source (each carrying its btrfs uuid).
+        destination_endpoint: The destination; queried via ``correspondent_of``.
+        no_incremental: If True, every snapshot is a full send (``parent=None``).
+        keep_num_backups: If > 0, only consider the latest N source snapshots.
+        only: If given, plan just this one snapshot (single-snapshot transfer mode).
 
-    Returns:
-        List of snapshots that need to be transferred
+    A snapshot whose correspondent is already present on the destination is skipped. For
+    each snapshot to transfer, the parent is the newest source snapshot OLDER than it whose
+    correspondent is present on the destination (so ``btrfs receive`` can resolve the
+    ``send -p``); if none corresponds the snapshot is sent in full. Correspondence is the
+    only presence/parent authority -- a snapshot the destination cannot verifiably resolve
+    is never used as a parent. Parents are drawn from the destination's current state (no
+    within-run chaining), matching existing run semantics.
     """
-    # Only consider the latest N snapshots if keep_num_backups > 0
-    to_consider = (
-        source_snapshots[-keep_num_backups:]
-        if keep_num_backups > 0
-        else source_snapshots
+    present = snapshots_present_on(source_snapshots, destination_endpoint)
+
+    if only is not None:
+        candidates = [only]
+    elif keep_num_backups > 0:
+        candidates = source_snapshots[-keep_num_backups:]
+    else:
+        candidates = list(source_snapshots)
+
+    to_transfer = sorted(
+        (s for s in candidates if s.get_name() not in present),
+        key=lambda s: s.time_obj,
     )
 
-    # Filter out those already at destination
-    to_transfer = [
-        snapshot for snapshot in to_consider if snapshot not in destination_snapshots
-    ]
+    plan = []
+    for snap in to_transfer:
+        parent = None
+        if not no_incremental:
+            older_newest_first = sorted(
+                (o for o in source_snapshots if o.time_obj < snap.time_obj),
+                key=lambda o: o.time_obj,
+                reverse=True,
+            )
+            for candidate in older_newest_first:
+                # A valid incremental parent must have a verified correspondent on the
+                # destination (uuid for btrfs, name for raw) -- never a bare name match.
+                if candidate.get_name() in present:
+                    parent = candidate
+                    break
+        plan.append((snap, parent))
 
-    logger.debug("Planned %d snapshots for transfer", len(to_transfer))
-    return to_transfer
-
-
-def find_best_transfer_order(
-    to_transfer: list,
-    source_snapshots: list,
-    destination_snapshots: list,
-    no_incremental: bool = False,
-) -> list[tuple]:
-    """Determine optimal order for transfers with parent selection.
-
-    For incremental transfers, we want to minimize the distance
-    between a snapshot and its parent to reduce transfer size.
-
-    Args:
-        to_transfer: Snapshots that need to be transferred
-        source_snapshots: All source snapshots
-        destination_snapshots: Snapshots already at destination
-        no_incremental: If True, don't use incremental transfers
-
-    Returns:
-        List of (snapshot, parent) tuples in optimal transfer order
-    """
-    if no_incremental:
-        # No parent needed, just return in order
-        return [(snap, None) for snap in to_transfer]
-
-    result = []
-    remaining = list(to_transfer)
-    present = set(destination_snapshots)
-
-    while remaining:
-        # Find present snapshots that can serve as parents
-        present_snapshots = [
-            snap
-            for snap in source_snapshots
-            if snap in present and snap.get_name() not in snap.locks
-        ]
-
-        def key(s):
-            p = s.find_parent(present_snapshots)
-            if p is None:
-                return float("inf")
-            d = source_snapshots.index(s) - source_snapshots.index(p)
-            return -d if d < 0 else d
-
-        best = min(remaining, key=key)
-        parent = best.find_parent(present_snapshots)
-
-        result.append((best, parent))
-        remaining.remove(best)
-
-        # After transfer, this snapshot will be present
-        present.add(best)
-
-    return result
+    logger.debug(
+        "Planned %d transfer(s) (%d incremental)",
+        len(plan),
+        sum(1 for _, p in plan if p is not None),
+    )
+    return plan

--- a/src/btrfs_backup_ng/endpoint/common.py
+++ b/src/btrfs_backup_ng/endpoint/common.py
@@ -368,18 +368,26 @@ class Endpoint:
         Runs ``btrfs subvolume show`` on each snapshot's exact path. ``show`` targets one
         path, so the identity is unambiguous even when snapshots live under a mounted
         (non-filesystem-root) subvolume -- unlike ``subvolume list``, whose id-5-relative
-        paths cannot be reliably matched back to a mount-relative absolute path. Purely
-        additive: any failure (not root, not btrfs, older btrfs-progs, command error)
-        leaves that snapshot's uuids empty and enumeration unaffected. Identity is NOT
-        changed here -- these values are carried for the Phase 2 planner, not yet
-        consulted."""
+        paths cannot be reliably matched back to a mount-relative absolute path.
+
+        ``subvolume show`` needs CAP_SYS_ADMIN to read the uuid/received_uuid, so it is
+        sudo-escalated in the SAME context the transfer path uses (``sudo -n`` when not
+        root; see the send/receive escalation and restore's parent-by-uuid lookup) --
+        otherwise a non-root run WITH passwordless sudo would send/receive fine yet read
+        empty uuids, silently degrading the planner to full sends and disabling the
+        re-created-snapshot (received_uuid) correspondence. ``-n`` keeps enumeration
+        non-interactive: with no passwordless sudo it fails fast rather than prompting.
+        Purely additive and best-effort: any failure (no sudo, not btrfs, older
+        btrfs-progs, command error) leaves that snapshot's uuids empty and enumeration
+        unaffected. The planner consumes these identities (Phase 2 correspondence)."""
         if not snapshots:
             return
+        sudo_prefix = ["sudo", "-n"] if os.geteuid() != 0 else []
         enriched = 0
         for snap in snapshots:
             try:
                 result = subprocess.run(
-                    ["btrfs", "subvolume", "show", str(snap.get_path())],
+                    [*sudo_prefix, "btrfs", "subvolume", "show", str(snap.get_path())],
                     capture_output=True,
                     text=True,
                     timeout=30,

--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -468,15 +468,14 @@ class RawEndpoint(Endpoint):
         get_name = getattr(snapshot, "get_name", None)
         if not callable(get_name):
             return None
-        name = get_name()
         try:
+            name = get_name()
             candidates = self.list_snapshots()
+            for candidate in candidates:
+                if candidate.get_name() == name:
+                    return candidate
         except Exception as e:  # noqa: BLE001 - contract: never raise; None is safe
-            logger.debug("correspondent_of: could not list snapshots (%s)", e)
-            return None
-        for candidate in candidates:
-            if candidate.get_name() == name:
-                return candidate
+            logger.debug("correspondent_of: could not resolve correspondent (%s)", e)
         return None
 
     @contextlib.contextmanager

--- a/tests/test_error_delivery.py
+++ b/tests/test_error_delivery.py
@@ -265,10 +265,7 @@ def _drive_transfers(monkeypatch, send_side_effect):
     result = ops._execute_transfers(
         source_endpoint=src,
         destination_endpoint=dest,
-        source_snapshots=[snap],
-        destination_snapshots=[],
-        to_transfer=[snap],
-        no_incremental=True,
+        plan=[(snap, None)],
         options={},
     )
     return result, headings

--- a/tests/test_r1_orchestration_contract.py
+++ b/tests/test_r1_orchestration_contract.py
@@ -16,12 +16,28 @@ import pytest
 import btrfs_backup_ng.core.operations as ops
 from btrfs_backup_ng import __util__
 
+_TIME = [0]
+
 
 def _fake_snap(name: str) -> MagicMock:
     s = MagicMock()
     s.locks = {}
     s.parent_locks = {}
     s.get_name.return_value = name
+    s.uuid = "uuid-" + name
+    s.received_uuid = ""
+    _TIME[0] += 1
+    s.time_obj = (
+        2024,
+        1,
+        _TIME[0],
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    )  # comparable, for planner ordering
     return s
 
 
@@ -32,6 +48,9 @@ def _endpoints(source_snaps, dest_snaps=()):
     dst = MagicMock()
     dst.get_id.return_value = "dest-id"
     dst.list_snapshots.return_value = list(dest_snaps)
+    # Presence via the correspondence primitive: present iff a same-named dest snap exists.
+    _dest_by_name = {s.get_name(): s for s in dest_snaps}
+    dst.correspondent_of.side_effect = lambda s: _dest_by_name.get(s.get_name())
     return src, dst
 
 
@@ -47,11 +66,50 @@ class TestExecuteTransfersResult:
 
         monkeypatch.setattr(ops, "send_snapshot", fake_send)
 
-        result = ops._execute_transfers(src, dst, [s1, s2], [], [s1, s2], True, {})
+        result = ops._execute_transfers(src, dst, [(s1, None), (s2, None)], {})
         assert result.transferred_count == 1
         assert result.failed_count == 1
         assert result.attempted == 2
         assert not result.ok
+
+    def test_parent_lock_lifecycle(self, monkeypatch):
+        """The executor locks the incremental PARENT (parent=True) before the send and
+        releases it after a verified success -- the R3 lock lifecycle that keeps retention
+        from pruning a parent a pending transfer still needs. Only covered end-to-end
+        elsewhere; this pins it directly. Mutation guard: dropping either parent set_lock
+        call fails this."""
+        parent = _fake_snap("p")
+        child = _fake_snap("c")
+        src, dst = _endpoints([parent, child])
+        monkeypatch.setattr(ops, "send_snapshot", MagicMock(return_value=None))
+
+        result = ops._execute_transfers(src, dst, [(child, parent)], {})
+
+        # Parent locked (parent=True) before send, released (parent=True) on success.
+        src.set_lock.assert_any_call(parent, "dest-id", True, parent=True)
+        src.set_lock.assert_any_call(parent, "dest-id", False, parent=True)
+        # The transferred child is locked then released.
+        src.set_lock.assert_any_call(child, "dest-id", True)
+        src.set_lock.assert_any_call(child, "dest-id", False)
+        assert result.transferred_count == 1
+
+
+class TestSourceEnrichmentOrdering:
+    def test_sync_lists_source_with_flush_for_enriched_snapshots(self, monkeypatch):
+        """sync_snapshots must enumerate the source with ``flush_cache=True`` so the
+        correspondence-based planner/reconcile always see freshly ENRICHED (uuid-carrying)
+        snapshots -- never a stale cache that a prior list + unenriched ``add_snapshot()``
+        left with empty uuids (which would silently degrade every transfer to a full send).
+        Mutation guard: a plain ``list_snapshots()`` (no flush) fails this."""
+        snap = _fake_snap("snap-1")
+        src, dst = _endpoints(
+            [snap], dest_snaps=[snap]
+        )  # present -> nothing to transfer
+        monkeypatch.setattr(ops, "send_snapshot", MagicMock(return_value=None))
+
+        ops.sync_snapshots(src, dst, snapshot=snap, no_incremental=True)
+
+        src.list_snapshots.assert_any_call(flush_cache=True)
 
 
 class TestSyncSnapshotsFailLoud:

--- a/tests/test_r2_cleanup_recovery.py
+++ b/tests/test_r2_cleanup_recovery.py
@@ -104,7 +104,7 @@ class TestExecuteTransfersCleansPartialOnFailure:
         spy = MagicMock()
         monkeypatch.setattr(ops, "_cleanup_partial_local_subvolume", spy)
 
-        ops._execute_transfers(src, dst, [snap], [], [snap], True, {})
+        ops._execute_transfers(src, dst, [(snap, None)], {})
 
         spy.assert_called_once()
         # cleanup targets the exact received name of the snapshot that failed
@@ -121,7 +121,7 @@ class TestExecuteTransfersCleansPartialOnFailure:
         spy = MagicMock()
         monkeypatch.setattr(ops, "_cleanup_partial_local_subvolume", spy)
 
-        ops._execute_transfers(src, dst, [snap], [], [snap], True, {})
+        ops._execute_transfers(src, dst, [(snap, None)], {})
         spy.assert_not_called()
 
 
@@ -239,5 +239,5 @@ class TestRawPartialCleanup:
         monkeypatch.setattr(ops, "_cleanup_partial_local_subvolume", MagicMock())
         spy = MagicMock()
         monkeypatch.setattr(ops, "_cleanup_partial_raw_stream", spy)
-        ops._execute_transfers(src, dst, [snap], [], [snap], True, {})
+        ops._execute_transfers(src, dst, [(snap, None)], {})
         spy.assert_called_once_with(dst)

--- a/tests/test_r3_lock_persistence.py
+++ b/tests/test_r3_lock_persistence.py
@@ -29,6 +29,7 @@ import pytest
 
 import btrfs_backup_ng.core.operations as ops
 from btrfs_backup_ng import __util__
+from btrfs_backup_ng.endpoint.common import Endpoint
 from btrfs_backup_ng.endpoint.local import LocalEndpoint
 
 
@@ -60,6 +61,8 @@ def _fake_snap(name, locks=None, parent_locks=None):
     s.locks = set(locks or ())
     s.parent_locks = set(parent_locks or ())
     s.get_name.return_value = name
+    s.uuid = "uuid-" + name  # truthy -> presence is decided by correspondent_of only
+    s.received_uuid = ""
     return s
 
 
@@ -70,7 +73,37 @@ def _endpoints(source_snaps, dest_snaps=()):
     dst = MagicMock()
     dst.get_id.return_value = "dest-1"
     dst.list_snapshots.return_value = list(dest_snaps)
+    # Presence via the correspondence primitive: present iff a same-named dest snap exists.
+    _dest_by_name = {s.get_name(): s for s in dest_snaps}
+    dst.correspondent_of.side_effect = lambda s: _dest_by_name.get(s.get_name())
     return src, dst
+
+
+class _FakeDest:
+    """Minimal destination test double with REAL correspondence semantics.
+
+    ``correspondent_of`` is the production ``Endpoint.correspondent_of`` bound here verbatim
+    -- so the double can never drift from the real ``received_uuid == source.uuid`` logic --
+    while the test supplies only the state (``list_snapshots``) and bookkeeping
+    (``get_id``/``add_snapshot``). This is the wired-reconcile fidelity the review asked for
+    without monkeypatching a real ``LocalEndpoint`` (whose send/receive side effects would
+    otherwise leak into the test).
+    """
+
+    correspondent_of = Endpoint.correspondent_of  # the real uuid-correspondence logic
+
+    def __init__(self, dest_snaps=(), ep_id="fake-dest"):
+        self._snaps = list(dest_snaps)
+        self._id = ep_id
+
+    def list_snapshots(self, flush_cache=False):
+        return list(self._snaps)
+
+    def get_id(self):
+        return self._id
+
+    def add_snapshot(self, snapshot, *args, **kwargs):
+        self._snaps.append(snapshot)
 
 
 # --------------------------------------------------------------------------- #
@@ -143,7 +176,7 @@ def test_reconcile_clears_lock_when_present_on_destination(monkeypatch):
     """A snapshot confirmed present on the destination has done its job -> clear the
     lock. Mutation guard: making the reconcile a no-op (never clear) fails this."""
     monkeypatch.setattr(
-        "btrfs_backup_ng.core.planning.plan_transfers", lambda *a, **k: []
+        "btrfs_backup_ng.core.planning.plan_transfer_sequence", lambda *a, **k: []
     )
     snap = _fake_snap("snap-1", locks=["dest-1"], parent_locks=["dest-1"])
     present = _fake_snap("snap-1")  # same NAME on the destination
@@ -161,7 +194,7 @@ def test_reconcile_keeps_lock_when_absent_from_destination(monkeypatch):
     unconditional blanket-clear (no presence check) clears this lock and fails the
     test."""
     monkeypatch.setattr(
-        "btrfs_backup_ng.core.planning.plan_transfers", lambda *a, **k: []
+        "btrfs_backup_ng.core.planning.plan_transfer_sequence", lambda *a, **k: []
     )
     snap = _fake_snap("snap-1", locks=["dest-1"])
     other = _fake_snap("snap-2")  # destination has a DIFFERENT snapshot
@@ -173,6 +206,87 @@ def test_reconcile_keeps_lock_when_absent_from_destination(monkeypatch):
         c for c in src.set_lock.call_args_list if c.args[:3] == (snap, "dest-1", False)
     ]
     assert clears == []
+
+
+def test_reconcile_keeps_lock_for_recreated_snapshot_via_real_correspondence(
+    monkeypatch,
+):
+    """WIRED reconcile through the REAL ``Endpoint.correspondent_of`` (received_uuid==uuid),
+    not a name fake: a re-created snapshot (same name, NEW uuid) whose destination copy is a
+    STALE same-named subvolume (received_uuid = OLD) is correctly ABSENT, so its lock is KEPT
+    -- retention cannot prune the snapshot the next real transfer still needs. Mutation guard:
+    reverting the reconcile to name-based presence clears the lock on the name coincidence and
+    fails this; the name-fake reconcile tests above structurally cannot catch that."""
+    monkeypatch.setattr(
+        "btrfs_backup_ng.core.planning.plan_transfer_sequence", lambda *a, **k: []
+    )
+    stale = MagicMock()  # destination's stale same-named copy
+    stale.get_name.return_value = "snap-1"
+    stale.received_uuid = "OLD-UUID"
+    dst = _FakeDest(dest_snaps=[stale], ep_id="dest-1")
+
+    recreated = _fake_snap("snap-1", locks=["dest-1"], parent_locks=["dest-1"])
+    recreated.uuid = "NEW-UUID"  # re-created: same name, brand-new uuid
+    src = MagicMock()
+    src.list_snapshots.return_value = [recreated]
+
+    ops.sync_snapshots(src, dst)
+
+    # Real correspondence reports ABSENT (NEW != OLD) -> the lock must NOT be cleared.
+    clears = [
+        c
+        for c in src.set_lock.call_args_list
+        if c.args[:3] == (recreated, "dest-1", False)
+    ]
+    assert clears == []
+
+
+def test_reconcile_and_planner_agree_end_to_end(monkeypatch):
+    """End-to-end ``sync_snapshots``: the reconcile and the planner share ONE presence
+    authority (``correspondent_of``), so for a mixed source they cannot disagree. The
+    uuid-present snapshot has its lock CLEARED by the reconcile (it is on the destination)
+    and is SKIPPED by the planner; the re-created snapshot (new uuid, same name as a stale
+    dest copy) is planned and transferred incrementally against the older *corresponding*
+    snapshot -- never ``send -p`` against the stale same-named dest copy. (The re-created
+    snapshot's lock-keeping across a FAILED transfer is covered in isolation above; here the
+    transfer succeeds, so its lock is released normally by the executor.)
+
+    Uses the real-semantics ``_FakeDest`` (not a monkeypatched LocalEndpoint) so the real
+    planner runs end-to-end with only ``send_snapshot`` stubbed."""
+    monkeypatch.setattr(ops, "send_snapshot", MagicMock(return_value=None))
+
+    present_copy = MagicMock()
+    present_copy.get_name.return_value = "snap-A"
+    present_copy.received_uuid = "U-PRESENT"
+    stale_copy = MagicMock()
+    stale_copy.get_name.return_value = "snap-B"
+    stale_copy.received_uuid = "OLD"
+    dst = _FakeDest(dest_snaps=[present_copy, stale_copy], ep_id="dest-1")
+
+    # snap-A truly present (uuid corresponds); snap-B re-created (new uuid vs the stale copy).
+    present = _fake_snap("snap-A", locks=["dest-1"])
+    present.uuid = "U-PRESENT"
+    present.time_obj = (2024, 1, 1, 0, 0, 0, 0, 0, 0)
+    recreated = _fake_snap("snap-B", locks=["dest-1"])
+    recreated.uuid = "NEW"
+    recreated.time_obj = (2024, 1, 2, 0, 0, 0, 0, 0, 0)
+    src = MagicMock()
+    src.list_snapshots.return_value = [present, recreated]
+
+    result = ops.sync_snapshots(src, dst)
+
+    # Reconcile CLEARS the present snapshot's lock (it is confirmed on the destination).
+    assert any(
+        c.args[:3] == (present, "dest-1", False) for c in src.set_lock.call_args_list
+    )
+    # Planner: the present snapshot is SKIPPED; only the re-created snapshot transfers,
+    # parented on the older CORRESPONDING snapshot (present), never on the stale same-named
+    # dest copy.
+    assert result.transferred_count == 1
+    sent = ops.send_snapshot.call_args_list
+    assert len(sent) == 1
+    assert sent[0].args[0] is recreated
+    assert sent[0].kwargs.get("parent") is present
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_r4_phase0_uuid_identity.py
+++ b/tests/test_r4_phase0_uuid_identity.py
@@ -4,8 +4,10 @@ Phase 0 is strictly NON-behavioral: it only ENRICHES snapshot objects with the b
 ``uuid`` and ``received_uuid`` at enumeration -- local endpoints via ``btrfs subvolume
 show`` per snapshot (mount-safe, unambiguous), ssh endpoints from each ``subvolume list
 -o -u -R`` line. Identity (`__eq__` / `__lt__` / `find_parent`) is unchanged and nothing
-consults the new fields yet -- that is Phase 2. Population is best-effort: any failure
-(non-root, non-btrfs, older btrfs-progs) leaves the uuids empty and enumeration working.
+consults the new fields yet -- that is Phase 2. ``subvolume show`` is sudo-escalated
+(``sudo -n`` when not root) so a non-root+passwordless-sudo run populates uuids like the
+transfer path; population stays best-effort: any failure (no sudo, non-btrfs, older
+btrfs-progs) leaves the uuids empty and enumeration working.
 """
 
 from __future__ import annotations
@@ -135,6 +137,49 @@ def test_enrichment_uses_subvolume_show_per_snapshot(tmp_path, monkeypatch):
     assert by["home-20240102-000000"].received_uuid == (
         "cccccccc-cccc-cccc-cccc-cccccccccccc"
     )
+
+
+def test_enrichment_sudo_escalates_when_not_root(tmp_path, monkeypatch):
+    """``subvolume show`` needs CAP_SYS_ADMIN, so a NON-root enumeration must sudo-escalate
+    (``sudo -n``) exactly like the transfer path -- otherwise a non-root run WITH passwordless
+    sudo backs up fine yet reads empty uuids, silently degrading the planner. Mutation guard:
+    dropping the escalation leaves the bare ``btrfs`` argv and fails this."""
+    ep = _local(tmp_path)
+    snaps = _named_snaps(ep, tmp_path)
+    captured = []
+
+    def fake_run(argv, *a, **k):
+        captured.append(list(argv))
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("btrfs_backup_ng.endpoint.common.os.geteuid", lambda: 1000)
+    monkeypatch.setattr("btrfs_backup_ng.endpoint.common.subprocess.run", fake_run)
+    ep._load_subvolume_ids_into(snaps)
+
+    assert captured, "enrichment ran no commands"
+    for argv in captured:
+        assert argv[:3] == ["sudo", "-n", "btrfs"], argv
+        assert argv[3:5] == ["subvolume", "show"]
+
+
+def test_enrichment_no_sudo_when_root(tmp_path, monkeypatch):
+    """When already root, enrichment runs ``btrfs`` directly -- no needless sudo. Mutation
+    guard: unconditionally prepending sudo fails this."""
+    ep = _local(tmp_path)
+    snaps = _named_snaps(ep, tmp_path)
+    captured = []
+
+    def fake_run(argv, *a, **k):
+        captured.append(list(argv))
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("btrfs_backup_ng.endpoint.common.os.geteuid", lambda: 0)
+    monkeypatch.setattr("btrfs_backup_ng.endpoint.common.subprocess.run", fake_run)
+    ep._load_subvolume_ids_into(snaps)
+
+    assert captured, "enrichment ran no commands"
+    for argv in captured:
+        assert argv[0] == "btrfs" and "sudo" not in argv, argv
 
 
 def test_parse_subvolume_show_uuid_and_received():

--- a/tests/test_r4_phase1_correspondence.py
+++ b/tests/test_r4_phase1_correspondence.py
@@ -191,6 +191,22 @@ def test_raw_correspondent_returns_none_when_list_snapshots_raises(
     assert raw.correspondent_of(source) is None
 
 
+def test_raw_correspondent_returns_none_when_get_name_raises(tmp_path):
+    """The never-raises contract also covers a callable ``get_name`` that itself raises
+    (malformed time tuple, etc.) -- it is inside the try, not before it. Mutation guard:
+    moving ``get_name()`` back outside the try lets the exception escape and fails this."""
+    from btrfs_backup_ng.endpoint.raw import RawEndpoint
+
+    raw = RawEndpoint(config={"path": str(tmp_path)})
+    raw.list_snapshots = lambda flush_cache=False: []  # type: ignore[method-assign]
+
+    class _BadName:
+        def get_name(self):
+            raise ValueError("malformed time tuple")
+
+    assert raw.correspondent_of(_BadName()) is None
+
+
 def test_correspondent_none_for_arg_without_identity(tmp_path, monkeypatch):
     """An arg with no uuid attr (btrfs) or no get_name (raw) yields None, not AttributeError.
     Mutation guard: dropping the getattr guards raises."""
@@ -220,14 +236,16 @@ def test_polymorphism_btrfs_uses_base_raw_overrides():
     assert SSHRawEndpoint.correspondent_of is RawEndpoint.correspondent_of
 
 
-def test_phase1_is_non_behavioral_not_wired_into_planner_or_restore():
-    """Phase 1 only ADDS the primitive; the planner and restore adopt it in P2/P3.
-    Mutation guard: wiring correspondent_of into these modules now fails this."""
-    import btrfs_backup_ng.core.operations as ops
+def test_phase_boundary_planner_wired_restore_not_yet():
+    """Phase 2 wires the backup planner onto correspondent_of; restore is converged in
+    Phase 3, not before. This guards the phase boundary -- a still-name-based restore is
+    expected until P3."""
     import btrfs_backup_ng.core.planning as planning
     import btrfs_backup_ng.core.restore as restore
 
-    for mod in (ops, planning, restore):
-        assert "correspondent_of" not in inspect.getsource(mod), (
-            f"{mod.__name__} references correspondent_of; Phase 1 must stay non-behavioral"
-        )
+    assert "correspondent_of" in inspect.getsource(planning), (
+        "P2 should wire the planner onto correspondent_of"
+    )
+    assert "correspondent_of" not in inspect.getsource(restore), (
+        "restore converges onto correspondent_of in Phase 3, not now"
+    )

--- a/tests/test_r4_phase2_planner.py
+++ b/tests/test_r4_phase2_planner.py
@@ -1,0 +1,292 @@
+"""R4 Phase 2: the single UUID-first TransferPlanner.
+
+``plan_transfer_sequence`` is the sole authority for what to transfer, in what order, and
+with which parent -- decided via ``correspondent_of`` (uuid for btrfs, name for raw), so a
+``send -p`` is only ever emitted for a parent the destination actually holds. A re-created
+snapshot (same name, new uuid) is therefore correctly "not present" and sent in full,
+instead of being matched to a stale same-named copy.
+"""
+
+from __future__ import annotations
+
+import time
+
+from btrfs_backup_ng import __util__
+from btrfs_backup_ng.core.planning import plan_transfer_sequence, snapshots_present_on
+from btrfs_backup_ng.endpoint.local import LocalEndpoint
+
+
+def _snap(stamp, uuid="", received_uuid=""):
+    s = __util__.Snapshot(
+        "/snaps",
+        "home-",
+        None,
+        time_obj=time.strptime(stamp, "%Y%m%d-%H%M%S"),
+        time_format="%Y%m%d-%H%M%S",
+    )
+    s.uuid = uuid
+    s.received_uuid = received_uuid
+    return s
+
+
+def _dest(tmp_path, dest_snaps):
+    """A real btrfs (Local) destination endpoint whose listing we control, so the real
+    Endpoint.correspondent_of (received_uuid == source.uuid) drives the planner."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    ep = LocalEndpoint(
+        config={
+            "path": tmp_path,
+            "source": None,
+            "snapshot_folder": ".snapshots",
+            "snap_prefix": "home-",
+        }
+    )
+    ep.list_snapshots = lambda flush_cache=False: list(dest_snaps)  # type: ignore[method-assign]
+    return ep
+
+
+# --------------------------------------------------------------------------- #
+# Skip detection + parent selection by correspondence
+# --------------------------------------------------------------------------- #
+def test_absent_snapshot_is_planned_present_is_skipped(tmp_path):
+    s1 = _snap("20240101-000000", uuid="U1")
+    s2 = _snap("20240102-000000", uuid="U2")
+    # dest holds the received copy of s1 (received_uuid == s1.uuid), not s2.
+    dcopy1 = _snap("20240101-000000", uuid="Dx", received_uuid="U1")
+    dest = _dest(tmp_path, [dcopy1])
+
+    plan = plan_transfer_sequence([s1, s2], dest)
+    # s1 present -> skipped; s2 absent -> planned, with s1 (corresponding) as parent.
+    assert len(plan) == 1
+    assert plan[0][0] is s2
+    assert plan[0][1] is s1
+
+
+def test_parent_is_newest_older_corresponding_source(tmp_path):
+    s1 = _snap("20240101-000000", uuid="U1")
+    s2 = _snap("20240102-000000", uuid="U2")
+    s3 = _snap("20240103-000000", uuid="U3")
+    # dest holds copies of s1 AND s2.
+    dest = _dest(
+        tmp_path,
+        [
+            _snap("20240101-000000", uuid="Da", received_uuid="U1"),
+            _snap("20240102-000000", uuid="Db", received_uuid="U2"),
+        ],
+    )
+    plan = plan_transfer_sequence([s1, s2, s3], dest)
+    # only s3 to transfer; parent = s2 (newest older corresponding), NOT s1.
+    assert [s.get_name() for s, _ in plan] == ["home-20240103-000000"]
+    assert plan[0][1] is s2
+
+
+def test_full_send_when_no_older_corresponding_parent(tmp_path):
+    """Dropped reverse-parent heuristic: if no OLDER corresponding parent exists, full-send
+    (parent=None) -- even when a NEWER corresponding snapshot is on the destination.
+    Mutation guard: restoring the oldest-present fallback assigns the newer snap as parent."""
+    s_old = _snap("20240101-000000", uuid="U-OLD")
+    s_new = _snap("20240103-000000", uuid="U-NEW")
+    # dest only holds the NEWER snapshot's copy.
+    dest = _dest(tmp_path, [_snap("20240103-000000", uuid="Dn", received_uuid="U-NEW")])
+    plan = plan_transfer_sequence([s_old, s_new], dest)
+    # s_new is present (skipped); s_old is absent with no older corresponding parent -> full.
+    assert [s.get_name() for s, _ in plan] == ["home-20240101-000000"]
+    assert plan[0][1] is None
+
+
+def test_recreated_snapshot_same_name_new_uuid_full_send(tmp_path):
+    """THE R4 WIN (presence): a re-created source snapshot (same name, new uuid) is NOT
+    present -- its uuid does not correspond to the dest's stale same-named copy -- so it is
+    planned (not silently skipped). With no older snapshot it is a clean FULL send. Mutation
+    guard: name-based presence would skip it. (The parent clause is guarded separately, in
+    test_recreated_snapshot_parents_on_older_corresponding_not_stale_copy.)"""
+    recreated = _snap("20240101-000000", uuid="NEW-UUID")
+    stale_copy = _snap("20240101-000000", uuid="Dx", received_uuid="OLD-UUID")
+    dest = _dest(tmp_path, [stale_copy])
+    plan = plan_transfer_sequence([recreated], dest)
+    assert len(plan) == 1
+    assert plan[0][0] is recreated
+    assert plan[0][1] is None  # full send, NOT send -p against the stale copy
+
+
+def test_parent_skips_name_present_but_noncorresponding_older_snapshot(tmp_path):
+    """Parent selection is by CORRESPONDENCE, not name: an older snapshot that is present on
+    the destination BY NAME but whose dest copy does NOT correspond (received_uuid differs --
+    e.g. it too was re-created) is NOT a valid ``send -p`` parent and must be skipped in favor
+    of an older snapshot that truly corresponds. Mutation guard: a name-based parent wrongly
+    picks the non-corresponding s_mid (its unresolvable ``send -p`` would fail on receive)."""
+    s_oldest = _snap("20240101-000000", uuid="U-OLDEST")  # corresponds on dest
+    s_mid = _snap(
+        "20240102-000000", uuid="U-MID-NEW"
+    )  # name on dest, but NON-corresponding
+    newest = _snap("20240103-000000", uuid="U-NEW")  # absent -> to transfer
+    dest = _dest(
+        tmp_path,
+        [
+            _snap(
+                "20240101-000000", uuid="Da", received_uuid="U-OLDEST"
+            ),  # corresponds
+            _snap(
+                "20240102-000000", uuid="Db", received_uuid="U-MID-OLD"
+            ),  # NON-matching
+        ],
+    )
+    plan = plan_transfer_sequence([s_oldest, s_mid, newest], dest)
+    # s_oldest present (skipped); s_mid absent (U-MID-NEW != U-MID-OLD) and newest absent.
+    # newest's parent must be s_oldest (verified) -- NEVER the newer name-present-but-
+    # non-corresponding s_mid, whose send -p the destination could not resolve.
+    by = {s.get_name(): p for s, p in plan}
+    assert set(by) == {"home-20240102-000000", "home-20240103-000000"}
+    assert (
+        by["home-20240103-000000"] is s_oldest
+    )  # skipped s_mid (name-only), used s_oldest
+    assert by["home-20240102-000000"] is s_oldest  # s_mid parents on s_oldest too
+
+
+# --------------------------------------------------------------------------- #
+# Fallbacks: no_incremental, unknown uuid, empty
+# --------------------------------------------------------------------------- #
+def test_no_incremental_forces_full_sends(tmp_path):
+    s1 = _snap("20240101-000000", uuid="U1")
+    s2 = _snap("20240102-000000", uuid="U2")
+    dest = _dest(tmp_path, [_snap("20240101-000000", uuid="Da", received_uuid="U1")])
+    plan = plan_transfer_sequence([s1, s2], dest, no_incremental=True)
+    assert [s.get_name() for s, _ in plan] == ["home-20240102-000000"]
+    assert plan[0][1] is None  # no parent despite s1 corresponding
+
+
+def test_empty_uuid_source_is_not_present_and_planned_full(tmp_path):
+    """NO name fallback (R4 purity): a source snapshot whose uuid is unknown cannot be
+    verified present -- correspondent_of returns None for an empty uuid -- so it is planned
+    as a FULL send, never skipped by a name coincidence and never given an unverifiable
+    incremental parent. An empty uuid is an enrichment problem to fix at the source
+    (sudo-escalated `subvolume show`), not a reason to dilute the planner into name matching.
+    Mutation guard: any name-based presence/parent fallback re-skips these."""
+    s1 = _snap("20240101-000000", uuid="")  # unknown identity
+    s2 = _snap("20240102-000000", uuid="")
+    # The dest even lists a SAME-NAMED snapshot for s1: a name fallback would (wrongly) skip
+    # it. Pure correspondence does not.
+    dest = _dest(
+        tmp_path, [_snap("20240101-000000", uuid="Dz", received_uuid="anything")]
+    )
+    present = snapshots_present_on([s1, s2], dest)
+    assert present == set()  # strictly correspondence; no name fallback
+    plan = plan_transfer_sequence([s1, s2], dest)
+    assert [s.get_name() for s, _ in plan] == [
+        "home-20240101-000000",
+        "home-20240102-000000",
+    ]
+    assert all(p is None for _, p in plan)  # no name-based parent
+
+
+def test_ordering_is_oldest_first(tmp_path):
+    s3 = _snap("20240103-000000", uuid="U3")
+    s1 = _snap("20240101-000000", uuid="U1")
+    s2 = _snap("20240102-000000", uuid="U2")
+    dest = _dest(tmp_path, [])  # empty -> all full sends
+    plan = plan_transfer_sequence([s3, s1, s2], dest)
+    assert [s.get_name() for s, _ in plan] == [
+        "home-20240101-000000",
+        "home-20240102-000000",
+        "home-20240103-000000",
+    ]
+    assert all(p is None for _, p in plan)
+
+
+def test_only_single_snapshot_mode(tmp_path):
+    s1 = _snap("20240101-000000", uuid="U1")
+    s2 = _snap("20240102-000000", uuid="U2")
+    dest = _dest(tmp_path, [_snap("20240101-000000", uuid="Da", received_uuid="U1")])
+    plan = plan_transfer_sequence([s1, s2], dest, only=s2)
+    assert [s.get_name() for s, _ in plan] == ["home-20240102-000000"]
+    assert plan[0][1] is s1  # incremental against the corresponding s1
+
+
+def test_keep_num_backups_limits_candidates(tmp_path):
+    snaps = [_snap(f"2024010{i}-000000", uuid=f"U{i}") for i in range(1, 5)]
+    dest = _dest(tmp_path, [])
+    plan = plan_transfer_sequence(snaps, dest, keep_num_backups=2)
+    # only the latest 2 considered.
+    assert [s.get_name() for s, _ in plan] == [
+        "home-20240103-000000",
+        "home-20240104-000000",
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# snapshots_present_on (shared presence authority)
+# --------------------------------------------------------------------------- #
+def test_snapshots_present_on_is_pure_correspondence(tmp_path):
+    """Presence is strictly received_uuid==uuid (btrfs), never name. A same-named dest
+    snapshot whose received_uuid does not match, and an empty-uuid source, are both ABSENT.
+    Mutation guard: a name fallback would mark the empty-uuid or wrong-received_uuid ones
+    present."""
+    s_corresponds = _snap("20240101-000000", uuid="U1")
+    s_empty_uuid = _snap(
+        "20240102-000000", uuid=""
+    )  # unknown -> absent despite name match
+    s_wrong_recv = _snap(
+        "20240103-000000", uuid="U3"
+    )  # dest same name, non-matching recv
+    dest = _dest(
+        tmp_path,
+        [
+            _snap("20240101-000000", uuid="Da", received_uuid="U1"),
+            _snap("20240102-000000", uuid="Db", received_uuid="X"),
+            _snap("20240103-000000", uuid="Dc", received_uuid="OTHER"),
+        ],
+    )
+    present = snapshots_present_on([s_corresponds, s_empty_uuid, s_wrong_recv], dest)
+    assert present == {"home-20240101-000000"}  # only the true uuid correspondent
+
+
+# --------------------------------------------------------------------------- #
+# Raw destination: correspondence is name-based (polymorphic dispatch)
+# --------------------------------------------------------------------------- #
+def test_raw_destination_planner_uses_name_correspondence(tmp_path):
+    """Against a RAW target, correspondent_of is name semantics (a raw stream has no
+    received_uuid), so the planner skips a same-named backup and picks an older same-named
+    backup as the incremental parent -- even though the source and raw-backup uuids differ.
+    Exercises the polymorphic dispatch the planner relies on for raw (the btrfs LocalEndpoint
+    tests can never cover this name path)."""
+    from btrfs_backup_ng.endpoint.raw import RawEndpoint
+    from btrfs_backup_ng.endpoint.raw_metadata import RawSnapshot
+
+    raw = RawEndpoint(config={"path": str(tmp_path)})
+    backup1 = RawSnapshot(
+        name="home-20240101-000000",
+        stream_path=tmp_path / "home-20240101-000000.btrfs",
+        uuid="RAW1",
+    )
+    raw.list_snapshots = lambda flush_cache=False: [backup1]  # type: ignore[method-assign]
+
+    s1 = _snap(
+        "20240101-000000", uuid="SRC1"
+    )  # different uuid, same name -> present by name
+    s2 = _snap("20240102-000000", uuid="SRC2")  # absent -> planned
+    present = snapshots_present_on([s1, s2], raw)
+    assert present == {"home-20240101-000000"}  # name correspondence, uuid ignored
+    plan = plan_transfer_sequence([s1, s2], raw)
+    assert [s.get_name() for s, _ in plan] == ["home-20240102-000000"]
+    assert (
+        plan[0][1] is s1
+    )  # incremental parent = s1 by raw name correspondence, not None
+
+
+def test_presence_and_plan_survive_destination_listing_failure(tmp_path):
+    """correspondent_of never raises: a destination whose list_snapshots raises yields None
+    (absent), so snapshots_present_on returns an empty set and the planner produces a
+    full-send plan -- never a crash and never a silent skip. Mutation guard: letting the
+    listing exception propagate fails this."""
+    s1 = _snap("20240101-000000", uuid="U1")
+    dest = _dest(tmp_path, [])
+
+    def boom(flush_cache=False):
+        raise RuntimeError("transient listing failure")
+
+    dest.list_snapshots = boom  # type: ignore[method-assign]
+    present = snapshots_present_on([s1], dest)
+    assert present == set()
+    plan = plan_transfer_sequence([s1], dest)
+    assert [s.get_name() for s, _ in plan] == ["home-20240101-000000"]
+    assert plan[0][1] is None


### PR DESCRIPTION
## What
Phase 2 of the R4 architectural reset: collapse the divergent parent-selection authorities and name-based identity into one UUID-first planner built on the Phase 1 `correspondent_of` primitive — and fix the enrichment root cause that made UUIDs go missing under non-root.

## Why
Name-based identity collides: a re-created snapshot reuses the on-disk name but has a new btrfs uuid. The old logic could skip it as "already present" (silent divergence) or emit a `send -p` against a parent the destination could not resolve. `btrfs receive` resolves incrementals by `received_uuid == source.uuid`, so presence and parent are now decided by that correspondence — with **no name-based fallback** to reintroduce the collision.

## How
- **`plan_transfer_sequence`** — the single ordered `[(snapshot, parent_or_None)]` authority. Skip = correspondent present. Parent = newest older source snapshot whose correspondent is present on the destination; else full send. Strictly `correspondent_of`; the name-fallback hack is deleted.
- **`snapshots_present_on`** — shared presence authority; the R3 lock reconcile uses it too, so reconcile and planner can never disagree.
- **`_execute_transfers`** — dumb executor: only moves bytes + manages the lock lifecycle. `sync_snapshots` enumerates the source with `flush_cache=True` so the planner always sees freshly enriched snapshots regardless of cache-population order.
- **`_load_subvolume_ids_into` (root cause)** — sudo-escalates `btrfs subvolume show` (`sudo -n` when not root), matching the transfer path, so non-root+passwordless-sudo runs read populated uuids and keep verified incrementals + the re-created-snapshot correspondence.
- **`raw.correspondent_of`** — `get_name()` moved inside the try to honor its never-raises contract.
- Reverse-parent heuristic dropped; dead `plan_transfers` / `find_best_transfer_order` removed.

## Verification
- **Unit:** new `tests/test_r4_phase2_planner.py` + updated R0/R1/R2/R3/R4 suites; full suite **2429 passed, 1 skipped**. ruff (0.15.22) + mypy clean.
- **Mutation (Edit-only, never git-checkout):** 7 mutations, each caught — drop enrichment escalation; name-based presence (→ 6 tests incl. both wired reconcile tests); name-based parent (→ 7 tests incl. raw-dest + the non-corresponding-older guard); `get_name()` outside try; revert flush guard; drop parent-lock; name-based parent vs the non-corresponding-older test.
- **Hardware — non-root + sudo:** bare `subvolume show` fails "Operation not permitted"; escalated enrichment populates **every** UUID (euid=1000).
- **Hardware — real btrfs (local):** full; incremental `send -p`; idempotent skip; re-created snapshot (same name, new uuid) → not present, planned, never matched to the stale copy; broken chain → full-send fallback; all applied and `received_uuid`-verified.
- **Hardware — real ssh transport:** full, incremental `send -p`, idempotent, and the re-created-snapshot win, with remote `received_uuid` enrichment.
- **Adversarial review:** full 4-lens review + a focused re-review of the fix delta; every finding verified. No real code defects; the reviewer's low-risk closures (source-enrichment ordering guard, parent-lock unit test, sharpened recreated-parent test) are applied.

## Deferred (tracked follow-ups, non-blocking)
- Optional single upfront `sudo -n` probe in enrichment to avoid per-snapshot auth-log noise on hosts without passwordless sudo.
- An only-mode planner test using an empty-uuid target.
