### PR TITLE
refactor(restore): select restore parent via correspondent_of (R4 Phase 3a)

### DIFF
--- a/src/btrfs_backup_ng/core/restore.py
+++ b/src/btrfs_backup_ng/core/restore.py
@@ -490,12 +490,12 @@ def restore_snapshots(
     if dry_run:
         logger.info("Dry run - no changes made")
         for i, snap in enumerate(to_restore, 1):
-            # Try UUID-based parent detection first
-            parent, _local_match = find_parent_by_uuid(
+            # Correspondence-based parent (received_uuid for btrfs, name for raw)
+            parent, _local_match = find_parent_by_correspondence(
                 backup_snapshots, local_snapshots, snap, backup_endpoint
             )
             if not parent:
-                # Fall back to traditional parent finding
+                # Degrade to time-based parent finding when no correspondent exists
                 parent = snap.find_parent(
                     [s for s in to_restore if s != snap] + local_snapshots
                 )
@@ -525,14 +525,14 @@ def restore_snapshots(
         # Then fall back to name/time-based matching
         parent = None
         if not no_incremental:
-            # Try UUID-based parent detection first
-            parent, _local_match = find_parent_by_uuid(
+            # Correspondence-based parent (received_uuid for btrfs, name for raw)
+            parent, _local_match = find_parent_by_correspondence(
                 backup_snapshots, restored_snapshots, snap, backup_endpoint
             )
             if parent:
-                logger.debug("Found UUID-matched parent: %s", parent.get_name())
+                logger.debug("Found corresponding parent: %s", parent.get_name())
             else:
-                # Fall back to traditional parent finding
+                # Degrade to time-based parent finding when no correspondent exists
                 parent = snap.find_parent(restored_snapshots)
                 if parent:
                     logger.debug("Found time-based parent: %s", parent.get_name())
@@ -623,92 +623,62 @@ def list_remote_snapshots(
     return snapshots
 
 
-def find_parent_by_uuid(
+def find_parent_by_correspondence(
     backup_snapshots: list,
     local_snapshots: list,
     target_backup,
     backup_endpoint,
 ) -> tuple:
-    """Find a parent backup whose Received UUID matches a local snapshot's UUID.
+    """Find a backup to use as the incremental parent for restoring ``target_backup``.
 
-    For btrfs incremental send/receive to work across filesystems:
-    1. The backup's "Received UUID" must match a local snapshot's UUID
-    2. We use -p with the backup that has this matching Received UUID
+    A valid restore parent must be present on BOTH sides: on the backup side (its path feeds
+    ``btrfs send -p``) AND locally (so ``btrfs receive`` can apply the diff onto it). That is
+    exactly ``backup_endpoint.correspondent_of(local_snap)`` -- the ONE polymorphic
+    correspondence primitive the backup planner uses (R4): ``received_uuid == uuid`` for
+    btrfs, name for raw. So restore no longer re-implements uuid matching with its own
+    ``btrfs subvolume show`` parsing (which blocked on a password via bare ``sudo`` and, on a
+    raw target, silently failed because a stream file is not a subvolume -- forcing raw
+    restore onto the time-based fallback). Correspondence gives btrfs restore the identical
+    result (Phase 1 proved the equivalence) and raw restore proper name correspondence.
 
     Args:
-        backup_snapshots: All snapshots at backup location
-        local_snapshots: Snapshots that exist locally
-        target_backup: The backup we want to restore
-        backup_endpoint: Endpoint where backups are stored
+        backup_snapshots: All snapshots at the backup location.
+        local_snapshots: Snapshots that exist locally (already-restored copies).
+        target_backup: The backup being restored (never its own parent).
+        backup_endpoint: Endpoint where backups are stored; queried via correspondent_of.
 
     Returns:
-        Tuple of (parent_backup, matching_local_snapshot) or (None, None)
+        Tuple of (parent_backup, matching_local_snapshot) or (None, None). Never raises
+        (the correspondent_of contract). When None, the caller degrades to the time-based
+        ``Snapshot.find_parent`` fallback.
     """
-    import subprocess
+    # A backup is a valid parent iff a local snapshot corresponds to it (present on both
+    # sides). Map each locally-present backup (by name) to its local correspondent.
+    local_by_backup_name: dict = {}
+    for local_snap in local_snapshots:
+        backup = backup_endpoint.correspondent_of(local_snap)
+        if backup is not None:
+            local_by_backup_name[backup.get_name()] = local_snap
 
-    backup_path = Path(backup_endpoint.config["path"])
-
-    # Build map of local UUID -> snapshot
-    local_uuid_map = {}
-    for snap in local_snapshots:
-        try:
-            result = subprocess.run(
-                ["sudo", "btrfs", "subvolume", "show", str(snap.get_path())],
-                capture_output=True,
-                text=True,
-                check=True,
-            )
-            for line in result.stdout.split("\n"):
-                if (
-                    "UUID:" in line
-                    and "Parent UUID" not in line
-                    and "Received UUID" not in line
-                ):
-                    uuid_val = line.split(":")[1].strip()
-                    if uuid_val and uuid_val != "-":
-                        local_uuid_map[uuid_val] = snap
-                    break
-        except Exception:
-            continue
-
-    if not local_uuid_map:
-        logger.debug("No local UUIDs found for parent matching")
+    if not local_by_backup_name:
+        logger.debug(
+            "No corresponding local snapshot found for restore parent matching"
+        )
         return None, None
 
-    # Find a backup whose Received UUID matches a local snapshot's UUID
+    # Preserve the prior selection order: the first backup (in backup_snapshots order,
+    # excluding the target) that is present locally becomes the incremental parent.
     for backup in backup_snapshots:
         if backup == target_backup:
             continue
-
-        backup_snap_path = backup_path / backup.get_name()
-        try:
-            result = subprocess.run(
-                ["sudo", "btrfs", "subvolume", "show", str(backup_snap_path)],
-                capture_output=True,
-                text=True,
-                check=True,
+        local_match = local_by_backup_name.get(backup.get_name())
+        if local_match is not None:
+            logger.debug(
+                "Restore parent by correspondence: backup %s <-> local %s",
+                backup.get_name(),
+                local_match.get_name(),
             )
-            received_uuid = None
-            for line in result.stdout.split("\n"):
-                if "Received UUID:" in line:
-                    received_uuid = line.split(":")[1].strip()
-                    break
-
-            if (
-                received_uuid
-                and received_uuid != "-"
-                and received_uuid in local_uuid_map
-            ):
-                local_snap = local_uuid_map[received_uuid]
-                logger.debug(
-                    "Found UUID match: backup %s (Received UUID %s) matches local %s",
-                    backup.get_name(),
-                    received_uuid,
-                    local_snap.get_name(),
-                )
-                return backup, local_snap
-        except Exception:
-            continue
+            return backup, local_match
 
     return None, None
 

--- a/tests/test_native_restore_lock.py
+++ b/tests/test_native_restore_lock.py
@@ -145,7 +145,7 @@ def test_incremental_parent_is_the_backup_side_snapshot(monkeypatch):
 
     # Force the name/time fallback parent path (the one that picked a local snapshot).
     monkeypatch.setattr(
-        restore_mod, "find_parent_by_uuid", lambda *a, **k: (None, None)
+        restore_mod, "find_parent_by_correspondence", lambda *a, **k: (None, None)
     )
 
     captured = {}

--- a/tests/test_r4_phase1_correspondence.py
+++ b/tests/test_r4_phase1_correspondence.py
@@ -114,14 +114,15 @@ def test_correspondent_none_when_no_match(tmp_path, monkeypatch):
 
 
 # --------------------------------------------------------------------------- #
-# Restore direction (backup_ep.correspondent_of(local)) == find_parent_by_uuid relation
+# Restore direction: backup_ep.correspondent_of(local) is the restore-parent relation
 # --------------------------------------------------------------------------- #
-def test_correspondent_restore_direction_matches_find_parent_by_uuid(
+def test_correspondent_restore_direction_finds_backup_by_received_uuid(
     tmp_path, monkeypatch
 ):
-    """restore's find_parent_by_uuid returns the backup whose received_uuid == a local
-    snapshot's uuid. That relation is exactly ``backup_ep.correspondent_of(local)``.
-    Mutation guard: any direction/field change breaks this equivalence."""
+    """Restore's parent selection (P3a find_parent_by_correspondence) needs the backup whose
+    received_uuid == a local snapshot's uuid. That relation is exactly
+    ``backup_ep.correspondent_of(local)``. Mutation guard: any direction/field change breaks
+    this equivalence."""
     backup_ep = _local(tmp_path)
     b_match = _snap(
         backup_ep, tmp_path, "20240101-000000", uuid="B1", received_uuid="LOCAL-UUID"
@@ -236,16 +237,21 @@ def test_polymorphism_btrfs_uses_base_raw_overrides():
     assert SSHRawEndpoint.correspondent_of is RawEndpoint.correspondent_of
 
 
-def test_phase_boundary_planner_wired_restore_not_yet():
-    """Phase 2 wires the backup planner onto correspondent_of; restore is converged in
-    Phase 3, not before. This guards the phase boundary -- a still-name-based restore is
-    expected until P3."""
+def test_planner_and_restore_both_wired_onto_correspondent_of():
+    """Phase 2 wired the backup planner onto correspondent_of; Phase 3a converges restore's
+    incremental-parent selection onto the SAME primitive (find_parent_by_correspondence).
+    Both now route through the one correspondence authority -- no more bespoke uuid parsing
+    in restore."""
     import btrfs_backup_ng.core.planning as planning
     import btrfs_backup_ng.core.restore as restore
 
     assert "correspondent_of" in inspect.getsource(planning), (
-        "P2 should wire the planner onto correspondent_of"
+        "the planner is wired onto correspondent_of (P2)"
     )
-    assert "correspondent_of" not in inspect.getsource(restore), (
-        "restore converges onto correspondent_of in Phase 3, not now"
+    assert "correspondent_of" in inspect.getsource(restore), (
+        "restore is converged onto correspondent_of (P3a)"
+    )
+    # The bespoke restore-side uuid matcher is gone.
+    assert "find_parent_by_uuid" not in inspect.getsource(restore), (
+        "find_parent_by_uuid should be replaced by find_parent_by_correspondence"
     )

--- a/tests/test_r4_phase3a_restore.py
+++ b/tests/test_r4_phase3a_restore.py
@@ -1,0 +1,244 @@
+"""R4 Phase 3a: restore's incremental-parent selection converged onto correspondent_of.
+
+``restore.find_parent_by_correspondence`` replaces the bespoke ``btrfs subvolume show``
+uuid parser with the ONE polymorphic correspondence primitive: ``received_uuid == uuid`` for
+btrfs, name for raw. A valid restore parent is a backup present on BOTH sides -- on the
+backup (its path feeds ``send -p``) and locally (so ``receive`` can apply the diff). These
+tests drive the REAL ``correspondent_of`` (via real Local/Raw endpoints) so a name-based or
+wrong-direction regression is caught.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from btrfs_backup_ng import __util__
+from btrfs_backup_ng.core import restore as restore_mod
+from btrfs_backup_ng.core.restore import find_parent_by_correspondence
+from btrfs_backup_ng.endpoint.local import LocalEndpoint
+
+
+def _snap(stamp, uuid="", received_uuid=""):
+    s = __util__.Snapshot(
+        "/snaps",
+        "home-",
+        None,
+        time_obj=time.strptime(stamp, "%Y%m%d-%H%M%S"),
+        time_format="%Y%m%d-%H%M%S",
+    )
+    s.uuid = uuid
+    s.received_uuid = received_uuid
+    return s
+
+
+def _btrfs_backup_ep(tmp_path, backups):
+    """A real btrfs (Local) backup endpoint whose listing we control, so the real
+    Endpoint.correspondent_of (received_uuid == source.uuid) drives parent selection."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    ep = LocalEndpoint(
+        config={
+            "path": tmp_path,
+            "source": None,
+            "snapshot_folder": ".snapshots",
+            "snap_prefix": "home-",
+        }
+    )
+    ep.list_snapshots = lambda flush_cache=False: list(backups)  # type: ignore[method-assign]
+    return ep
+
+
+# --------------------------------------------------------------------------- #
+# btrfs restore: parent by received_uuid == local uuid (== old find_parent_by_uuid)
+# --------------------------------------------------------------------------- #
+def test_btrfs_parent_by_received_uuid(tmp_path):
+    b0 = _snap("20240101-000000", uuid="B0", received_uuid="U0")
+    b1 = _snap("20240102-000000", uuid="B1", received_uuid="U1")
+    backup_ep = _btrfs_backup_ep(tmp_path, [b0, b1])
+    # A locally-restored copy of b0: its uuid is what b0 was received from.
+    l0 = _snap("20240101-000000", uuid="U0")
+
+    parent, local_match = find_parent_by_correspondence([b0, b1], [l0], b1, backup_ep)
+    assert parent is b0  # b0.received_uuid == l0.uuid
+    assert local_match is l0
+
+
+def test_target_is_never_its_own_parent(tmp_path):
+    b0 = _snap("20240101-000000", uuid="B0", received_uuid="U0")
+    backup_ep = _btrfs_backup_ep(tmp_path, [b0])
+    l0 = _snap("20240101-000000", uuid="U0")  # corresponds to b0
+
+    # Restoring b0 itself -> b0 is excluded as its own parent -> no parent.
+    parent, local_match = find_parent_by_correspondence([b0], [l0], b0, backup_ep)
+    assert parent is None
+    assert local_match is None
+
+
+def test_no_correspondent_returns_none_for_time_fallback(tmp_path):
+    """No local correspondent -> (None, None) so the caller degrades to the time-based
+    Snapshot.find_parent fallback. Mutation guard: returning a non-corresponding backup fails."""
+    b0 = _snap("20240101-000000", uuid="B0", received_uuid="U0")
+    b1 = _snap("20240102-000000", uuid="B1", received_uuid="U1")
+    backup_ep = _btrfs_backup_ep(tmp_path, [b0, b1])
+    l_other = _snap("20240103-000000", uuid="NOMATCH")  # corresponds to nothing
+
+    parent, local_match = find_parent_by_correspondence(
+        [b0, b1], [l_other], b1, backup_ep
+    )
+    assert parent is None
+    assert local_match is None
+
+
+def test_recreated_local_new_uuid_is_not_matched(tmp_path):
+    """A re-created local snapshot (same name, NEW uuid) does not correspond to the backup's
+    stale received_uuid, so it is NOT selected as a parent -- the R4 win, carried into restore.
+    Mutation guard: a name-based match would wrongly pick b0."""
+    b0 = _snap("20240101-000000", uuid="B0", received_uuid="U0-OLD")
+    b1 = _snap("20240102-000000", uuid="B1", received_uuid="U1")
+    backup_ep = _btrfs_backup_ep(tmp_path, [b0, b1])
+    recreated_local = _snap("20240101-000000", uuid="U0-NEW")  # same name, new uuid
+
+    parent, local_match = find_parent_by_correspondence(
+        [b0, b1], [recreated_local], b1, backup_ep
+    )
+    assert parent is None  # U0-NEW != b0.received_uuid U0-OLD
+    assert local_match is None
+
+
+def test_first_backup_present_locally_is_chosen(tmp_path):
+    b0 = _snap("20240101-000000", uuid="B0", received_uuid="U0")
+    b1 = _snap("20240102-000000", uuid="B1", received_uuid="U1")
+    b2 = _snap("20240103-000000", uuid="B2", received_uuid="U2")  # target
+    backup_ep = _btrfs_backup_ep(tmp_path, [b0, b1, b2])
+    l0 = _snap("20240101-000000", uuid="U0")  # corresponds to b0
+    l1 = _snap("20240102-000000", uuid="U1")  # corresponds to b1
+
+    parent, local_match = find_parent_by_correspondence(
+        [b0, b1, b2], [l0, l1], b2, backup_ep
+    )
+    assert parent is b0  # first backup (in order) present locally
+    assert local_match is l0
+
+
+# --------------------------------------------------------------------------- #
+# raw restore: parent by NAME (the P3a behavioral gain -- was always time-fallback)
+# --------------------------------------------------------------------------- #
+def test_raw_parent_by_name_correspondence(tmp_path):
+    """On a RAW backup target, correspondent_of is name-based, so restore now gets proper
+    name correspondence instead of always degrading to time-based (the old bespoke uuid
+    parser silently failed -- a stream file is not a subvolume). Mutation guard: a
+    uuid-only matcher returns None here (raw streams carry no received_uuid)."""
+    from btrfs_backup_ng.endpoint.raw import RawEndpoint
+    from btrfs_backup_ng.endpoint.raw_metadata import RawSnapshot
+
+    rb0 = RawSnapshot(
+        name="home-20240101-000000",
+        stream_path=tmp_path / "home-20240101-000000.btrfs",
+        uuid="RB0",
+    )
+    rb1 = RawSnapshot(
+        name="home-20240102-000000",
+        stream_path=tmp_path / "home-20240102-000000.btrfs",
+        uuid="RB1",
+    )
+    raw_ep = RawEndpoint(config={"path": str(tmp_path)})
+    raw_ep.list_snapshots = lambda flush_cache=False: [rb0, rb1]  # type: ignore[method-assign]
+
+    # A locally-restored copy whose NAME matches rb0 (raw ignores uuid).
+    l0 = _snap("20240101-000000", uuid="irrelevant-for-raw")
+
+    parent, local_match = find_parent_by_correspondence([rb0, rb1], [l0], rb1, raw_ep)
+    assert parent is rb0  # matched by NAME (raw name semantics), not uuid
+    assert local_match is l0
+
+
+def test_empty_uuid_local_yields_no_correspondent(tmp_path):
+    """An empty-uuid local snapshot (enrichment miss) has no verifiable identity ->
+    correspondent_of returns None -> (None, None) so restore degrades to the time-based
+    fallback. Mutation guard: a name-based match would wrongly pair them."""
+    b0 = _snap("20240101-000000", uuid="B0", received_uuid="")
+    backup_ep = _btrfs_backup_ep(tmp_path, [b0])
+    l_empty = _snap("20240101-000000", uuid="")  # same name, but no identity
+
+    parent, local_match = find_parent_by_correspondence([b0], [l_empty], b0, backup_ep)
+    assert parent is None
+    assert local_match is None
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end through restore_snapshots: the correspondence path actually fires
+# --------------------------------------------------------------------------- #
+def test_restore_snapshots_takes_correspondence_path_end_to_end(
+    tmp_path, monkeypatch, caplog
+):
+    """Drive restore_snapshots end-to-end with the REAL correspondent_of (the parent finder
+    is NOT mocked). A target whose parent is present locally by correspondence takes the
+    correspondence path and is handed the BACKUP-SIDE parent object. Kills a call-site
+    arg-swap (swap -> correspondence returns None -> the path never fires) that the robust
+    time-based fallback would otherwise mask."""
+    b0 = _snap("20240101-000000", uuid="B0", received_uuid="U0")
+    b1 = _snap("20240102-000000", uuid="B1", received_uuid="U1")
+    backup_ep = _btrfs_backup_ep(tmp_path / "backup", [b0, b1])
+    # A pre-existing local snapshot corresponding to b0 (its uuid == b0.received_uuid).
+    l0 = _snap("20240101-000000", uuid="U0")
+    local_ep = _btrfs_backup_ep(tmp_path / "local", [l0])
+
+    captured: dict = {}
+
+    def fake_restore_snapshot(be, le, snap, parent=None, **k):
+        captured[snap.get_name()] = parent
+
+    monkeypatch.setattr(restore_mod, "restore_snapshot", fake_restore_snapshot)
+
+    with caplog.at_level(logging.DEBUG, logger="btrfs_backup_ng.core.restore"):
+        restore_mod.restore_snapshots(
+            backup_endpoint=backup_ep,
+            local_endpoint=local_ep,
+            restore_all=True,
+            skip_existing=False,
+            no_incremental=False,
+        )
+
+    # The correspondence path fired (not the time fallback)...
+    assert "Restore parent by correspondence" in caplog.text
+    # ...and b1 was handed the BACKUP-SIDE parent b0 (present locally as l0 by uuid).
+    assert captured.get("home-20240102-000000") is b0
+
+
+def test_restore_snapshots_dry_run_uses_correspondence(tmp_path, caplog):
+    """Dry-run restore selects the parent by correspondence too (covers the dry-run call site);
+    no transfers happen. Mutation guard for the dry-run arg order."""
+    b0 = _snap("20240101-000000", uuid="B0", received_uuid="U0")
+    b1 = _snap("20240102-000000", uuid="B1", received_uuid="U1")
+    backup_ep = _btrfs_backup_ep(tmp_path / "backup", [b0, b1])
+    l0 = _snap("20240101-000000", uuid="U0")  # pre-existing local corresponding to b0
+    local_ep = _btrfs_backup_ep(tmp_path / "local", [l0])
+
+    with caplog.at_level(logging.DEBUG, logger="btrfs_backup_ng.core.restore"):
+        stats = restore_mod.restore_snapshots(
+            backup_endpoint=backup_ep,
+            local_endpoint=local_ep,
+            restore_all=True,
+            skip_existing=False,
+            dry_run=True,
+        )
+
+    assert "Restore parent by correspondence" in caplog.text
+    assert stats["restored"] == 0  # dry run: nothing actually restored
+
+
+def test_never_raises_when_backup_listing_fails(tmp_path):
+    """correspondent_of never raises (a listing failure -> None), so find_parent_by_correspondence
+    degrades to (None, None) -> time-based fallback, never a crash."""
+    b0 = _snap("20240101-000000", uuid="B0", received_uuid="U0")
+    backup_ep = _btrfs_backup_ep(tmp_path, [b0])
+
+    def boom(flush_cache=False):
+        raise RuntimeError("transient backup listing failure")
+
+    backup_ep.list_snapshots = boom  # type: ignore[method-assign]
+    l0 = _snap("20240101-000000", uuid="U0")
+
+    parent, local_match = find_parent_by_correspondence([b0], [l0], b0, backup_ep)
+    assert parent is None
+    assert local_match is None


### PR DESCRIPTION
## What
R4 Phase 3a: converge restore's incremental-parent selection onto the single correspondence
primitive (`endpoint.correspondent_of`) the backup planner already uses, removing the last
bespoke received_uuid matcher.

## Why
`find_parent_by_uuid` re-implemented `received_uuid == uuid` with its own `btrfs subvolume
show` parsing. That duplicate had two defects: it used bare `sudo` (no `-n`), so it could
**block on a password prompt** during enumeration; and it ran `subvolume show` on the backup
path, which for a **raw** target is a stream file, not a subvolume — so it always failed and
raw restore silently fell back to time-based parent selection.

## How
- New `find_parent_by_correspondence(backup_snapshots, local_snapshots, target_backup,
  backup_endpoint)`: a valid restore parent is a backup present on **both** sides — on the
  backup (its path feeds `send -p`) and locally (so `receive` can apply the diff). That is
  exactly `backup_endpoint.correspondent_of(local_snap)`. Deletes the subprocess parser.
- The 2 callers (dry-run + main loop) updated; the time-based `Snapshot.find_parent` fallback
  + name-remap are kept for the empty-uuid / no-correspondent degradation.
- **btrfs restore unchanged** (Phase 1 proved `backup_ep.correspondent_of(local)` == the old
  matcher). **raw restore gains** correct name-correspondence parent selection.
- `RawSnapshot.find_parent` and `Snapshot.find_parent` retained (live time-based fallbacks,
  not uuid duplicates).

## Verification
- **Unit:** new `tests/test_r4_phase3a_restore.py` (9 tests, real Local/Raw endpoints so
  `correspondent_of` is real, incl. an end-to-end `restore_snapshots` correspondence-path
  test); full suite **2438 passed, 1 skipped**; ruff + mypy clean.
- **Mutation (Edit-only):** drop target exclusion → caught; name-based instead of
  correspondence → caught by the re-created-local test; **call-site arg-swap** (which the
  adversarial review proved previously slipped CI) → now caught by the end-to-end test.
- **Hardware (real btrfs, loop rig):** byte-identical **btrfs** restore round-trip (fresh
  restore uses the documented time fallback, unchanged) **and** byte-identical **raw** restore
  round-trip with the parent confirmed selected by name-correspondence.
- Adversarial review of the diff: 18 findings, 5 confirmed (all test-coverage gaps, no code
  defects), 13 refuted; the material end-to-end gap is closed here.

## Note
btrfs restore's correspondence path (received_uuid==uuid) fires only when *original* source
snapshots are present locally (Phase-1-equivalent to the old matcher); a fresh cross-system
restore correctly uses the time-based fallback — unchanged from before. The behavioral gain
here is for **raw** restore.

## Next
P3b — snapper convergence (enrich the wrapper's uuid; replace number-based presence/parent
with correspondence; unblock snapper→raw incrementals). Its own reviewed + snapper-hardware-
proven PR.
