### PR TITLE
fix(retention): ISO-week bucketing + calendar-aware month/year min (R10c)

### DIFF
--- a/src/btrfs_backup_ng/retention.py
+++ b/src/btrfs_backup_ng/retention.py
@@ -23,6 +23,7 @@ Example:
     monthly = 12    # Then keep 12 monthly
 """
 
+import calendar
 import logging
 import re
 from dataclasses import dataclass
@@ -113,6 +114,39 @@ def parse_duration(duration_str: str) -> timedelta:
         raise ValueError(f"Unknown duration unit: {unit}")
 
 
+def _subtract_months(dt: datetime, months: int) -> datetime:
+    """Return ``dt`` minus ``months`` CALENDAR months, clamping the day to the target month's
+    length (e.g. Mar 31 minus 1 month -> Feb 28/29)."""
+    total = dt.year * 12 + (dt.month - 1) - months
+    year, month0 = divmod(total, 12)
+    month = month0 + 1
+    last_day = calendar.monthrange(year, month)[1]
+    return dt.replace(year=year, month=month, day=min(dt.day, last_day))
+
+
+def subtract_duration(now: datetime, duration_str: str) -> datetime:
+    """Return ``now`` minus a duration string, CALENDAR-aware for month/year units.
+
+    Seconds/minutes/hours/days/weeks are fixed timedeltas; ``M`` and ``y`` are calendar
+    arithmetic, so ``min="1M"`` means "one calendar month ago" -- aligning the ``min`` window with
+    the calendar-based monthly/yearly bucket keys instead of a fixed 30/365 days (which made
+    ``min="1M"`` up to a day short in a 31-day month and ``12M != 1y``). Raises ValueError on an
+    invalid duration; callers map it to RetentionError/ConfigError (fail closed -- never delete on
+    ambiguous input). ``parse_duration`` keeps its plain-timedelta contract for other callers.
+    """
+    s = duration_str.strip()
+    match = DURATION_PATTERN.match(s)
+    if not match:
+        raise ValueError(f"Invalid duration format: {duration_str}")
+    value = int(match.group("value"))
+    unit = match.group("unit")
+    if unit == "M":
+        return _subtract_months(now, value)
+    if unit == "y":
+        return _subtract_months(now, value * 12)
+    return now - parse_duration(s)
+
+
 @dataclass
 class SnapshotInfo:
     """Information about a snapshot for retention processing."""
@@ -200,8 +234,12 @@ def get_bucket_key(timestamp: datetime, bucket_type: str) -> str:
     elif bucket_type == "daily":
         return timestamp.strftime("%Y-%m-%d")
     elif bucket_type == "weekly":
-        # ISO week number
-        return timestamp.strftime("%Y-W%W")
+        # ISO-8601 year + week so a single ISO week is never split across a year boundary
+        # (calendar %Y + %W does: the year flips on Jan 1 while the week counter resets to 00,
+        # over-retaining a boundary week as two buckets). isocalendar() pairs the ISO week-year
+        # with the ISO week; e.g. 2023-01-01 (Sun) -> "2022-W52", not "2023-W00".
+        iso = timestamp.isocalendar()
+        return f"{iso[0]}-W{iso[1]:02d}"
     elif bucket_type == "monthly":
         return timestamp.strftime("%Y-%m")
     elif bucket_type == "yearly":
@@ -241,18 +279,18 @@ def apply_retention(
     # Use provided get_name or default to str()
     name_func: Callable[[Any], str] = get_name if get_name is not None else str
 
-    # Parse minimum retention duration. ``min`` is a corrupt-retention selector when invalid:
-    # fail LOUD and CLOSED (raise -> the caller prunes nothing) rather than silently choosing a
-    # shorter, more-permissive window that DELETES more (the project's R1/R3 "never delete on
-    # ambiguous input" contract). Config load validates ``min`` too, so this is defence-in-depth.
+    # Minimum retention cutoff, CALENDAR-aware for month/year units (subtract_duration) so
+    # ``min="1M"`` is one calendar month, aligned with the monthly/yearly bucket keys. ``min`` is
+    # a corrupt-retention selector when invalid: fail LOUD and CLOSED (raise -> the caller prunes
+    # nothing) rather than silently choosing a shorter, more-permissive window that DELETES more
+    # (R1/R3 "never delete on ambiguous input"). Config load validates ``min`` too (defence-in-depth).
     try:
-        min_age = parse_duration(config.min)
+        min_cutoff = subtract_duration(now, config.min)
     except ValueError as e:
         raise RetentionError(
             f"Invalid retention 'min' duration {config.min!r}: {e}"
         ) from e
 
-    min_cutoff = now - min_age
     future_cutoff = now + CLOCK_SKEW_TOLERANCE
 
     # Partition the snapshots. VALID = a parseable timestamp no further in the future than the

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -13,6 +13,7 @@ from btrfs_backup_ng.retention import (
     format_retention_summary,
     get_bucket_key,
     parse_duration,
+    subtract_duration,
 )
 
 
@@ -195,6 +196,21 @@ class TestGetBucketKey:
         bucket = get_bucket_key(dt, "weekly")
         # Should return a consistent key for the week
         assert bucket is not None
+
+    def test_weekly_bucket_is_iso_week_no_year_boundary_split(self):
+        """R10c: all seven days of an ISO week share ONE weekly key, even across a year boundary
+        (2021-12-27 Mon .. 2022-01-02 Sun == ISO 2021-W52). Mutation guard: calendar %Y+%W splits
+        this week into '2021-W52' and '2022-W00'."""
+        keys = {
+            get_bucket_key(datetime(2021, 12, 27) + timedelta(days=d), "weekly")
+            for d in range(7)  # Mon 2021-12-27 .. Sun 2022-01-02
+        }
+        assert keys == {"2021-W52"}
+
+    def test_weekly_bucket_jan1_maps_to_prior_iso_year(self):
+        """R10c: 2023-01-01 (a Sunday) belongs to ISO week 2022-W52, not '2023-W00'. Mutation
+        guard: %Y+%W yields '2023-W00'."""
+        assert get_bucket_key(datetime(2023, 1, 1), "weekly") == "2022-W52"
 
     def test_monthly_bucket(self):
         """Test monthly bucket calculation."""
@@ -485,3 +501,55 @@ class TestFormatRetentionSummary:
         result = format_retention_summary(to_keep, to_delete)
 
         assert "and 10 more" in result
+
+
+class TestSubtractDuration:
+    """R10c: calendar-aware min cutoff for month/year units (stdlib, no dep)."""
+
+    def test_fixed_units_unchanged(self):
+        """s/m/h/d/w stay fixed timedeltas (identical to the old behavior). Mutation guard:
+        routing these through month math changes them."""
+        now = datetime(2024, 3, 15, 12, 0, 0)
+        assert subtract_duration(now, "7d") == now - timedelta(days=7)
+        assert subtract_duration(now, "2h") == now - timedelta(hours=2)
+        assert subtract_duration(now, "3w") == now - timedelta(weeks=3)
+
+    def test_calendar_month_full_31_day_month(self):
+        """min='1M' subtracts a CALENDAR month, not a fixed 30 days: 2024-03-31 - 1M -> 2024-02-29
+        (not 2024-03-01). Mutation guard: fixed 30d yields 2024-03-01."""
+        assert subtract_duration(datetime(2024, 3, 31, 12), "1M") == datetime(
+            2024, 2, 29, 12
+        )
+
+    def test_calendar_month_day_clamp_non_leap(self):
+        """Day clamps to the target month's last day: 2023-03-31 - 1M -> 2023-02-28."""
+        assert subtract_duration(datetime(2023, 3, 31), "1M") == datetime(2023, 2, 28)
+
+    def test_12M_equals_1y_calendar(self):
+        """Calendar math makes 12M == 1y (both one calendar year), fixing the old 360d != 365d
+        mismatch. Mutation guard: the fixed 30d/365d approximation makes them differ."""
+        now = datetime(2024, 7, 15, 8, 30, 0)
+        assert subtract_duration(now, "12M") == subtract_duration(now, "1y")
+        assert subtract_duration(now, "1y") == datetime(2023, 7, 15, 8, 30, 0)
+
+    def test_year_leap_day_clamp(self):
+        """1y from a leap day clamps: 2024-02-29 - 1y -> 2023-02-28."""
+        assert subtract_duration(datetime(2024, 2, 29), "1y") == datetime(2023, 2, 28)
+
+    def test_invalid_duration_raises_valueerror(self):
+        """An invalid duration raises ValueError (callers map it to RetentionError/ConfigError --
+        fail closed)."""
+        with pytest.raises(ValueError):
+            subtract_duration(datetime(2024, 1, 1), "not-a-duration")
+
+    def test_calendar_min_keeps_snapshot_a_30day_cutoff_would_prune(self):
+        """Integration: with now on a 31-day month's last day and min='1M', a snapshot 31 days old
+        is KEPT (calendar month back), where the old fixed-30d cutoff would have PRUNED it.
+        Mutation guard: reverting to `now - parse_duration` deletes the 31-day-old snapshot."""
+        now = datetime(2024, 1, 31, 12, 0, 0)
+        newest = "home-20240131-000000"  # holds the always-keep-latest slot
+        old = "home-20231231-120000"  # 31 days before now; calendar 1M cutoff is 2023-12-31 12:00
+        retention = RetentionConfig(min="1M", hourly=0, daily=0, weekly=0, monthly=0)
+        to_keep, to_delete = apply_retention([newest, old], retention, now=now)
+        # 'old' is kept ONLY by the within-min rule -> proves the calendar cutoff reaches 31 days.
+        assert old in to_keep and old not in to_delete


