### PR TITLE
build: pin ruff to the 0.15 line to keep CI lint green

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,10 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "pytest-asyncio>=0.23.0",
-    "ruff>=0.1.0",
+    # Pin below 0.16: ruff 0.16.0 enabled new/changed lint+format rules that flag ~1000
+    # pre-existing findings repo-wide. Adopting 0.16 is a deliberate follow-up (folds into the
+    # 0.9.0 reliability audit); until then, stay on the 0.15 line the codebase is clean against.
+    "ruff>=0.15.0,<0.16.0",
     "mypy>=1.0",
     "types-paramiko>=3.0",
 ]


### PR DESCRIPTION
## Unblock CI: constrain ruff below 0.16

ruff **0.16.0** (just released) enabled a batch of new/changed lint and format rules that flag **~1000 pre-existing findings** across the repo (`BLE001` blind-except ×229, `UP045` ×215, `PLW1510` ×85, `SIM117` ×63, `DTZ` datetime ×93, …) plus formatting tweaks. Because the `[dev]` extra declared `ruff>=0.1.0` with **no upper bound**, `pip install -e ".[dev]"` in CI resolved to 0.16.0 and every PR's **Lint & Type Check** job went red on unrelated, pre-existing code.

### Fix
Constrain the dev dependency to the 0.15 line the codebase is already clean against:

```toml
"ruff>=0.15.0,<0.16.0"
```

CI's `pip install` now resolves a compatible ruff (0.15.x) and lint goes green with **zero code churn**. `uv.lock` (gitignored) re-resolves to 0.15.22 locally to match.

### Deferred
Adopting ruff 0.16 and addressing its ~1000 findings is a deliberate, separate cleanup — several of the new rules (blind-except, naive-datetime) dovetail with the **0.9.0 reliability audit (R8)**, so the upgrade is best scheduled there rather than as a rushed mechanical sweep.