### PR TITLE
fix(raw): record the incremental parent_name in the raw .meta sidecar

### DIFF
--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -266,6 +266,7 @@ def send_snapshot(
                 show_progress=show_progress,
                 snapshot_name=snapshot_name,
                 estimated_size=estimated_size,
+                parent_name=parent_name,
             )
 
         if any(rc != 0 for rc in return_codes):
@@ -595,9 +596,10 @@ def _transfer_chunks_local(
     # Create a reader to reassemble chunks
     reader = chunked_manager.create_reassembly_reader(manifest)
 
-    # Start btrfs receive
+    # Start btrfs receive (parent_name lets a raw endpoint record the incremental parent in
+    # its .meta sidecar; btrfs ignores it).
     receive_process = destination_endpoint.receive(
-        subprocess.PIPE, manifest.snapshot_name
+        subprocess.PIPE, manifest.snapshot_name, parent_name=manifest.parent_name
     )
     if receive_process is None:
         raise __util__.SnapshotTransferError("Receive process failed to start")
@@ -694,9 +696,10 @@ def _transfer_chunks_ssh(
             raise __util__.SnapshotTransferError("SSH chunked receive failed")
     else:
         # Fall back to streaming through regular receive
-        # Start btrfs receive on remote
+        # Start btrfs receive on remote (parent_name lets a raw endpoint record the
+        # incremental parent in its .meta sidecar; btrfs ignores it).
         receive_process = destination_endpoint.receive(
-            subprocess.PIPE, manifest.snapshot_name
+            subprocess.PIPE, manifest.snapshot_name, parent_name=manifest.parent_name
         )
         if receive_process is None:
             raise __util__.SnapshotTransferError("SSH receive process failed to start")
@@ -917,6 +920,7 @@ def _do_process_transfer(
     show_progress: bool = False,
     snapshot_name: str = "",
     estimated_size: int | None = None,
+    parent_name: str | None = None,
 ) -> list[int]:
     """Perform transfer using traditional process piping.
 
@@ -967,6 +971,7 @@ def _do_process_transfer(
             is_ssh_endpoint,
             snapshot_name,
             estimated_size,
+            parent_name=parent_name,
         )
 
     pipeline_processes = []
@@ -985,8 +990,11 @@ def _do_process_transfer(
                 show_progress=effective_show_progress,
             )
 
-        # Start receive process with potentially modified input stream
-        receive_process = destination_endpoint.receive(current_stdout, snapshot_name)
+        # Start receive process with potentially modified input stream. parent_name lets a
+        # raw endpoint record the incremental parent in its .meta sidecar (btrfs ignores it).
+        receive_process = destination_endpoint.receive(
+            current_stdout, snapshot_name, parent_name=parent_name
+        )
         if receive_process is None:
             logger.error("Failed to start receive process")
             if is_ssh_endpoint and not destination_endpoint.config.get(
@@ -1060,6 +1068,7 @@ def _do_rich_progress_transfer(
     is_ssh_endpoint: bool,
     snapshot_name: str,
     estimated_size: int | None,
+    parent_name: str | None = None,
 ) -> list[int]:
     """Perform transfer with Rich progress bar display.
 
@@ -1081,7 +1090,9 @@ def _do_rich_progress_transfer(
     # this path reports a clean failure with the failed-transaction audit log,
     # exactly like the non-rich transfer path.
     try:
-        receive_process = destination_endpoint.receive(subprocess.PIPE, snapshot_name)
+        receive_process = destination_endpoint.receive(
+            subprocess.PIPE, snapshot_name, parent_name=parent_name
+        )
     except Exception as e:
         logger.error("Failed to start receive process: %s", e)
         try:

--- a/tests/test_r2_cleanup_recovery.py
+++ b/tests/test_r2_cleanup_recovery.py
@@ -130,6 +130,7 @@ class TestChunkedPartialCleanup:
         manifest = SimpleNamespace(
             snapshot_path="/src/snapshot",
             snapshot_name="snap",
+            parent_name=None,
             chunk_count=1,
             chunks=[SimpleNamespace(sequence=0)],
         )

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -583,11 +583,12 @@ class TestCleanupPipelineExceptions:
 
 
 class TestReceivePassesSnapshotName:
-    """The transfer paths pass snapshot_name to endpoint.receive().
+    """The transfer paths pass snapshot_name AND parent_name to endpoint.receive().
 
-    Raw endpoints require snapshot_name to name their output file; passing it on
-    every transfer path is what makes raw and raw+ssh targets work end to end.
-    These would fail on the pre-fix code where receive() was called without it.
+    Raw endpoints require snapshot_name to name their output file; parent_name lets them
+    record the incremental parent in the .meta sidecar (btrfs ignores it). Passing both on
+    every transfer path is what makes raw and raw+ssh incrementals self-describing end to
+    end. These would fail on code that dropped either argument.
     """
 
     def _mock_process(self, returncode=0):
@@ -613,10 +614,13 @@ class TestReceivePassesSnapshotName:
             snapshot_name="host-20240115-120000",
             estimated_size=None,
             show_progress=False,
+            parent_name="host-20240110-120000",
         )
 
         dest.receive.assert_called_once_with(
-            send_process.stdout, "host-20240115-120000"
+            send_process.stdout,
+            "host-20240115-120000",
+            parent_name="host-20240110-120000",
         )
 
     def test_rich_progress_transfer_passes_snapshot_name(self):
@@ -638,9 +642,14 @@ class TestReceivePassesSnapshotName:
                 False,
                 "host-20240115-120000",
                 1000,
+                parent_name="host-20240110-120000",
             )
 
-        dest.receive.assert_called_once_with(subprocess.PIPE, "host-20240115-120000")
+        dest.receive.assert_called_once_with(
+            subprocess.PIPE,
+            "host-20240115-120000",
+            parent_name="host-20240110-120000",
+        )
 
     def test_chunked_local_passes_snapshot_name(self):
         """The chunked local reassembly path forwards manifest.snapshot_name."""
@@ -648,6 +657,7 @@ class TestReceivePassesSnapshotName:
 
         manifest = MagicMock()
         manifest.snapshot_name = "host-20240115-120000"
+        manifest.parent_name = "host-20240110-120000"
         manifest.chunk_count = 1
         manifest.chunks = []
         dest = MagicMock()
@@ -659,7 +669,11 @@ class TestReceivePassesSnapshotName:
 
         operations._transfer_chunks_local(manifest, dest, chunked_manager, {})
 
-        dest.receive.assert_called_once_with(subprocess.PIPE, "host-20240115-120000")
+        dest.receive.assert_called_once_with(
+            subprocess.PIPE,
+            "host-20240115-120000",
+            parent_name="host-20240110-120000",
+        )
 
     def test_chunked_ssh_passes_snapshot_name(self):
         """The chunked SSH fallback (non-receive_chunked) path forwards the name."""
@@ -667,6 +681,7 @@ class TestReceivePassesSnapshotName:
 
         manifest = MagicMock()
         manifest.snapshot_name = "host-20240115-120000"
+        manifest.parent_name = "host-20240110-120000"
         manifest.pending_chunks = [MagicMock()]
         manifest.completed_chunks = 0
         manifest.chunk_count = 1
@@ -683,4 +698,8 @@ class TestReceivePassesSnapshotName:
 
         operations._transfer_chunks_ssh(manifest, dest, chunked_manager, {})
 
-        dest.receive.assert_called_once_with(subprocess.PIPE, "host-20240115-120000")
+        dest.receive.assert_called_once_with(
+            subprocess.PIPE,
+            "host-20240115-120000",
+            parent_name="host-20240110-120000",
+        )


### PR DESCRIPTION
# fix: record parent_name in raw sidecar for incrementals

## Commit message
```
fix(raw): record the incremental parent_name in the raw .meta sidecar

RawEndpoint.receive already accepts and records parent_name, but the four transfer paths in
core/operations.py called receive() without it, so every raw incremental's authoritative
.meta sidecar recorded parent_name=null. Thread parent_name into all four call sites:
_do_process_transfer and _do_rich_progress_transfer gain a parent_name argument (from
send_snapshot's existing parent_name), and the two chunked paths pass manifest.parent_name.
The base btrfs Endpoint.receive accepts and ignores parent_name, so all endpoint types are
safe.

Restores the 0.8.5 authoritative-sidecar intent for raw incrementals (previously observable
only for full sends). Foundation for R4 Phase 3b-2, where snapper->raw incrementals become
common. Hardware-proven: a real raw incremental's sidecar now records the parent's name; a
full send stays null.
```

## PR body

### What
Thread the incremental `parent_name` into all four `receive()` call sites so a raw target
records it in the `.meta` sidecar.

### Why
`RawEndpoint.receive` accepts `parent_name` and seals it into the authoritative sidecar
(0.8.5), but the transfer paths in `operations.py` never passed it — so every raw incremental
recorded `parent_name = null`. The upcoming R4 Phase 3b-2 makes snapper→raw incrementals
common, so the sidecar should record the parent accurately.

### How
- `_do_process_transfer` and `_do_rich_progress_transfer` gain a `parent_name` parameter,
  threaded from `send_snapshot`'s existing `parent_name` (which equals `parent.get_name()` —
  `Snapshot.__repr__` returns `get_name()`).
- The two chunked paths pass `manifest.parent_name` (already populated on the manifest).
- The base btrfs `Endpoint.receive` accepts and ignores `parent_name`, so passing it is safe
  on every endpoint type.

### Verification
- **Unit:** the existing `TestReceivePassesSnapshotName` suite (4 paths) now asserts both
  `snapshot_name` and `parent_name` reach `receive()`; full suite **2444 passed**; ruff + mypy
  clean.
- **Hardware (real btrfs → raw):** a real raw incremental's sidecar records `parent_name` =
  the parent's name; the full send's sidecar stays `null`.
- Focused adversarial review of the diff.

### Note
Observability/authoritative-sidecar fix only — restorability was already correct (raw restore
reconstructs the chain by time order). This is the deferred follow-up from PR #51.
