### PR TITLE
feat(core): within-run incremental chaining in the transfer planner (R4 Phase 3b-1)

### DIFF
--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -1412,7 +1412,30 @@ def _execute_transfers(
     destination_id = destination_endpoint.get_id()
     result = TransferResult()
 
+    # Names transferred in THIS run, to guard within-run incremental chaining: if a snapshot
+    # parents off an earlier in-run transfer that FAILED, the parent is not on the destination,
+    # so a ``send -p`` against it cannot apply. btrfs receive self-detects this (nonzero rc ->
+    # SnapshotTransferError), but a raw target would just write bytes and commit a valid-looking
+    # but UNRESTORABLE stream -- a false success (R1 violation). Short-circuit such a child on
+    # ALL endpoint types instead.
+    planned_names = {s.get_name() for s, _ in plan}
+    transferred_names: set = set()
+
     for best_snapshot, parent in plan:
+        if parent is not None:
+            parent_name = parent.get_name()
+            # A parent that is itself scheduled in this run must have already succeeded
+            # (plan is oldest-first, executed in order) before we can chain onto it.
+            if parent_name in planned_names and parent_name not in transferred_names:
+                err = __util__.SnapshotTransferError(
+                    f"incremental parent {parent_name} was not transferred to the "
+                    f"destination (its transfer failed); refusing to send "
+                    f"{best_snapshot.get_name()} against a missing parent"
+                )
+                logger.error("Skipping %s: %s", best_snapshot.get_name(), err)
+                result.failed.append((best_snapshot, err))
+                continue
+
         # Set locks
         source_endpoint.set_lock(best_snapshot, destination_id, True)
         if parent:
@@ -1441,6 +1464,7 @@ def _execute_transfers(
                 logger.debug("Post-transfer snapshot list refresh failed: %s", e)
 
             result.transferred.append(best_snapshot)
+            transferred_names.add(best_snapshot.get_name())
 
         except __util__.SnapshotTransferError as e:
             logger.error("Snapshot transfer failed for %s: %s", best_snapshot, e)

--- a/src/btrfs_backup_ng/core/planning.py
+++ b/src/btrfs_backup_ng/core/planning.py
@@ -50,12 +50,18 @@ def plan_transfer_sequence(
         only: If given, plan just this one snapshot (single-snapshot transfer mode).
 
     A snapshot whose correspondent is already present on the destination is skipped. For
-    each snapshot to transfer, the parent is the newest source snapshot OLDER than it whose
-    correspondent is present on the destination (so ``btrfs receive`` can resolve the
-    ``send -p``); if none corresponds the snapshot is sent in full. Correspondence is the
-    only presence/parent authority -- a snapshot the destination cannot verifiably resolve
-    is never used as a parent. Parents are drawn from the destination's current state (no
-    within-run chaining), matching existing run semantics.
+    each snapshot to transfer, the parent is the newest source snapshot OLDER than it that is
+    (or, within this run, will be) present on the destination by correspondence (uuid for
+    btrfs, name for raw), so ``btrfs receive`` can resolve the ``send -p``; if none qualifies
+    the snapshot is sent in full. Correspondence is the only presence/parent authority -- a
+    snapshot the destination cannot verifiably resolve is never used as a parent.
+
+    Within-run chaining: because the plan executes oldest-first and each transferred snapshot
+    then corresponds on the destination, a snapshot may parent off an EARLIER-in-this-run
+    transfer (not only snapshots already on the destination at plan time). This keeps a fresh
+    multi-snapshot run (e.g. an initial snapper-history backup) a tight incremental chain
+    instead of all-full sends. If an earlier transfer fails at execution, its dependent
+    incremental fails too and is surfaced (R1) -- never silently mis-applied.
     """
     present = snapshots_present_on(source_snapshots, destination_endpoint)
 
@@ -71,6 +77,12 @@ def plan_transfer_sequence(
         key=lambda s: s.time_obj,
     )
 
+    # A parent is valid if its correspondent is present on the destination -- either already
+    # (``present``) or projected to be, because it is transferred earlier in THIS run.
+    # ``to_transfer`` is oldest-first, so an earlier item is on the destination by the time a
+    # later one sends against it.
+    projected_present = set(present)
+
     plan = []
     for snap in to_transfer:
         parent = None
@@ -82,11 +94,15 @@ def plan_transfer_sequence(
             )
             for candidate in older_newest_first:
                 # A valid incremental parent must have a verified correspondent on the
-                # destination (uuid for btrfs, name for raw) -- never a bare name match.
-                if candidate.get_name() in present:
+                # destination (uuid for btrfs, name for raw) -- never a bare name match --
+                # counting in-run transfers already planned before this one.
+                if candidate.get_name() in projected_present:
                     parent = candidate
                     break
         plan.append((snap, parent))
+        # This snapshot will correspond on the destination once transferred, so later
+        # snapshots in this run may use it as an incremental parent.
+        projected_present.add(snap.get_name())
 
     logger.debug(
         "Planned %d transfer(s) (%d incremental)",

--- a/tests/test_r1_orchestration_contract.py
+++ b/tests/test_r1_orchestration_contract.py
@@ -72,6 +72,34 @@ class TestExecuteTransfersResult:
         assert result.attempted == 2
         assert not result.ok
 
+    def test_failed_in_run_parent_short_circuits_dependents(self, monkeypatch):
+        """Within-run chaining safety: if an in-run parent transfer FAILS, its dependent
+        incrementals must NOT be attempted or committed -- a raw target would otherwise write
+        a valid-looking but UNRESTORABLE stream (a false success). They are recorded as
+        failures (R1). Mutation guard: removing the short-circuit lets the dependents transfer
+        against a missing parent."""
+        s1 = _fake_snap("s1")
+        s2 = _fake_snap("s2")
+        s3 = _fake_snap("s3")
+        src, dst = _endpoints([s1, s2, s3])
+
+        attempted = []
+
+        def fake_send(snap, *a, **k):
+            attempted.append(snap)
+            if snap is s1:
+                raise __util__.SnapshotTransferError("boom")
+
+        monkeypatch.setattr(ops, "send_snapshot", fake_send)
+
+        # Chained plan: s2 parents s1, s3 parents s2. s1 fails -> s2, s3 must short-circuit.
+        result = ops._execute_transfers(src, dst, [(s1, None), (s2, s1), (s3, s2)], {})
+
+        assert result.transferred_count == 0
+        assert result.failed_count == 3
+        # Only s1 was actually attempted; s2 and s3 were short-circuited (parent missing).
+        assert attempted == [s1]
+
     def test_parent_lock_lifecycle(self, monkeypatch):
         """The executor locks the incremental PARENT (parent=True) before the send and
         releases it after a verified success -- the R3 lock lifecycle that keeps retention

--- a/tests/test_r4_phase2_planner.py
+++ b/tests/test_r4_phase2_planner.py
@@ -131,16 +131,39 @@ def test_parent_skips_name_present_but_noncorresponding_older_snapshot(tmp_path)
             ),  # NON-matching
         ],
     )
