### PR TITLE
fix(retention): protect raw incremental-parent streams from pruning (R10b)

### DIFF
--- a/src/btrfs_backup_ng/cli/prune.py
+++ b/src/btrfs_backup_ng/cli/prune.py
@@ -145,6 +145,11 @@ def execute_prune(args: argparse.Namespace) -> int:
                     prefix=prefix,
                     timestamp_format=get_timestamp_format(config),
                 )
+                # Never prune a snapshot a kept one still needs as an incremental parent
+                # (no-op for btrfs; protects raw stream chains from becoming unrestorable).
+                to_keep, to_delete = source_endpoint.protect_incremental_parents(
+                    to_keep, to_delete
+                )
 
                 logger.info("  Keeping %d, deleting %d", len(to_keep), len(to_delete))
 
@@ -154,9 +159,12 @@ def execute_prune(args: argparse.Namespace) -> int:
                             logger.info("    Would delete: %s", snap.get_name())
                         total_deleted += len(to_delete)
                     else:
+                        delete_session = {s.get_name() for s in to_delete}
                         for snap in to_delete:
                             try:
-                                source_endpoint.delete_snapshots([snap])
+                                source_endpoint.delete_snapshots(
+                                    [snap], delete_session=delete_session
+                                )
                                 logger.info("    Deleted: %s", snap.get_name())
                                 total_deleted += 1
                             except Exception as e:
@@ -199,6 +207,11 @@ def execute_prune(args: argparse.Namespace) -> int:
                         prefix=prefix,
                         timestamp_format=get_timestamp_format(config),
                     )