### PR DESCRIPTION
## R10c — ISO Week Bucketing + Calendar Month/Year Math

Third R10 sub-PR: two retention-accuracy fixes in the time math. **No delete-path or bucket-count changes.**

### Fixes
1. **Weekly bucket = ISO week.** `get_bucket_key` used `strftime("%Y-W%W")` (labelled "ISO week number" but `%W` is *not* ISO). Pairing the calendar year with a Monday-week counter that resets to `00` on Jan 1 **splits a single ISO week across two buckets at year boundaries** → weekly retention over-retains (keeps one extra) in boundary years. Now uses `isocalendar()` (ISO year + ISO week): e.g. 2023-01-01 (Sun) → `2022-W52`, and all seven days of a boundary week share one key.
2. **Calendar-aware `min` for month/year units.** The cutoff used a fixed 30 days/month and 365/year, so `min="1M"` was up to a day short in a 31-day month and `12M ≠ 1y`, mismatching the calendar-based `%Y-%m`/`%Y` bucket keys. New stdlib `subtract_duration(now, dur)` is calendar-aware for `M`/`y` (day clamped to the target month's length, e.g. Mar 31 − 1M → Feb 28/29) and is used for the cutoff. `parse_duration` keeps its plain-`timedelta` contract for R10a config validation and any other caller — a clean separation.

### Validation
- Full gate: **2485 passed**, ruff/mypy clean.
- **9 mutation-verified tests**: 7-day year-boundary ISO week shares one key, Jan-1 → prior ISO year, calendar month full/day-clamp, `12M == 1y`, leap-day year clamp, invalid → `ValueError`, fixed-unit (`s/m/h/d/w`) regression, and an integration case where a 31-day-old snapshot is kept by calendar-`1M` but a fixed-30d cutoff would have pruned it.
- Pure deterministic date math — no hardware needed.

Remaining in this root: R10d (prune confirmation gate + degenerate-policy guardrail) · R10e (delete the dead count-based retention engine).