-    plan = plan_transfer_sequence([s_oldest, s_mid, newest], dest)
-    # s_oldest present (skipped); s_mid absent (U-MID-NEW != U-MID-OLD) and newest absent.
+    # only=newest so s_mid is NOT transferred this run (and so not projected as an in-run
+    # parent) -- isolating the guard: a name-present-but-non-corresponding older snapshot,
+    # not itself in this run, must never be chosen as a parent.
+    plan = plan_transfer_sequence([s_oldest, s_mid, newest], dest, only=newest)
+    assert [s.get_name() for s, _ in plan] == ["home-20240103-000000"]
     # newest's parent must be s_oldest (verified) -- NEVER the newer name-present-but-
     # non-corresponding s_mid, whose send -p the destination could not resolve.
+    assert plan[0][1] is s_oldest
+
+
+def test_within_run_chaining_over_re_sent_noncorresponding_older(tmp_path):
+    """Full-list counterpart to the only= guard: when the name-present-but-non-corresponding
+    older snapshot (s_mid) IS transferred this run, its stale dest copy is corrected and it
+    becomes a valid IN-RUN parent -- so newest chains off s_mid (uuid U-MID-NEW), not the
+    older s_oldest. (This is safe: s_mid is executed before newest.)"""
+    s_oldest = _snap("20240101-000000", uuid="U-OLDEST")
+    s_mid = _snap("20240102-000000", uuid="U-MID-NEW")
+    newest = _snap("20240103-000000", uuid="U-NEW")
+    dest = _dest(
+        tmp_path,
+        [
+            _snap("20240101-000000", uuid="Da", received_uuid="U-OLDEST"),
+            _snap("20240102-000000", uuid="Db", received_uuid="U-MID-OLD"),  # stale
+        ],
+    )
+    plan = plan_transfer_sequence([s_oldest, s_mid, newest], dest)
     by = {s.get_name(): p for s, p in plan}