+                    # Never prune a backup a kept one still needs as an incremental parent
+                    # (no-op for btrfs; protects raw stream chains from becoming unrestorable).
+                    to_keep, to_delete = dest_endpoint.protect_incremental_parents(
+                        to_keep, to_delete
+                    )
 
                     logger.info(
                         "    Keeping %d, deleting %d", len(to_keep), len(to_delete)
@@ -210,9 +223,12 @@ def execute_prune(args: argparse.Namespace) -> int:
                                 logger.info("      Would delete: %s", snap.get_name())
                             total_deleted += len(to_delete)
                         else:
+                            delete_session = {s.get_name() for s in to_delete}
                             for snap in to_delete:
                                 try:
-                                    dest_endpoint.delete_snapshots([snap])
+                                    dest_endpoint.delete_snapshots(
+                                        [snap], delete_session=delete_session
+                                    )
                                     logger.info("      Deleted: %s", snap.get_name())
                                     total_deleted += 1
                                 except Exception as e:

--- a/src/btrfs_backup_ng/endpoint/common.py
+++ b/src/btrfs_backup_ng/endpoint/common.py
@@ -611,6 +611,20 @@ class Endpoint:
             logger.info("Deleting old snapshot: %s", snap)
             self.delete_snapshots([snap])
 
+    def protect_incremental_parents(
+        self, to_keep: List[Any], to_delete: List[Any]
+    ) -> tuple[List[Any], List[Any]]:
+        """Adjust a retention decision so deleting a snapshot cannot break an incremental chain
+        a KEPT snapshot still depends on. Returns the (possibly adjusted) ``(to_keep, to_delete)``.
+
+        Base (btrfs) behaviour is a NO-OP: on a btrfs destination a received subvolume is
+        self-contained once committed, so pruning an incremental PARENT only forces the next
+        backup to be a full send (a bandwidth/space cost) -- never data loss. Raw targets, whose
+        backups are ``btrfs send`` STREAM files, override this: deleting a parent stream makes
+        every dependent child stream unrestorable, so raw must protect the chain.
+        """
+        return to_keep, to_delete
+
     def get_space_info(self, path: Optional[str] = None) -> SpaceInfo:
         """Get space information for the endpoint's destination path.
 

--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -1356,24 +1356,113 @@ class RawEndpoint(Endpoint):
         else:
             target.discard(lock_id)
 
+    def protect_incremental_parents(
+        self, to_keep: list, to_delete: list
+    ) -> tuple[list, list]:
+        """Raw override: never delete a stream a KEPT stream needs as an incremental parent.
+
+        A raw backup is a ``btrfs send`` stream file; an incremental child cannot be applied
+        without its parent stream, so deleting a parent silently makes its children unrestorable.
+        Walk the ``parent_name`` chain from every kept stream back to its root and rescue any
+        ancestor currently marked for deletion (transitive -- walking the full chain also covers a
+        rescued parent's own parents). A kept stream whose parent is not present on this target has
+        a chain already broken upstream (pre-existing, not caused by this prune): warn, never
+        fabricate. Legacy streams with no recorded ``parent_name`` cannot be chain-resolved and are
+        left as the time-based decision placed them.
+        """
+        by_name = {s.get_name(): s for s in list(to_keep) + list(to_delete)}
+        delete_names = {s.get_name() for s in to_delete}
+        protected: set[str] = set()
+        for leaf in to_keep:
+            cur = leaf
+            seen: set[str] = set()
+            while cur is not None:
+                parent_name = getattr(cur, "parent_name", None)
+                if not parent_name or parent_name in seen:
+                    break
+                seen.add(parent_name)
+                parent = by_name.get(parent_name)
+                if parent is None:
+                    logger.warning(
+                        "Retention: retained raw stream %r references parent %r which is not "
+                        "present on this target -- its incremental chain is already broken "
+                        "upstream (not caused by this prune)",
+                        leaf.get_name(),
+                        parent_name,
+                    )
+                    break
+                if parent.get_name() in delete_names:
+                    protected.add(parent.get_name())
+                cur = parent
+        if protected:
+            rescued = [s for s in to_delete if s.get_name() in protected]
+            to_keep = list(to_keep) + rescued
+            to_delete = [s for s in to_delete if s.get_name() not in protected]
+            logger.info(
+                "Retention: protecting %d raw incremental parent(s) from deletion: %s",
+                len(rescued),
+                ", ".join(sorted(protected)),
+            )
+        return to_keep, to_delete
+
+    def _chain_referenced_parents(
+        self, delete_batch: list[RawSnapshot], delete_session: set[str] | None = None
+    ) -> set[str]:
+        """Defence-in-depth for the delete primitive: names in ``delete_batch`` that are still the
+        recorded ``parent_name`` of a SURVIVING stream -- one present on the target and NOT part of
+        this deletion session -- so deleting them would orphan a child. The delete primitive skips
+        these for ANY caller, independent of the prune-level ``protect_incremental_parents`` pass.
+
+        ``delete_session`` (a set of names) is the FULL set intended for deletion this pass; a
+        caller that deletes a chain across multiple one-at-a-time calls (prune) passes it so a
+        legitimate whole-chain delete is not mistaken for orphaning. Absent, the session is just
+        this batch.
+        """
+        batch_names = {s.get_name() for s in delete_batch}
+        session = delete_session if delete_session is not None else batch_names
+        try:
+            current = self.list_snapshots()
+        except Exception as e:  # noqa: BLE001 - best-effort net; prune-level pass is primary
+            logger.debug("chain-guard: could not list snapshots (%s)", e)
+            return set()
+        referenced_by_survivors = {
+            s.parent_name
+            for s in current
+            if s.parent_name and s.get_name() not in session
+        }
+        return {n for n in batch_names if n in referenced_by_survivors}
+
     def delete_snapshots(self, snapshots: list[RawSnapshot], **kwargs: Any) -> None:
         """Delete raw snapshot files and their metadata.
 
         Args:
             snapshots: List of snapshots to delete
-            **kwargs: Additional arguments (unused)
+            **kwargs: ``delete_session`` (set[str]) -- the full set of names being deleted this
+                pass, so the chain guard does not mistake a whole-chain delete for orphaning.
         """
+        delete_session = kwargs.get("delete_session")
         # Prune under the per-target lock so it cannot race a concurrent backup
         # commit or backfill. If the target is busy, skip (safe -- do NOT delete
         # during contention); retention retries on the next run.
         try:
             with self.target_lock():
-                self._delete_snapshots_locked(snapshots)
+                self._delete_snapshots_locked(snapshots, delete_session)
         except RuntimeError as e:
             logger.warning("Skipping raw delete (target busy): %s", e)
 
-    def _delete_snapshots_locked(self, snapshots: list[RawSnapshot]) -> None:
+    def _delete_snapshots_locked(
+        self, snapshots: list[RawSnapshot], delete_session: set[str] | None = None
+    ) -> None:
+        protected = self._chain_referenced_parents(snapshots, delete_session)
         for snapshot in snapshots:
+            if snapshot.get_name() in protected:
+                logger.error(
+                    "Refusing to delete raw stream %r: it is the incremental parent of a stream "
+                    "that is NOT being deleted; removing it would make that child unrestorable. "
+                    "Skipping.",
+                    snapshot.get_name(),
+                )
+                continue
             try:
                 # Delete stream file
                 if snapshot.stream_path.exists():
@@ -2164,17 +2253,29 @@ class SSHRawEndpoint(RawEndpoint):
         self._cached_snapshots = snapshots
         return list(snapshots)
 
-    def _delete_snapshots_locked(self, snapshots: list[RawSnapshot]) -> None:
+    def _delete_snapshots_locked(
+        self, snapshots: list[RawSnapshot], delete_session: set[str] | None = None
+    ) -> None:
         """Delete snapshots on the remote host (issuing a remote ``rm``).
 
         This overrides the LOCAL delete primitive rather than ``delete_snapshots``,
         so both entry points that wrap it in ``target_lock`` -- ``delete_snapshots``
         (per batch) and ``delete_old_snapshots`` (whole prune pass) -- dispatch to the
         remote deletion for a raw+ssh target. Inheriting the base ``delete_snapshots``
-        keeps the (no-op) lock discipline uniform across local and remote."""
+        keeps the (no-op) lock discipline uniform across local and remote. The same
+        chain guard as the local primitive applies (never orphan a child stream)."""
+        protected = self._chain_referenced_parents(snapshots, delete_session)
         ssh_cmd = self._build_ssh_command()
 
         for snapshot in snapshots:
+            if snapshot.get_name() in protected:
+                logger.error(
+                    "Refusing to delete raw+ssh stream %r: it is the incremental parent of a "
+                    "stream that is NOT being deleted; removing it would make that child "
+                    "unrestorable. Skipping.",
+                    snapshot.get_name(),
+                )
+                continue
             try:
                 # Build rm command for stream and metadata
                 rm_cmd = (

--- a/src/btrfs_backup_ng/retention.py
+++ b/src/btrfs_backup_ng/retention.py
@@ -4,9 +4,16 @@ Implements a clear, predictable retention model:
 
 1. `min` - Absolute minimum retention period. Nothing deleted before this age.
 2. Time buckets (hourly, daily, weekly, monthly, yearly) evaluated newest-to-oldest.
-3. First snapshot in each bucket is kept.
+3. The OLDEST snapshot in each bucket is kept (the first-of-interval representative, matching
+   btrbk/snapper convention).
 4. Latest snapshot is always preserved.
-5. Snapshots needed for incremental chains are preserved automatically.
+
+Incremental chains: this module decides keep/delete purely by time. It does NOT itself preserve
+incremental parents -- that is applied afterwards by ``Endpoint.protect_incremental_parents`` on
+the (to_keep, to_delete) result. For btrfs that is a no-op (a pruned parent only forces the next
+backup to be a full send -- a bandwidth/space cost, not data loss). For raw targets it is real:
+``RawEndpoint`` refuses to delete a stream a kept stream still needs as a parent, because a raw
+child stream is unrestorable without its parent.
 
 Example:
     min = "1d"      # Keep everything for at least 1 day

--- a/tests/test_r10b_raw_parent_protection.py
+++ b/tests/test_r10b_raw_parent_protection.py
@@ -1,0 +1,141 @@
+"""R10b: raw incremental-parent protection.
+
+A raw backup is a ``btrfs send`` stream file; an incremental child stream cannot be applied
+without its parent stream. Time-based retention must therefore never delete a stream that a KEPT
+stream still needs as a parent (that would silently make the child unrestorable). btrfs targets
+are unaffected -- a pruned parent there only forces the next backup to be a full send.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from btrfs_backup_ng.endpoint.common import Endpoint
+from btrfs_backup_ng.endpoint.raw import RawEndpoint
+from btrfs_backup_ng.endpoint.raw_metadata import RawSnapshot
+
+
+def _snap(name: str, parent: str | None = None, tmp: Path = Path("/b")) -> RawSnapshot:
+    return RawSnapshot(name=name, stream_path=tmp / f"{name}.btrfs", parent_name=parent)
+
+
+def _raw(tmp_path: Path) -> RawEndpoint:
+    return RawEndpoint(config={"path": str(tmp_path)})
+
+
+# --------------------------------------------------------------------------- #
+# Part 1: prune-level protect_incremental_parents (chain walk)
+# --------------------------------------------------------------------------- #
+def test_protect_rescues_kept_childs_parent_chain(tmp_path):
+    """A kept incremental child rescues its ENTIRE parent chain from to_delete (transitive), so a
+    raw child stream can never be orphaned. Mutation guard: the btrfs no-op (return unchanged)
+    leaves the parents in to_delete."""
+    ep = _raw(tmp_path)
+    s1 = _snap("cfg-1-x")  # root (full)
+    s2 = _snap("cfg-2-x", parent="cfg-1-x")
+    s3 = _snap("cfg-3-x", parent="cfg-2-x")
+    keep, delete = ep.protect_incremental_parents([s3], [s1, s2])
+    assert {s.get_name() for s in keep} == {"cfg-1-x", "cfg-2-x", "cfg-3-x"}
+    assert delete == []
+
+
+def test_protect_allows_whole_chain_delete(tmp_path):
+    """When NOTHING in a chain is kept, the whole chain is deletable -- no false protection.
+    Mutation guard: protecting parents regardless of the kept set leaks the streams forever."""
+    ep = _raw(tmp_path)
+    s1, s2, s3 = (
+        _snap("cfg-1-x"),
+        _snap("cfg-2-x", parent="cfg-1-x"),
+        _snap("cfg-3-x", parent="cfg-2-x"),
+    )
+    keep, delete = ep.protect_incremental_parents([], [s1, s2, s3])
+    assert keep == []
+    assert {s.get_name() for s in delete} == {"cfg-1-x", "cfg-2-x", "cfg-3-x"}
+
+
+def test_protect_kept_child_missing_parent_warns_no_crash(tmp_path):
+    """A kept stream whose parent is not present (chain already broken upstream) does not crash
+    and fabricates nothing -- it is left exactly as the time-based decision placed it."""
+    ep = _raw(tmp_path)
+    orphan = _snap("cfg-9-x", parent="cfg-8-gone")
+    keep, delete = ep.protect_incremental_parents([orphan], [])
+    assert [s.get_name() for s in keep] == ["cfg-9-x"]
+    assert delete == []
+
+
+def test_protect_legacy_null_parent_left_as_is(tmp_path):
+    """Legacy streams with no recorded parent_name can't be chain-resolved; the time-based
+    decision stands (a null-parent stream in to_delete is still deleted)."""
+    ep = _raw(tmp_path)
+    keep, delete = ep.protect_incremental_parents(
+        [_snap("cfg-3-x", parent=None)], [_snap("cfg-1-x", parent=None)]
+    )
+    assert [s.get_name() for s in delete] == ["cfg-1-x"]
+
+
+def test_protect_cycle_does_not_hang(tmp_path):
+    """A pathological parent_name cycle is bounded by the visited-set guard (never infinite
+    loops)."""
+    ep = _raw(tmp_path)
+    a = _snap("a", parent="b")
+    b = _snap("b", parent="a")
+    keep, delete = ep.protect_incremental_parents([a], [b])
+    # b is a's parent -> rescued; the walk terminates on the cycle.
+    assert {s.get_name() for s in keep} == {"a", "b"}
+
+
+def test_btrfs_base_protect_is_noop():
+    """The base Endpoint (btrfs) never adjusts the retention decision -- a pruned parent there is
+    just a full re-send, not data loss. Mutation guard: any base-level protection changes it."""
+    ep = object.__new__(Endpoint)  # no __init__ needed; method is stateless
+    keep, delete = ["k"], ["d"]
+    k, d = ep.protect_incremental_parents(keep, delete)
+    assert k is keep and d is delete
+
+
+# --------------------------------------------------------------------------- #
+# Part 2: delete-primitive chain guard (defense-in-depth for any caller)
+# --------------------------------------------------------------------------- #
+def test_chain_guard_protects_survivor_referenced_parent(tmp_path):
+    """The delete primitive refuses to delete a stream referenced as parent by a SURVIVING stream
+    (not in the delete session) -- so any caller, not just prune, cannot orphan a child. Mutation
+    guard: a session-blind or absent guard returns an empty protected set here."""
+    ep = _raw(tmp_path)
+    parent = _snap("cfg-1-x", tmp=tmp_path)
+    child = _snap("cfg-2-x", parent="cfg-1-x", tmp=tmp_path)
+    ep.list_snapshots = lambda flush_cache=False: [parent, child]  # type: ignore[method-assign]
+    protected = ep._chain_referenced_parents([parent], delete_session={"cfg-1-x"})
+    assert protected == {"cfg-1-x"}
+
+
+def test_chain_guard_allows_whole_chain_via_session(tmp_path):
+    """When the whole chain is in the delete session, no member is a surviving reference, so all
+    are deletable. Mutation guard: ignoring delete_session over-protects and leaks the chain."""
+    ep = _raw(tmp_path)
+    parent = _snap("cfg-1-x", tmp=tmp_path)
+    child = _snap("cfg-2-x", parent="cfg-1-x", tmp=tmp_path)
+    ep.list_snapshots = lambda flush_cache=False: [parent, child]  # type: ignore[method-assign]
+    protected = ep._chain_referenced_parents(
+        [parent], delete_session={"cfg-1-x", "cfg-2-x"}
+    )
+    assert protected == set()
+
+
+def test_delete_locked_skips_protected_parent_on_disk(tmp_path):
+    """End-to-end on real files: _delete_snapshots_locked leaves a survivor-referenced parent's
+    stream + sidecar on disk (skipped), and only removes an unreferenced target. Mutation guard:
+    dropping the guard unlinks the parent and orphans the child."""
+    ep = _raw(tmp_path)
+    for n in ("cfg-1-x", "cfg-2-x", "cfg-9-x"):
+        (tmp_path / f"{n}.btrfs").write_text("stream")
+        (tmp_path / f"{n}.btrfs.meta").write_text("{}")
+    parent = _snap("cfg-1-x", tmp=tmp_path)
+    child = _snap("cfg-2-x", parent="cfg-1-x", tmp=tmp_path)
+    unref = _snap("cfg-9-x", tmp=tmp_path)  # nobody's parent
+    ep.list_snapshots = lambda flush_cache=False: [parent, child, unref]  # type: ignore[method-assign]
+
+    # Try to delete the parent (needed by survivor child) and the unreferenced stream.
+    ep._delete_snapshots_locked([parent, unref], delete_session={"cfg-1-x", "cfg-9-x"})
+
+    assert (tmp_path / "cfg-1-x.btrfs").exists()  # protected -> kept
+    assert not (tmp_path / "cfg-9-x.btrfs").exists()  # unreferenced -> deleted

--- a/tests/test_raw_endpoint.py
+++ b/tests/test_raw_endpoint.py
@@ -1066,6 +1066,9 @@ class TestSSHRawEndpointMethods:
             name="test",
             stream_path=Path("/backup/test.btrfs"),
         )
+        # The chain guard lists snapshots before deleting; stub it so this test isolates the
+        # remote rm (no survivors -> nothing protected -> the delete proceeds).
+        endpoint.list_snapshots = lambda flush_cache=False: []  # type: ignore[method-assign]
 
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)


### PR DESCRIPTION
## R10b — Raw Incremental-Parent Protection

Second R10 sub-PR. A raw backup is a `btrfs send` **stream file**; an incremental child cannot be applied without its parent stream. Time-based `apply_retention` decided keep/delete purely by age, so it could delete a parent still needed by a kept child — silently making that child **unrestorable** on a fresh restore while reporting success. (btrfs targets are unaffected: a pruned parent there just forces the next backup to a full send.)

### Design
- **Primary — `Endpoint.protect_incremental_parents(to_keep, to_delete)`**, called in `cli/prune` right after `apply_retention` (both source and target sites). Base (btrfs) = **no-op**. `RawEndpoint` override walks the recorded `parent_name` chain from every kept stream back to its root and **rescues** any ancestor marked for deletion — transitive, cycle-guarded. A kept stream whose parent is absent = a chain already broken upstream → warn, never fabricate. Legacy streams with no recorded `parent_name` are left as the time-based decision placed them.
- **Defense-in-depth** — the raw delete primitive (local **and** ssh) refuses to unlink a stream still referenced as `parent_name` by a **surviving** stream, so no caller (not just prune) can orphan a child. A `delete_session` set — the full batch being deleted this pass, threaded by prune — keeps a legitimate whole-chain delete from looking like orphaning (prune deletes one-at-a-time).
- **Docstring honesty** — `retention.py` no longer claims the time-based module preserves chains; that's applied afterward by the endpoint (real for raw, no-op for btrfs).

### Validation
- Full gate: **2476 passed**, ruff/mypy clean.
- **9 mutation-verified tests** (chain rescue, whole-chain-delete allowed, missing-parent warn, legacy null-parent, cycle guard, btrfs no-op, delete guard, `delete_session` soundness).
- **Hardware ALL PASS — local `raw://` + cross-machine `raw+ssh://.70`:** parents survive retention, the delete guard keeps the parent stream, the full chain restores byte-identical, and (negative control) with a parent stream deleted the orphaned child is **unrestorable** on a fresh fs (`failed`, "cannot find parent subvolume").

### Empirical note
`btrfs receive` resolves an incremental's parent subvolume by uuid across the **whole target filesystem**, not just the target dir — so this data loss manifests specifically when restoring to a **fresh/isolated fs** (the real disaster-recovery case). The hardware negative control required three isolated filesystems to be valid; a naive single-fs rig "passes" for the wrong reason (the source subvol stays findable).

Remaining in this root: R10c (ISO week + calendar M/y + docstrings) · R10d (prune confirmation gate + degenerate guardrail) · R10e (delete the dead count-based engine).