### PR TITLE
docs(retention): mark the legacy count-based path as legacy (R10e)

### DIFF
--- a/src/btrfs_backup_ng/core/execution.py
+++ b/src/btrfs_backup_ng/core/execution.py
@@ -36,9 +36,15 @@ def run_task(
 ) -> list[JobResult]:
     """Run a backup task with given endpoints.
 
-    This is the main entry point for executing a backup task.
-    Handles snapshot creation, transfer to all destinations,
-    and cleanup.
+    Handles snapshot creation, transfer to all destinations, and cleanup.
+
+    LEGACY path: this drives the old-style CLI (``_legacy_main`` via
+    ``cli/dispatcher.is_legacy_mode``) and its COUNT-based cleanup
+    (``_cleanup_snapshots`` -> ``Endpoint.delete_old_snapshots(keep)``). The MODERN CLI does
+    not use it: the ``run`` command transfers via ``core.operations.sync_snapshots`` and the
+    ``prune`` command applies the TIME-based policy engine ``retention.apply_retention``. Kept
+    for backwards compatibility; do not wire new code through here -- use ``prune``/
+    ``apply_retention`` for retention.
 
     Args:
         source_endpoint: Prepared source endpoint
@@ -100,7 +106,10 @@ def run_task(
 
 
 def _cleanup_snapshots(source_endpoint, destination_endpoints, options) -> None:
-    """Clean up old snapshots according to retention settings."""
+    """LEGACY COUNT-based cleanup: keep the most recent ``num_snapshots``/``num_backups`` via
+    ``Endpoint.delete_old_snapshots(keep)``. Used only by the legacy ``run_task`` path. The
+    modern retention authority is the TIME-based ``retention.apply_retention`` (``prune``
+    command); prefer that."""
     logger.info(__util__.log_heading("Cleaning up..."))
 
     num_snapshots = options.get("num_snapshots", 0)

--- a/src/btrfs_backup_ng/endpoint/common.py
+++ b/src/btrfs_backup_ng/endpoint/common.py
@@ -586,8 +586,15 @@ class Endpoint:
         self.delete_snapshots([snapshot], **kwargs)
 
     def delete_old_snapshots(self, keep: int) -> None:
-        """
-        Delete old snapshots, keeping only the most recent `keep` unlocked snapshots.
+        """Delete old snapshots, keeping only the most recent ``keep`` unlocked snapshots.
+
+        LEGACY COUNT-based retention: keeps a fixed NUMBER of snapshots, ignoring age/time
+        buckets. It is used only by the legacy CLI path (``core.execution.run_task`` ->
+        ``_cleanup_snapshots``, reached via ``cli/dispatcher.is_legacy_mode``). The MODERN,
+        time-based policy engine is ``retention.apply_retention`` (min + hourly/daily/weekly/
+        monthly/yearly buckets), driven by the ``prune`` command -- prefer it for any new code.
+        Chain/lock safety is preserved either way: this routes deletions through
+        ``delete_snapshots`` (R10b incremental-parent guard) and skips R3-locked snapshots.
         """
         snapshots = self.list_snapshots()
         if getattr(self, "_locks_read_failed", False):

--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -1495,6 +1495,9 @@ class RawEndpoint(Endpoint):
     def delete_old_snapshots(self, keep: int) -> None:
         """Delete old snapshots, keeping only the most recent.
 
+        LEGACY count-based path (see ``Endpoint.delete_old_snapshots``); the modern retention
+        engine is time-based ``retention.apply_retention`` via ``prune``.
+
         Args:
             keep: Number of snapshots to keep
         """

--- a/src/btrfs_backup_ng/endpoint/ssh.py
+++ b/src/btrfs_backup_ng/endpoint/ssh.py
@@ -616,8 +616,10 @@ class SSHEndpoint(Endpoint):
                 logger.debug(f"Deletion exception details: {e}", exc_info=True)
 
     def delete_old_snapshots(self, keep: int) -> None:
-        """
-        Delete old snapshots on the remote host, keeping only the most recent `keep` unlocked snapshots.
+        """Delete old snapshots on the remote host, keeping the most recent ``keep`` unlocked.
+
+        LEGACY count-based path (see ``Endpoint.delete_old_snapshots``); the modern retention
+        engine is time-based ``retention.apply_retention`` via ``prune``.
         """
         snapshots = self.list_snapshots()  # type: ignore
         unlocked = [  # type: ignore


### PR DESCRIPTION
## R10e — Legacy count-based retention path: documented, not deleted

The R10 audit's premise for R10e ("delete the dead count-based `delete_old_snapshots(keep)` engine") was **empirically refuted**: it is **not dead**. `core.execution.run_task` → `_cleanup_snapshots` → `Endpoint.delete_old_snapshots(keep)` is the **live retention path of the legacy CLI mode** — old-style `btrfs-backup-ng <src> <dst>` invocations route through `cli/dispatcher.is_legacy_mode` → `_legacy_main.legacy_main` → `run_task` (also called directly at `_legacy_main:386/393/521`). It's covered by `test_r1_legacy_exit_code`, `test_cli`, `test_cli_e2e`. Deleting it would break backwards compatibility + those tests.

It's also already **data-safe**: its deletions route through `delete_snapshots`, which carries R10b's incremental-parent chain guard, and it skips R3-locked snapshots — so there's no safety gain from removing it.

So instead of deleting live code, this PR **documents** it: the docstrings on `delete_old_snapshots` (base `Endpoint` + raw + ssh) and `run_task`/`_cleanup_snapshots` now clearly mark them the **legacy count-based** path and point to the modern time-based policy engine `retention.apply_retention` (the `prune` command) for any new code.

**No behavior change.** Gate: 2496 passed, ruff/mypy clean.

This closes **Root R10 (retention)** — R10a (latest-slot integrity + fail-closed min), R10b (raw incremental-parent protection), R10c (ISO week + calendar month/year), R10d (prune confirmation gate + degenerate guardrail), R10e (legacy-path clarity).