-    assert set(by) == {"home-20240102-000000", "home-20240103-000000"}
-    assert (
-        by["home-20240103-000000"] is s_oldest
-    )  # skipped s_mid (name-only), used s_oldest
-    assert by["home-20240102-000000"] is s_oldest  # s_mid parents on s_oldest too
+    assert set(by) == {
+        "home-20240102-000000",
+        "home-20240103-000000",
+    }  # s_oldest skipped
+    assert by["home-20240102-000000"] is s_oldest  # s_mid re-sent, parents on s_oldest
+    assert by["home-20240103-000000"] is s_mid  # newest chains off the IN-RUN s_mid
 
 
 # --------------------------------------------------------------------------- #
@@ -158,39 +181,59 @@ def test_no_incremental_forces_full_sends(tmp_path):
 def test_empty_uuid_source_is_not_present_and_planned_full(tmp_path):
     """NO name fallback (R4 purity): a source snapshot whose uuid is unknown cannot be
     verified present -- correspondent_of returns None for an empty uuid -- so it is planned
-    as a FULL send, never skipped by a name coincidence and never given an unverifiable
-    incremental parent. An empty uuid is an enrichment problem to fix at the source
-    (sudo-escalated `subvolume show`), not a reason to dilute the planner into name matching.
-    Mutation guard: any name-based presence/parent fallback re-skips these."""
-    s1 = _snap("20240101-000000", uuid="")  # unknown identity
-    s2 = _snap("20240102-000000", uuid="")
-    # The dest even lists a SAME-NAMED snapshot for s1: a name fallback would (wrongly) skip
-    # it. Pure correspondence does not.
+    as a FULL send, never skipped by a name coincidence with a same-named dest copy. An empty
+    uuid is an enrichment problem to fix at the source (sudo-escalated `subvolume show`), not
+    a reason to dilute the planner into name matching. (Single snapshot, so within-run
+    chaining is not in play.) Mutation guard: a name-based presence fallback re-skips it."""
+    s = _snap("20240101-000000", uuid="")  # unknown identity
+    # The dest lists a SAME-NAMED snapshot: a name fallback would (wrongly) skip s.
     dest = _dest(
         tmp_path, [_snap("20240101-000000", uuid="Dz", received_uuid="anything")]
     )
-    present = snapshots_present_on([s1, s2], dest)
+    present = snapshots_present_on([s], dest)
     assert present == set()  # strictly correspondence; no name fallback
-    plan = plan_transfer_sequence([s1, s2], dest)
-    assert [s.get_name() for s, _ in plan] == [
-        "home-20240101-000000",
-        "home-20240102-000000",
-    ]
-    assert all(p is None for _, p in plan)  # no name-based parent
+    plan = plan_transfer_sequence([s], dest)
+    assert [n.get_name() for n, _ in plan] == ["home-20240101-000000"]
+    assert plan[0][1] is None  # full send (no older snapshot to parent off)
 
 
-def test_ordering_is_oldest_first(tmp_path):
+def test_ordering_oldest_first_with_within_run_chaining(tmp_path):
+    """Plan is oldest-first, and a fresh multi-snapshot run forms a tight within-run
+    incremental CHAIN: the oldest is a full send, each later one parents off the
+    immediately-earlier in-run transfer (safe -- executed oldest-first, so the parent is on
+    the destination by the time its child sends). Mutation guard: dropping the in-run
+    projection makes every snapshot a full send."""
     s3 = _snap("20240103-000000", uuid="U3")
     s1 = _snap("20240101-000000", uuid="U1")
     s2 = _snap("20240102-000000", uuid="U2")
-    dest = _dest(tmp_path, [])  # empty -> all full sends
+    dest = _dest(tmp_path, [])  # empty dest
     plan = plan_transfer_sequence([s3, s1, s2], dest)
     assert [s.get_name() for s, _ in plan] == [
         "home-20240101-000000",
         "home-20240102-000000",
         "home-20240103-000000",
     ]
-    assert all(p is None for _, p in plan)
+    assert plan[0][1] is None  # oldest: full send
+    assert plan[1][1] is s1  # chains off the in-run s1
+    assert plan[2][1] is s2  # chains off the in-run s2
+
+
+def test_within_run_chaining_off_earlier_in_run_transfer(tmp_path):
+    """A snapshot parents off an EARLIER-in-this-run transfer, not only the destination's
+    plan-time state: the dest already holds s1; s2 and s3 transfer this run -> s2 parents the
+    on-dest s1, and s3 parents the IN-RUN s2. Mutation guard: dropping the in-run projection
+    makes s3 parent s1 (stale, larger diff) instead of s2."""
+    s1 = _snap("20240101-000000", uuid="U1")
+    s2 = _snap("20240102-000000", uuid="U2")
+    s3 = _snap("20240103-000000", uuid="U3")
+    dest = _dest(tmp_path, [_snap("20240101-000000", uuid="Da", received_uuid="U1")])
+    plan = plan_transfer_sequence([s1, s2, s3], dest)
+    by = {s.get_name(): p for s, p in plan}
+    assert set(by) == {"home-20240102-000000", "home-20240103-000000"}  # s1 skipped
+    assert by["home-20240102-000000"] is s1  # s2 parents the already-on-dest s1
+    assert (
+        by["home-20240103-000000"] is s2
+    )  # s3 parents the IN-RUN s2 (within-run chain)
 
 
 def test_only_single_snapshot_mode(tmp_path):
@@ -200,6 +243,41 @@ def test_only_single_snapshot_mode(tmp_path):
     plan = plan_transfer_sequence([s1, s2], dest, only=s2)
     assert [s.get_name() for s, _ in plan] == ["home-20240102-000000"]
     assert plan[0][1] is s1  # incremental against the corresponding s1
+
+
+def test_no_incremental_suppresses_within_run_chaining(tmp_path):
+    """``no_incremental`` forces ALL full sends even across a multi-snapshot in-run batch --
+    the in-run projection must never sneak in an incremental parent. Mutation guard: chaining
+    under no_incremental."""
+    s1 = _snap("20240101-000000", uuid="U1")
+    s2 = _snap("20240102-000000", uuid="U2")
+    s3 = _snap("20240103-000000", uuid="U3")
+    dest = _dest(tmp_path, [])
+    plan = plan_transfer_sequence([s1, s2, s3], dest, no_incremental=True)
+    assert [s.get_name() for s, _ in plan] == [
+        "home-20240101-000000",
+        "home-20240102-000000",
+        "home-20240103-000000",
+    ]
+    assert all(p is None for _, p in plan)
+
+
+def test_keep_num_backups_chain_does_not_parent_outside_window(tmp_path):
+    """With ``keep_num_backups``, an in-window snapshot must NOT parent off an OUT-of-window
+    older snapshot (which is not transferred this run, so not on the destination). The first
+    kept snapshot is a full send; later kept ones chain within the window. Mutation guard:
+    parenting off the out-of-window U2 would emit an unresolvable send -p."""
+    snaps = [_snap(f"2024010{i}-000000", uuid=f"U{i}") for i in range(1, 5)]  # U1..U4
+    dest = _dest(tmp_path, [])  # empty
+    plan = plan_transfer_sequence(snaps, dest, keep_num_backups=2)
+    # candidates = [U3, U4]. U3 is full (out-of-window U2 is not transferred -> not present);
+    # U4 chains off the in-run U3.
+    assert [s.get_name() for s, _ in plan] == [
+        "home-20240103-000000",
+        "home-20240104-000000",
+    ]
+    assert plan[0][1] is None  # U3 full -- never parents off the out-of-window U2
+    assert plan[1][1] is snaps[2]  # U4 chains off the in-run U3
 
 
 def test_keep_num_backups_limits_candidates(tmp_path):


### PR DESCRIPTION
## What
Add within-run incremental chaining to the shared planner `plan_transfer_sequence`, so a
multi-snapshot run forms a tight chain instead of all-full sends — plus an executor safety
guard so a failed in-run parent can never yield a false-success backup.

## Why
The R4 planner drew parents only from the destination's state at plan time (no within-run
chaining). For one new snapshot per run that's fine, but backing up a **history in one run**
— the common case for snapper (Phase 3b-2) — made every snapshot a full send.

## How
- A growing `projected_present` set starts from the real destination correspondents
  (`snapshots_present_on`) and gains each planned snapshot's name after it is planned. Parent
  eligibility checks `projected_present`, so a snapshot can parent off an earlier-in-this-run
  transfer. `to_transfer` is oldest-first and `_execute_transfers` runs the plan in that
  order, so the in-run parent is on the destination by the time its child sends.
- **Executor safety guard:** a child whose in-run parent's transfer FAILED is short-circuited
  and recorded as a failure (R1), never attempted/committed. btrfs `receive` self-detects a
  missing parent, but a raw target would otherwise write a valid-looking but **unrestorable**
  stream — a false success. The guard is endpoint-agnostic (protects btrfs and raw).
- Skip-detection and the R3 lock reconcile are unchanged (only PARENT eligibility grows).

## Verification
- **Unit:** dedicated chaining tests + a failed-in-run-parent short-circuit test + boundary
  tests (`keep_num_backups` window, `no_incremental` suppression); full suite **2444 passed**;
  ruff + mypy clean.
- **Mutation (Edit-only):** dropping the in-run projection → chaining tests fail; removing the
  short-circuit → the failed-parent test catches the false successes.
- **Hardware (real btrfs + raw):** a fresh 3-snapshot run chains (oldest full, 2nd→1st,
  3rd→2nd), all transferred, byte-identical with a correct `received_uuid` chain; the **raw**
  chain also restores byte-identically.
- **Adversarial review:** 15 findings → 7 confirmed; the HIGH/real raw false-success defect is
  **fixed here** (executor guard); test-coverage gaps closed. Refuted/deferred below.

## Deferred (tracked follow-up, non-blocking)
The raw `.meta` sidecar records `parent_name = null` even for a real incremental (all four
`receive()` call sites omit it). This is **pre-existing** (not introduced here) and does not
affect restorability (raw restore reconstructs the chain by time order, proven in P3a) — it's
an authoritative-sidecar/observability gap. Within-run chaining makes raw incrementals common,
so it's worth a follow-up to thread `parent_name` through the receive path.

## Next
P3b-2 — snapper convergence (wrapper uuid enrichment + btrfs numbered-layout dest enumeration
+ correspondence skip/parent + delete the number logic + snapper→raw incrementals), built on
this chaining. Hardware-tested strictly against disposable snapper configs/subvols.
