### PR TITLE
fix(planning): break same-second ties so equal-timestamp snapshots chain

### DIFF
--- a/src/btrfs_backup_ng/core/planning.py
+++ b/src/btrfs_backup_ng/core/planning.py
@@ -50,11 +50,13 @@ def plan_transfer_sequence(
         only: If given, plan just this one snapshot (single-snapshot transfer mode).
 
     A snapshot whose correspondent is already present on the destination is skipped. For
-    each snapshot to transfer, the parent is the newest source snapshot OLDER than it that is
-    (or, within this run, will be) present on the destination by correspondence (uuid for
-    btrfs, name for raw), so ``btrfs receive`` can resolve the ``send -p``; if none qualifies
-    the snapshot is sent in full. Correspondence is the only presence/parent authority -- a
-    snapshot the destination cannot verifiably resolve is never used as a parent.
+    each snapshot to transfer, the parent is the newest source snapshot ordered BEFORE it --
+    by creation time, then source-enumeration position to break same-second ties (see
+    ``_order_key``) -- that is (or, within this run, will be) present on the destination by
+    correspondence (uuid for btrfs, name for raw), so ``btrfs receive`` can resolve the
+    ``send -p``; if none qualifies the snapshot is sent in full. Correspondence is the only
+    presence/parent authority -- a snapshot the destination cannot verifiably resolve is never
+    used as a parent.
 
     Within-run chaining: because the plan executes oldest-first and each transferred snapshot
     then corresponds on the destination, a snapshot may parent off an EARLIER-in-this-run
@@ -72,9 +74,21 @@ def plan_transfer_sequence(
     else:
         candidates = list(source_snapshots)
 
+    # A TOTAL order over snapshots: primary = creation time, secondary = position in the source
+    # enumeration (snapper number / btrfs subvol-id order, which is creation order -- and unlike
+    # a ``.number`` attribute, every snapshot type has a list position). The secondary breaks
+    # SAME-SECOND ties (e.g. a fast pre/post pair snapper's 1s-resolution date collapses to one
+    # timestamp): without it, ``o.time_obj < snap.time_obj`` excludes an equal-timestamp earlier
+    # snapshot from being a parent, so each same-second snapshot falls back to a full send. For
+    # distinct timestamps the secondary never engages, so ordering is unchanged.
+    order_pos = {s.get_name(): i for i, s in enumerate(source_snapshots)}
+
+    def _order_key(s):
+        return (s.time_obj, order_pos.get(s.get_name(), 0))
+
     to_transfer = sorted(
         (s for s in candidates if s.get_name() not in present),
-        key=lambda s: s.time_obj,
+        key=_order_key,
     )
 
     # A parent is valid if its correspondent is present on the destination -- either already
@@ -88,8 +102,8 @@ def plan_transfer_sequence(
         parent = None
         if not no_incremental:
             older_newest_first = sorted(
-                (o for o in source_snapshots if o.time_obj < snap.time_obj),
-                key=lambda o: o.time_obj,
+                (o for o in source_snapshots if _order_key(o) < _order_key(snap)),
+                key=_order_key,
                 reverse=True,
             )
             for candidate in older_newest_first:

--- a/tests/test_r4_phase2_planner.py
+++ b/tests/test_r4_phase2_planner.py
@@ -29,6 +29,15 @@ def _snap(stamp, uuid="", received_uuid=""):
     return s
 
 
+def _snap_named(name, stamp, uuid="", received_uuid=""):
+    """A snapshot with an EXPLICIT name decoupled from its timestamp -- the real snapper shape
+    (``{config}-{number}-{date}``), so two snapshots can share a same-second ``time_obj`` yet
+    keep distinct identities/uuids (which the vanilla name==timestamp ``_snap`` cannot express)."""
+    s = _snap(stamp, uuid=uuid, received_uuid=received_uuid)
+    s.get_name = lambda: name  # type: ignore[method-assign]
+    return s
+
+
 def _dest(tmp_path, dest_snaps):
     """A real btrfs (Local) destination endpoint whose listing we control, so the real
     Endpoint.correspondent_of (received_uuid == source.uuid) drives the planner."""
@@ -234,6 +243,78 @@ def test_within_run_chaining_off_earlier_in_run_transfer(tmp_path):
     assert (
         by["home-20240103-000000"] is s2
     )  # s3 parents the IN-RUN s2 (within-run chain)
+
+
+# --------------------------------------------------------------------------- #
+# Same-second tiebreak: equal timestamps still chain (deterministic total order)
+# --------------------------------------------------------------------------- #
+def test_same_second_snapshots_chain_incrementally(tmp_path):
+    """Two snapshots created in the SAME SECOND (equal ``time_obj``, distinct names/uuids -- e.g.
+    a fast pre/post pair, snapper's date having 1s resolution) must still chain: ordered by the
+    positional tiebreak, the later one parents off the earlier in-run transfer instead of BOTH
+    falling back to full sends. Mutation guard: selecting parents by ``time_obj <`` alone (no
+    positional tiebreak) excludes the equal-second earlier snapshot -> plan[1] parent is None
+    (a redundant full send)."""
+    s1 = _snap_named("cfg-1-20240101-000000", "20240101-000000", uuid="U1")
+    s2 = _snap_named("cfg-2-20240101-000000", "20240101-000000", uuid="U2")
+    dest = _dest(tmp_path, [])  # fresh dest
+    plan = plan_transfer_sequence([s1, s2], dest)
+    assert [s.get_name() for s, _ in plan] == [
+        "cfg-1-20240101-000000",
+        "cfg-2-20240101-000000",
+    ]
+    assert plan[0][1] is None  # oldest by (time, position): full send
+    assert plan[1][1] is s1  # SAME-SECOND child chains off s1 -- the fix
+
+
+def test_same_second_present_snapshot_is_used_as_parent(tmp_path):
+    """A same-second earlier snapshot ALREADY on the destination is a valid parent for the later
+    same-second snapshot -- the positional tiebreak makes it 'ordered before', so ``send -p`` can
+    resolve. Mutation guard: a ``time_obj``-only comparison drops it -> full send."""
+    s1 = _snap_named("cfg-1-20240101-000000", "20240101-000000", uuid="U1")
+    s2 = _snap_named("cfg-2-20240101-000000", "20240101-000000", uuid="U2")
+    dest = _dest(
+        tmp_path,
+        [
+            _snap_named(
+                "cfg-1-20240101-000000",
+                "20240101-000000",
+                uuid="Da",
+                received_uuid="U1",
+            )
+        ],
+    )
+    plan = plan_transfer_sequence([s1, s2], dest)
+    # s1 present -> skipped; s2 planned with the on-dest same-second s1 as parent.
+    assert [s.get_name() for s, _ in plan] == ["cfg-2-20240101-000000"]
+    assert plan[0][1] is s1
+
+
+def test_same_second_pair_embedded_in_longer_chain(tmp_path):
+    """A same-second pair inside a longer fresh run chains cleanly end-to-end: the oldest is
+    full, the two same-second snaps chain (second off first), and a later snap chains off the
+    second. Guards that the tiebreak threads a whole chain, not just an isolated pair."""
+    s0 = _snap_named("cfg-0-20240101-000000", "20240101-000000", uuid="U0")
+    s1 = _snap_named("cfg-1-20240101-000010", "20240101-000010", uuid="U1")
+    s2 = _snap_named(
+        "cfg-2-20240101-000010", "20240101-000010", uuid="U2"
+    )  # same sec as s1
+    s3 = _snap_named("cfg-3-20240101-000020", "20240101-000020", uuid="U3")
+    dest = _dest(tmp_path, [])
+    plan = plan_transfer_sequence([s0, s1, s2, s3], dest)
+    parents = {s.get_name(): (p.get_name() if p else None) for s, p in plan}
+    assert [s.get_name() for s, _ in plan] == [
+        "cfg-0-20240101-000000",
+        "cfg-1-20240101-000010",
+        "cfg-2-20240101-000010",
+        "cfg-3-20240101-000020",
+    ]
+    assert parents["cfg-0-20240101-000000"] is None
+    assert parents["cfg-1-20240101-000010"] == "cfg-0-20240101-000000"
+    assert (
+        parents["cfg-2-20240101-000010"] == "cfg-1-20240101-000010"
+    )  # same-second chain
+    assert parents["cfg-3-20240101-000020"] == "cfg-2-20240101-000010"
 
 
 def test_only_single_snapshot_mode(tmp_path):


### PR DESCRIPTION
## Same-second planner tiebreak

Follow-up polish surfaced during R4 P3b-2 hardware testing: two snapshots created in the **same second** (e.g. a fast pre/post pair — snapper's `date` has 1-second resolution) share a `time_obj`, and the parent predicate `o.time_obj < snap.time_obj` **excluded** an equal-timestamp earlier snapshot from being a candidate. So each same-second snapshot fell back to a **full send** instead of an incremental against its sibling — correct, but wasteful.

### Fix
A single total-order key replaces the bare timestamp:

```
_order_key(s) = (s.time_obj, position_in_source_enumeration)
```

used in **both** the transfer ordering and the parent predicate. The secondary key is the snapshot's position in `source_snapshots` (snapper number / btrfs subvol-id order = creation order), which every snapshot type carries — unlike a `.number` attribute that only snapper wrappers have.

- **Distinct timestamps:** the secondary never engages (tuple comparison stops at the first element), so ordering and parent selection are **byte-identical** to before.
- **Same-second pair:** the later snapshot now parents off the earlier one. Purely additive — it never removes a valid parent, and the parent is always earlier in execution order (safe within-run chaining).

### Validation
- 3 new tests in `test_r4_phase2_planner.py` (same-second within-run chaining, same-second already-present parent, same-second pair embedded in a longer chain) + a `_snap_named` helper for the real snapper shape (name decoupled from timestamp). All **mutation-verified** load-bearing — reverting the predicate to `time_obj <` fails all three.
- Full gate: 2463 passed, ruff/mypy clean.
- The problem was **empirically observed** during P3b-2 hardware (a same-second snapper pair produced `parent_name=null` — a full send); this deterministic pure-function fix is proven by unit + mutation.