### PR TITLE
feat(prune): confirmation gate + degenerate-policy guardrail (R10d)

### DIFF
--- a/src/btrfs_backup_ng/cli/dispatcher.py
+++ b/src/btrfs_backup_ng/cli/dispatcher.py
@@ -238,6 +238,17 @@ def create_subcommand_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Show what would be deleted without making changes",
     )
+    prune_parser.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help="Skip the interactive confirmation prompt (for automation)",
+    )
+    prune_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Allow pruning under a degenerate policy that would keep only the latest snapshot",
+    )
 
     # list command
     list_parser = subparsers.add_parser(

--- a/src/btrfs_backup_ng/cli/prune.py
+++ b/src/btrfs_backup_ng/cli/prune.py
@@ -2,9 +2,11 @@
 
 import argparse
 import logging
+import sys
 import time
+from datetime import timedelta
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from .. import __util__, endpoint
 from ..__logger__ import add_file_handler, create_logger
@@ -18,10 +20,33 @@ from ..notifications import (
 from ..notifications import (
     NotificationConfig as NotifConfig,
 )
-from ..retention import apply_retention
+from ..retention import apply_retention, parse_duration
 from .common import get_log_level, get_timestamp_format
 
 logger = logging.getLogger(__name__)
+
+
+def _is_degenerate_policy(retention: Any) -> bool:
+    """A retention policy that would keep only the LATEST snapshot: no periodic buckets AND a
+    near-zero ``min`` (<= 1 day). Such a policy is almost always a misconfiguration (fat-fingered
+    or all-zeroed config) that would prune essentially all history, so prune refuses it without
+    ``--force``. A legitimate short-window policy (e.g. ``min="30d"`` with zeroed buckets) is NOT
+    degenerate -- it deliberately keeps a time window."""
+    if any(
+        c > 0
+        for c in (
+            retention.hourly,
+            retention.daily,
+            retention.weekly,
+            retention.monthly,
+            retention.yearly,
+        )
+    ):
+        return False
+    try:
+        return parse_duration(retention.min) <= timedelta(days=1)
+    except ValueError:
+        return False  # invalid min is rejected at config load / fails closed in apply_retention
 
 
 def execute_prune(args: argparse.Namespace) -> int:
@@ -77,7 +102,11 @@ def execute_prune(args: argparse.Namespace) -> int:
     total_kept = 0
     volumes_processed = 0
     volumes_failed = 0
-    error_messages = []
+    error_messages: list[str] = []
+    force = getattr(args, "force", False)
+    # PLAN pass: collect every deletion as (endpoint, [snapshots], label) WITHOUT touching
+    # anything, so the whole prune is shown and confirmed once before any delete happens.
+    plan: list[tuple[Any, list, str]] = []
 
     for volume in volumes:
         logger.info("Volume: %s", volume.path)
@@ -86,13 +115,30 @@ def execute_prune(args: argparse.Namespace) -> int:
 
         retention = config.get_effective_retention(volume)
         logger.info(
-            "  Retention: min=%s, hourly=%d, daily=%d, weekly=%d, monthly=%d",
+            "  Retention: min=%s, hourly=%d, daily=%d, weekly=%d, monthly=%d, yearly=%d",
             retention.min,
             retention.hourly,
             retention.daily,
             retention.weekly,
             retention.monthly,
+            retention.yearly,
         )
+
+        # Degenerate-policy guardrail: refuse to prune a volume whose policy keeps only the
+        # latest snapshot, unless --force -- enforced even non-interactively (the fat-fingered-
+        # config-nukes-all-history backstop). Does not change pruning semantics, only gates them.
+        if _is_degenerate_policy(retention) and not force:
+            logger.error(
+                "  Refusing to prune %s: retention keeps ONLY the latest snapshot "
+                "(all buckets 0, min=%s). Re-run with --force if this is intended.",
+                volume.path,
+                retention.min,
+            )
+            error_messages.append(
+                f"Refused (degenerate policy, no --force): {volume.path}"
+            )
+            volumes_failed += 1
+            continue
 
         # Build endpoint kwargs
         endpoint_kwargs = {
@@ -152,29 +198,9 @@ def execute_prune(args: argparse.Namespace) -> int:
                 )
 
                 logger.info("  Keeping %d, deleting %d", len(to_keep), len(to_delete))
-
-                if to_delete:
-                    if dry_run:
-                        for snap in to_delete:
-                            logger.info("    Would delete: %s", snap.get_name())
-                        total_deleted += len(to_delete)
-                    else:
-                        delete_session = {s.get_name() for s in to_delete}
-                        for snap in to_delete:
-                            try:
-                                source_endpoint.delete_snapshots(
-                                    [snap], delete_session=delete_session
-                                )
-                                logger.info("    Deleted: %s", snap.get_name())
-                                total_deleted += 1
-                            except Exception as e:
-                                logger.error(
-                                    "    Failed to delete %s: %s", snap.get_name(), e
-                                )
-                                error_messages.append(f"Delete {snap.get_name()}: {e}")
-                                volume_had_errors = True
-
                 total_kept += len(to_keep)
+                if to_delete:
+                    plan.append((source_endpoint, to_delete, f"source {volume.path}"))
 
         except Exception as e:
             logger.error("  Error pruning source: %s", e)
@@ -216,33 +242,9 @@ def execute_prune(args: argparse.Namespace) -> int:
                     logger.info(
                         "    Keeping %d, deleting %d", len(to_keep), len(to_delete)
                     )
-
-                    if to_delete:
-                        if dry_run:
-                            for snap in to_delete:
-                                logger.info("      Would delete: %s", snap.get_name())
-                            total_deleted += len(to_delete)
-                        else:
-                            delete_session = {s.get_name() for s in to_delete}
-                            for snap in to_delete:
-                                try:
-                                    dest_endpoint.delete_snapshots(
-                                        [snap], delete_session=delete_session
-                                    )
-                                    logger.info("      Deleted: %s", snap.get_name())
-                                    total_deleted += 1
-                                except Exception as e:
-                                    logger.error(
-                                        "      Failed to delete %s: %s",
-                                        snap.get_name(),
-                                        e,
-                                    )
-                                    error_messages.append(
-                                        f"Delete {snap.get_name()}: {e}"
-                                    )
-                                    volume_had_errors = True
-
                     total_kept += len(to_keep)
+                    if to_delete:
+                        plan.append((dest_endpoint, to_delete, f"target {target.path}"))
 
             except Exception as e:
                 logger.error("  Error pruning target %s: %s", target.path, e)
@@ -252,6 +254,42 @@ def execute_prune(args: argparse.Namespace) -> int:
         # Track volume failure
         if volume_had_errors:
             volumes_failed += 1
+
+    # ---- AGGREGATE + CONFIRM + EXECUTE ----
+    total_to_delete = sum(len(td) for _, td, _ in plan)
+    if dry_run:
+        for _ep, to_delete, label in plan:
+            for snap in to_delete:
+                logger.info("  Would delete (%s): %s", label, snap.get_name())
+        total_deleted = total_to_delete
+    elif total_to_delete == 0:
+        logger.info("Nothing to prune")
+    else:
+        # A single confirmation before ANY deletion. An interactive TTY prompts unless --yes;
+        # a non-interactive run (cron) proceeds without prompting -- a degenerate policy was
+        # already refused above unless --force, so cron cannot silently mass-delete.
+        proceed = getattr(args, "yes", False) or not sys.stdin.isatty()
+        if not proceed:
+            print(f"About to delete {total_to_delete} snapshot(s)/backup(s):")
+            for _ep, to_delete, label in plan:
+                print(f"  {label} -- {len(to_delete)}:")
+                for snap in to_delete:
+                    print(f"    - {snap.get_name()}")
+            print(f"Proceed with deleting {total_to_delete}? [y/N] ", end="")
+            proceed = input().strip().lower() in ("y", "yes")
+        if not proceed:
+            logger.info("Aborted; nothing deleted.")
+        else:
+            for ep, to_delete, label in plan:
+                delete_session = {s.get_name() for s in to_delete}
+                for snap in to_delete:
+                    try:
+                        ep.delete_snapshots([snap], delete_session=delete_session)
+                        logger.info("  Deleted (%s): %s", label, snap.get_name())
+                        total_deleted += 1
+                    except Exception as e:
+                        logger.error("  Failed to delete %s: %s", snap.get_name(), e)
+                        error_messages.append(f"Delete {snap.get_name()}: {e}")
 
     end_time = time.time()
     duration = end_time - start_time

--- a/tests/test_r10d_prune_safety.py
+++ b/tests/test_r10d_prune_safety.py
@@ -1,0 +1,181 @@
+"""R10d: prune confirmation gate + degenerate-policy guardrail.
+
+Prune now runs a plan-then-execute flow: it computes the whole deletion plan, then (for a real
+run) asks for a single confirmation on an interactive TTY unless --yes, and REFUSES a degenerate
+policy (keeps only the latest snapshot) unless --force -- enforced even non-interactively.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timedelta
+
+from btrfs_backup_ng.cli.prune import _is_degenerate_policy, execute_prune
+from btrfs_backup_ng.config.schema import RetentionConfig
+from btrfs_backup_ng.endpoint.local import LocalEndpoint
+
+
+# --------------------------------------------------------------------------- #
+# _is_degenerate_policy (pure)
+# --------------------------------------------------------------------------- #
+def test_degenerate_all_zero_buckets_with_tiny_min():
+    """All buckets 0 AND a near-zero min (<=1d) keeps only the latest -> degenerate. Mutation
+    guard: ignoring min (all-zero => degenerate) would misclassify a short-window policy."""
+    assert _is_degenerate_policy(
+        RetentionConfig(min="0s", hourly=0, daily=0, weekly=0, monthly=0, yearly=0)
+    )
+    assert _is_degenerate_policy(
+        RetentionConfig(min="1d", hourly=0, daily=0, weekly=0, monthly=0, yearly=0)
+    )
+
+
+def test_not_degenerate_short_window_policy():
+    """All buckets 0 but a real min window (30d) is a legitimate short-retention policy, NOT
+    degenerate. Mutation guard: an all-zero-only check flags this."""
+    assert not _is_degenerate_policy(
+        RetentionConfig(min="30d", hourly=0, daily=0, weekly=0, monthly=0, yearly=0)
+    )
+
+
+def test_not_degenerate_with_a_bucket():
+    """Any positive bucket count means real periodic retention -> not degenerate. Mutation guard:
+    dropping the bucket check flags a normal policy."""
+    assert not _is_degenerate_policy(
+        RetentionConfig(min="1d", hourly=0, daily=7, weekly=0, monthly=0, yearly=0)
+    )
+
+
+# --------------------------------------------------------------------------- #
+# execute_prune: gate + guardrail (drives the real CLI orchestration)
+# --------------------------------------------------------------------------- #
+def _make_config(tmp_path, retention_lines):
+    """A minimal TOML config: one volume whose (empty) source .snapshots exists so the volume is
+    not skipped, and one local target dir holding 10 prunable snapshots (2..11 days old)."""
+    src = tmp_path / "src"
+    (src / ".snapshots").mkdir(parents=True)
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    now = datetime.now()
+    for d in range(2, 12):
+        (dest / f"home-{(now - timedelta(days=d)).strftime('%Y%m%d-%H%M%S')}").mkdir()
+    cfg = tmp_path / "config.toml"
+    cfg.write_text(
+        f"[global.retention]\n{retention_lines}\n\n"
+        f'[[volumes]]\npath = "{src}"\nsnapshot_prefix = "home-"\n\n'
+        f'[[volumes.targets]]\npath = "{dest}"\n'
+    )
+    return cfg
+
+
+def _args(cfg, **kw):
+    return argparse.Namespace(
+        config=str(cfg),
+        dry_run=kw.get("dry_run", False),
+        yes=kw.get("yes", False),
+        force=kw.get("force", False),
+        verbose=False,
+        quiet=False,
+        log_level=None,
+    )
+
+
+def _drive(
+    tmp_path, retention_lines, monkeypatch, *, isatty, input_answer=None, **argkw
+):
+    """Run execute_prune with the delete primitive spied and stdin/confirmation controlled.
+    Returns (exit_code, number_of_delete_calls, input_was_called)."""
+    cfg = _make_config(tmp_path, retention_lines)
+    deletes = []
+    monkeypatch.setattr(
+        LocalEndpoint,
+        "delete_snapshots",
+        lambda self, snaps, **k: deletes.append(list(snaps)),
+    )
+    monkeypatch.setattr("sys.stdin.isatty", lambda: isatty)
+    monkeypatch.setattr(
+        "btrfs_backup_ng.cli.prune._send_prune_notifications", lambda *a, **k: None
+    )
+    # Don't let the command reconfigure logging (it would detach caplog's handler).
+    monkeypatch.setattr("btrfs_backup_ng.cli.prune.create_logger", lambda *a, **k: None)
+    called = {"input": False}
+
+    def fake_input(*_a):
+        called["input"] = True
+        return input_answer if input_answer is not None else ""
+
+    monkeypatch.setattr("builtins.input", fake_input)
+    rc = execute_prune(_args(cfg, **argkw))
+    return rc, len(deletes), called["input"]
+
+
+NORMAL = 'min = "1d"\nhourly = 0\ndaily = 3\nweekly = 0\nmonthly = 0\nyearly = 0'
+DEGENERATE = 'min = "1d"\nhourly = 0\ndaily = 0\nweekly = 0\nmonthly = 0\nyearly = 0'
+
+
+def test_degenerate_policy_refused_without_force(tmp_path, monkeypatch):
+    """A degenerate policy (keeps only latest) is REFUSED with a non-zero exit and NO deletions,
+    even non-interactively. Mutation guard: dropping the guardrail deletes almost everything."""
+    rc, ndel, _ = _drive(tmp_path, DEGENERATE, monkeypatch, isatty=False, force=False)
+    assert rc == 1
+    assert ndel == 0
+
+
+def test_degenerate_policy_proceeds_with_force(tmp_path, monkeypatch):
+    """--force overrides the degenerate-policy refusal and the prune proceeds."""
+    rc, ndel, _ = _drive(tmp_path, DEGENERATE, monkeypatch, isatty=False, force=True)
+    assert ndel > 0  # deletions happened
+
+
+def test_non_tty_proceeds_without_prompt(tmp_path, monkeypatch):
+    """A normal policy on a non-interactive run (cron) proceeds without prompting. Mutation
+    guard: requiring a prompt in non-TTY would hang or delete nothing here (input not called)."""
+    rc, ndel, input_called = _drive(tmp_path, NORMAL, monkeypatch, isatty=False)
+    assert rc == 0 and ndel > 0 and input_called is False
+
+
+def test_tty_confirmation_decline_aborts(tmp_path, monkeypatch):
+    """On a TTY without --yes, answering 'n' aborts with ZERO deletions. Mutation guard: not
+    honoring the decline deletes anyway."""
+    rc, ndel, input_called = _drive(
+        tmp_path, NORMAL, monkeypatch, isatty=True, input_answer="n"
+    )
+    assert input_called is True
+    assert ndel == 0
+
+
+def test_tty_confirmation_accept_proceeds(tmp_path, monkeypatch):
+    """On a TTY, answering 'y' proceeds with the deletions."""
+    rc, ndel, input_called = _drive(
+        tmp_path, NORMAL, monkeypatch, isatty=True, input_answer="y"
+    )
+    assert input_called is True
+    assert ndel > 0
+
+
+def test_yes_flag_skips_prompt(tmp_path, monkeypatch):
+    """--yes proceeds without prompting even on a TTY (input never called). Mutation guard:
+    ignoring --yes would prompt (input called) / block."""
+    rc, ndel, input_called = _drive(
+        tmp_path, NORMAL, monkeypatch, isatty=True, input_answer="n", yes=True
+    )
+    assert input_called is False
+    assert (
+        ndel > 0
+    )  # proceeded despite the 'n' answer, because --yes skipped the prompt
+
+
+def test_dry_run_never_deletes(tmp_path, monkeypatch):
+    """--dry-run computes the plan and deletes nothing, regardless of policy."""
+    rc, ndel, input_called = _drive(
+        tmp_path, NORMAL, monkeypatch, isatty=True, dry_run=True
+    )
+    assert rc == 0 and ndel == 0 and input_called is False
+
+
+def test_resolved_policy_log_includes_yearly(tmp_path, monkeypatch, caplog):
+    """R10d/critic#10: the resolved-policy log line includes yearly (was omitted)."""
+    import logging
+
+    with caplog.at_level(logging.INFO):
+        _drive(tmp_path, NORMAL, monkeypatch, isatty=False)
+    assert any("yearly=" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## R10d — Prune Confirmation Gate + Degenerate-Policy Guardrail

Fourth R10 sub-PR: the first user-facing safety layer on `prune`. `execute_prune` is restructured into **plan-then-execute** (compute the full deletion plan across all volumes/sources/targets, *then* act), which enables one consolidated confirmation instead of deleting inline mid-scan.

### What's new
- **Confirmation gate** — a real (non-`--dry-run`) prune prints the plan and prompts once for `[y/N]` on an interactive **TTY** before any deletion; **`--yes`** skips it. A **non-interactive run (cron) proceeds without prompting** so schedules don't hang.
- **Degenerate-policy guardrail** — a policy that would keep **only the latest snapshot** (all bucket counts `0` **and** `min <= 1 day`) is **refused** with a non-zero exit and **zero deletions** unless **`--force`** — enforced *even non-interactively*, so a fat-fingered / all-zeroed config can't silently mass-delete history. A legitimate short-window policy (e.g. `min="30d"` with zeroed buckets) is **not** degenerate.
- **Resolved-policy log** now includes `yearly` (was omitted — critic finding #10), so a partial `[retention]` block's inherited defaults are visible.
- New flags: **`--yes`** (skip the routine prompt) and **`--force`** (override the degenerate refusal) — kept distinct on purpose.

Pruning **semantics are unchanged** — these are guardrails around the destructive act, and `protect_incremental_parents` (R10b) still runs in the plan pass.

### Validation
- Full gate: **2496 passed**, ruff/mypy clean.
- **11 mutation-verified tests**: `_is_degenerate_policy` (all-zero+tiny-min vs short-window vs has-bucket); and `execute_prune` end-to-end — degenerate refused without `--force` / proceeds with it, non-TTY proceeds without prompt, TTY decline aborts (0 deletions), TTY accept proceeds, `--yes` skips the prompt, `--dry-run` never deletes, resolved-policy log includes `yearly`. Mutations bypassing the guardrail, ignoring the decline, or dropping `yearly` all fail their tests.
- Pure CLI orchestration — no hardware needed.

Remaining in this root: **R10e** — delete the dead count-based `delete_old_snapshots(keep)` retention engine.