### PR TITLE
fix(retention): protect the "keep latest" slot + fail closed on invalid min (R10a)

### DIFF
--- a/src/btrfs_backup_ng/config/loader.py
+++ b/src/btrfs_backup_ng/config/loader.py
@@ -134,8 +134,21 @@ def find_config_file(explicit_path: str | None = None) -> Path | None:
 
 def _parse_retention(data: dict[str, Any]) -> RetentionConfig:
     """Parse retention configuration from dict."""
+    min_value = data.get("min", "1d")
+    # Validate the min duration at the config boundary so an invalid value fails LOUD here
+    # (ConfigError) instead of silently reaching the destructive prune path -- matching the
+    # fail-closed validation already done for compress/encrypt/source. Function-local import
+    # avoids a config<->retention import cycle.
+    from ..retention import parse_duration
+
+    try:
+        parse_duration(str(min_value))
+    except ValueError as e:
+        raise ConfigError(
+            f"Invalid retention 'min' duration: {min_value!r} ({e})"
+        ) from e
     return RetentionConfig(
-        min=data.get("min", "1d"),
+        min=min_value,
         hourly=data.get("hourly", 24),
         daily=data.get("daily", 7),
         weekly=data.get("weekly", 4),

--- a/src/btrfs_backup_ng/retention.py
+++ b/src/btrfs_backup_ng/retention.py
@@ -27,6 +27,23 @@ from .config import RetentionConfig
 logger = logging.getLogger(__name__)
 
 
+class RetentionError(Exception):
+    """Raised when a retention policy is invalid or ambiguous.
+
+    Retention decides what to DELETE, so an unresolvable policy must fail LOUD and CLOSED:
+    the caller (e.g. ``cli/prune``) catches this, prunes nothing for that volume, and reports
+    a non-zero exit -- never silently substitutes a more-permissive policy that deletes more.
+    """
+
+
+# A parsed snapshot timestamp at most this far in the future of ``now`` is treated as benign
+# clock skew (NTP jitter / VM drift / small host offset): it is clamped to ``now`` and still
+# participates in retention. Anything further in the future is quarantined (kept, but excluded
+# from the retention math) so it cannot hijack the "keep latest" slot. Full cross-timezone
+# normalization is a separate, later change; until then large skews are safely kept + warned.
+CLOCK_SKEW_TOLERANCE = timedelta(minutes=5)
+
+
 # Duration parsing regex
 DURATION_PATTERN = re.compile(r"^(?P<value>\d+)\s*(?P<unit>[smhdwMy])$")
 
@@ -217,57 +234,88 @@ def apply_retention(
     # Use provided get_name or default to str()
     name_func: Callable[[Any], str] = get_name if get_name is not None else str
 
-    # Parse minimum retention duration
+    # Parse minimum retention duration. ``min`` is a corrupt-retention selector when invalid:
+    # fail LOUD and CLOSED (raise -> the caller prunes nothing) rather than silently choosing a
+    # shorter, more-permissive window that DELETES more (the project's R1/R3 "never delete on
+    # ambiguous input" contract). Config load validates ``min`` too, so this is defence-in-depth.
     try:
         min_age = parse_duration(config.min)
-    except ValueError:
-        logger.warning("Invalid min duration '%s', defaulting to 1 day", config.min)
-        min_age = timedelta(days=1)
+    except ValueError as e:
+        raise RetentionError(
+            f"Invalid retention 'min' duration {config.min!r}: {e}"
+        ) from e
 
     min_cutoff = now - min_age
+    future_cutoff = now + CLOCK_SKEW_TOLERANCE
 
-    # Build snapshot info list with timestamps
-    snapshot_infos: list[SnapshotInfo] = []
+    # Partition the snapshots. VALID = a parseable timestamp no further in the future than the
+    # clock-skew tolerance (a within-tolerance future time is clamped to ``now`` so benign skew
+    # still participates in retention). QUARANTINED = unparseable OR implausibly future-dated:
+    # ALWAYS kept and COMPLETELY excluded from the retention math, so such an entry can never
+    # (a) consume the "keep latest" slot from the real newest snapshot, nor (b) occupy a
+    # time-bucket slot. This is the R10a data-loss fix: only real, orderable snapshots decide
+    # what gets deleted.
+    valid_infos: list[SnapshotInfo] = []
+    quarantined_infos: list[SnapshotInfo] = []
     for snap in snapshots:
         name = name_func(snap)
         timestamp = extract_timestamp(name, prefix, timestamp_format)
 
         if timestamp is None:
-            # Can't parse timestamp, keep it to be safe
-            logger.debug("Cannot parse timestamp from '%s', keeping", name)
-            snapshot_infos.append(
+            logger.warning(
+                "Retention: cannot parse a timestamp from %r; keeping it, excluded from "
+                "retention counting",
+                name,
+            )
+            quarantined_infos.append(
                 SnapshotInfo(
                     name=name,
-                    timestamp=now,  # Treat as current
+                    timestamp=now,
                     snapshot=snap,
                     keep=True,
                     keep_reason="unparseable timestamp",
                 )
             )
-        else:
-            snapshot_infos.append(
+        elif timestamp > future_cutoff:
+            logger.warning(
+                "Retention: snapshot %r is dated in the future (%s > now %s); keeping it, "
+                "excluded from retention counting -- check clock/timezone skew",
+                name,
+                timestamp,
+                now,
+            )
+            quarantined_infos.append(
                 SnapshotInfo(
                     name=name,
                     timestamp=timestamp,
                     snapshot=snap,
+                    keep=True,
+                    keep_reason="future-dated timestamp",
                 )
             )
+        else:
+            # Clamp a within-tolerance future timestamp to ``now`` so benign skew sorts as the
+            # newest and buckets correctly (it is within ``min`` anyway).
+            effective = timestamp if timestamp <= now else now
+            valid_infos.append(
+                SnapshotInfo(name=name, timestamp=effective, snapshot=snap)
+            )
 
-    # Sort by timestamp, newest first
-    snapshot_infos.sort(key=lambda s: s.timestamp, reverse=True)
+    # Sort valid snapshots newest-first (quarantined entries never participate in ordering).
+    valid_infos.sort(key=lambda s: s.timestamp, reverse=True)
 
-    # Rule 1: Always keep the latest snapshot
-    if snapshot_infos and not snapshot_infos[0].keep:
-        snapshot_infos[0].keep = True
-        snapshot_infos[0].keep_reason = "latest"
+    # Rule 1: Always keep the latest VALID snapshot (never a quarantined entry).
+    if valid_infos and not valid_infos[0].keep:
+        valid_infos[0].keep = True
+        valid_infos[0].keep_reason = "latest"
 
     # Rule 2: Keep everything within min retention period
-    for info in snapshot_infos:
+    for info in valid_infos:
         if not info.keep and info.timestamp >= min_cutoff:
             info.keep = True
             info.keep_reason = f"within min ({config.min})"
 
-    # Rule 3: Apply time bucket retention
+    # Rule 3: Apply time bucket retention (over the valid set only)
     bucket_types = [
         ("hourly", config.hourly),
         ("daily", config.daily),
@@ -280,15 +328,16 @@ def apply_retention(
         if count <= 0:
             continue
 
-        _apply_bucket_retention(snapshot_infos, bucket_type, count, min_cutoff)
+        _apply_bucket_retention(valid_infos, bucket_type, count, min_cutoff)
 
-    # Split into keep and delete lists
-    to_keep = [info.snapshot for info in snapshot_infos if info.keep]
-    to_delete = [info.snapshot for info in snapshot_infos if not info.keep]
+    # Assemble: quarantined snapshots are ALWAYS kept; only valid non-keeps are deleted.
+    to_keep = [info.snapshot for info in valid_infos if info.keep]
+    to_keep += [info.snapshot for info in quarantined_infos]
+    to_delete = [info.snapshot for info in valid_infos if not info.keep]
 
     # Log decisions
-    logger.debug("Retention decisions for %d snapshots:", len(snapshot_infos))
-    for info in snapshot_infos:
+    logger.debug("Retention decisions for %d snapshots:", len(snapshots))
+    for info in valid_infos + quarantined_infos:
         status = "KEEP" if info.keep else "DELETE"
         reason = f" ({info.keep_reason})" if info.keep_reason else ""
         logger.debug("  %s: %s%s", status, info.name, reason)

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -162,6 +162,24 @@ class TestLoadConfig:
         assert logs_volume.retention.daily == 14
         assert logs_volume.retention.weekly == 8
 
+    def test_load_invalid_retention_min(self, tmp_config_dir):
+        """R10a: an invalid retention 'min' duration fails LOUD at config load (ConfigError),
+        so a corrupt policy can never reach the destructive prune path. Mutation guard: without
+        load-time validation the bad value loads and only silently defaults/fails at prune time."""
+        bad_config = tmp_config_dir / "bad_min.toml"
+        bad_config.write_text("""
+[global.retention]
+min = "not-a-duration"
+
+[[volumes]]
+path = "/home"
+
+[[volumes.targets]]
+path = "/mnt/backup"
+""")
+        with pytest.raises(ConfigError, match="retention"):
+            load_config(bad_config)
+
     def test_load_nonexistent_file(self, tmp_path):
         """Test error when loading nonexistent file."""
         with pytest.raises(ConfigError, match="Cannot read config file"):

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -6,6 +6,8 @@ import pytest
 
 from btrfs_backup_ng.config.schema import RetentionConfig
 from btrfs_backup_ng.retention import (
+    CLOCK_SKEW_TOLERANCE,
+    RetentionError,
     apply_retention,
     extract_timestamp,
     format_retention_summary,
@@ -251,19 +253,70 @@ class TestApplyRetention:
 
         assert len(to_keep) >= 1
 
-    def test_invalid_min_duration_defaults(self):
-        """Test that invalid min duration defaults to 1 day."""
+    def test_invalid_min_raises_and_deletes_nothing(self):
+        """R10a: an invalid min fails LOUD and CLOSED -- apply_retention raises RetentionError
+        (so the caller prunes nothing) instead of silently defaulting to 1d and deleting.
+        Mutation guard: the old silent-1d fallback returns a non-empty to_delete."""
         now = datetime(2024, 1, 15, 12, 0, 0)
         retention = RetentionConfig(
             min="invalid", hourly=0, daily=0, weekly=0, monthly=0
         )
-
-        timestamps = [now - timedelta(hours=i) for i in range(5)]
+        timestamps = [now - timedelta(days=i) for i in range(5)]
         snapshots = self._make_snapshot_names(timestamps)
 
-        # Should not raise, should use default
-        to_keep, to_delete = apply_retention(snapshots, retention, now=now)
-        assert len(to_keep) >= 1
+        with pytest.raises(RetentionError):
+            apply_retention(snapshots, retention, now=now)
+
+    def test_unparseable_does_not_steal_latest(self):
+        """R10a CRITICAL: an unparseable-named entry must NOT consume the 'keep latest' slot --
+        the real newest snapshot is still kept, the junk is quarantined (kept). Mutation guard:
+        the old code assigns the unparseable timestamp=now, making IT 'latest' and DELETING the
+        real newest."""
+        now = datetime(2024, 1, 15, 12, 0, 0)
+        retention = RetentionConfig(min="0s", hourly=0, daily=0, weekly=0, monthly=0)
+        real_new = "home-20240115-100000"  # 2h before now -> newest real
+        real_old = "home-20240110-100000"
+        to_keep, to_delete = apply_retention(
+            ["garbage-name-xyz", real_new, real_old], retention, now=now
+        )
+        assert real_new in to_keep  # the real newest keeps its 'latest' guarantee
+        assert real_new not in to_delete
+        assert "garbage-name-xyz" in to_keep  # quarantined, always kept
+        assert "garbage-name-xyz" not in to_delete
+
+    def test_future_dated_does_not_steal_latest(self):
+        """R10a HIGH: a future-dated snapshot (beyond the skew tolerance) is quarantined (kept)
+        and never consumes 'latest'; the real newest valid snapshot survives. Mutation guard:
+        without the future partition it sorts first, steals latest, and the real newest is
+        deleted."""
+        now = datetime(2024, 1, 15, 12, 0, 0)
+        retention = RetentionConfig(min="0s", hourly=0, daily=0, weekly=0, monthly=0)
+        future = "home-20240115-180000"  # +6h, well beyond the 5m tolerance
+        real_new = "home-20240115-100000"
+        real_old = "home-20240110-100000"
+        to_keep, to_delete = apply_retention(
+            [future, real_new, real_old], retention, now=now
+        )
+        assert future in to_keep  # quarantined, kept
+        assert future not in to_delete
+        assert real_new in to_keep  # real newest still 'latest'
+        assert real_new not in to_delete
+
+    def test_skew_within_tolerance_is_valid_and_can_be_latest(self):
+        """R10a: a snapshot a couple minutes in the future (benign NTP jitter, within
+        CLOCK_SKEW_TOLERANCE) is treated as VALID (clamped to now), so it is the 'latest' and
+        retention still functions -- it is NOT quarantined. Mutation guard: dropping the
+        tolerance (quarantining every t>now) makes the OLDER snapshot 'latest', so nothing is
+        deleted and this test's `older in to_delete` fails."""
+        # This test fixes the skew at +2min; assert the default tolerance actually covers it.
+        assert CLOCK_SKEW_TOLERANCE >= timedelta(minutes=2)
+        now = datetime(2024, 1, 15, 12, 0, 0)
+        skew = "home-20240115-120200"  # +2min, within tolerance
+        older = "home-20240115-100000"
+        retention = RetentionConfig(min="0s", hourly=0, daily=0, weekly=0, monthly=0)
+        to_keep, to_delete = apply_retention([skew, older], retention, now=now)
+        assert skew in to_keep  # kept as the latest valid (clamped to now)
+        assert older in to_delete  # retention still runs: older is pruned
 
     def test_with_prefix(self):
         """Test retention with prefix parameter."""


### PR DESCRIPTION
## R10a — "Latest"-Slot Integrity + Invalid-Min Fail-Closed

First of the R10 retention sub-PRs (data-loss first). Grounded in an adversarial audit that **refuted** two of the originally-suspected bugs (keeping the oldest-per-bucket and all-zero→prune-to-latest are btrbk/snapper-correct) and **surfaced a CRITICAL one that wasn't on the list**: an unparseable-named entry could delete the real newest snapshot.

### Bugs fixed
1. **CRITICAL — unparseable-timestamp snapshot steals the "keep latest" slot.** `extract_timestamp → None` assigned `timestamp=now`, which sorted to the front and consumed the always-keep-latest rule → the real newest snapshot could be **deleted** (e.g. a stray `.part`/garbage-named entry + tight retention).
2. **HIGH — future-dated snapshot** (clock skew / cross-TZ) hijacked "latest" the same way, and was also permanently "within min" / unprunable.
3. **HIGH — invalid `min` silently became 1d and deleted** — failing *open* on ambiguous input, against the project's R1/R3 "never delete on ambiguous input" contract.

### Design
- **Quarantine partition:** snapshots split into **valid** (parseable, at most `CLOCK_SKEW_TOLERANCE = 5min` in the future — a within-tolerance future time is clamped to `now` so benign NTP jitter still prunes) and **quarantined** (unparseable or implausibly future-dated). Quarantined entries are **always kept and excluded from the retention math** — they can't steal the latest slot or a bucket slot. "Latest" is chosen only from the valid set. Both classes emit a `warning`.
- **Fail-closed `min`:** `apply_retention` raises `RetentionError` on an invalid `min` (prune records the error and deletes **nothing**); `_parse_retention` raises `ConfigError` at config load so a corrupt policy never reaches the delete path.
- **Behavior is byte-identical** when every snapshot has a valid, parseable, `<= now` timestamp (the common case).

### Validation
- Full gate: **2467 passed**, ruff/mypy clean.
- **All 5 fixes mutation-verified load-bearing** (clean pass→fail): unparseable/future don't steal latest, invalid-min raises, skew-within-tolerance stays valid, loader `ConfigError`.
- **Independent adversarial review: clean** — no data-loss bug, regression, or fail-closed gap; verified the keep-latest guarantee across all partition mixes, no mis-bucketing, byte-identical common case, and that prune's `except` path deletes nothing on `RetentionError`.

### Deferred (tracked)
Full timezone normalization (naive-datetime compare) — out of R10a scope; both quarantine classes fail *toward keeping*, so it's safe in the interim.

Follow-ups in this root: R10b raw incremental-parent protection · R10c ISO week + calendar M/y · R10d prune confirmation gate + degenerate-policy guardrail · R10e delete the dead count-based retention engine.