### PR TITLE
docs: prune --yes/--force + confirmation gate and 0.9.0 retention semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ See the [LICENSE](LICENSE) file for full copyright attribution.
 - **Full Snapper Support**: Back up and restore Snapper-managed snapshots
 - **Metadata Preservation**: Preserves `info.xml` for seamless Snapper restoration
 - **Pre/Post Pairs**: Supports single, pre, and post snapshot types
-- **Incremental Transfers**: Efficient delta-based transfers between snapshots
+- **Incremental Transfers**: Efficient delta-based transfers between snapshots, with the parent
+  matched by btrfs UUID correspondence (name for raw targets) — so a re-created snapshot with the
+  same name but new content is correctly treated as new, never reused as an incorrect parent
 - **Generate Config**: Auto-generate TOML config from existing Snapper setup
 
 ### btrbk Migration
@@ -526,14 +528,33 @@ sudo chown root:root /etc/btrfs-backup-ng/config.toml
 ```toml
 [global.retention]
 min = "1d"       # Keep all snapshots for at least 1 day
-hourly = 24      # Keep 24 hourly snapshots
-daily = 7        # Keep 7 daily snapshots
-weekly = 4       # Keep 4 weekly snapshots
-monthly = 12     # Keep 12 monthly snapshots
+hourly = 24      # Keep 24 hourly snapshots (one per hour)
+daily = 7        # Keep 7 daily snapshots (one per day)
+weekly = 4       # Keep 4 weekly snapshots (one per ISO week)
+monthly = 12     # Keep 12 monthly snapshots (one per calendar month)
 yearly = 0       # Don't keep yearly (0 = disabled)
 ```
 
-Duration format: `30m` (minutes), `2h` (hours), `1d` (days), `1w` (weeks)
+**How retention decides what to keep:**
+
+1. Everything is kept for at least `min`.
+2. The latest snapshot is always kept.
+3. For each time bucket, the **oldest** snapshot in the bucket is kept — the "first-of-interval"
+   representative, matching the btrbk/snapper convention — for the newest N buckets of each type.
+
+**Duration format:** `30s` (seconds), `30m` (minutes), `2h` (hours), `1d` (days), `1w` (weeks),
+`1M` (month), `1y` (year). Months and years are **calendar-aware**: `min = "1M"` means one calendar
+month (aligned with the monthly bucket boundary), not a flat 30 days, and `1y` is one calendar year.
+Weekly buckets use **ISO-8601 week numbering**, so a week that straddles a year boundary is counted
+once rather than split in two.
+
+An invalid `min` value (e.g. a typo) now **fails loudly** and prunes nothing for that volume, rather
+than silently falling back to a shorter window and deleting more than intended.
+
+> **Safety:** on an interactive terminal, [`prune`](#prune) shows its deletion plan and asks for
+> confirmation first (skip with `--yes`). A degenerate policy that would keep *only* the latest
+> snapshot (all buckets `0` **and** `min` ≤ 1 day) is refused unless you pass `--force`, even
+> non-interactively — so a mistyped or empty retention block can't silently wipe your history.
 
 ### Volume Configuration
 

--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -122,14 +122,48 @@ btrfs-backup-ng prune [OPTIONS]
 | Option | Description |
 |--------|-------------|
 | `--dry-run` | Show what would be deleted without making changes |
+| `--yes`, `-y` | Skip the interactive confirmation prompt (for automation) |
+| `--force` | Prune even under a degenerate policy that would keep only the latest snapshot |
+
+**Confirmation prompt.** On an interactive terminal, a real (non-`--dry-run`) prune first prints
+the full deletion plan and asks for confirmation before deleting anything:
+
+```
+About to delete 5 snapshot(s)/backup(s):
+  source /home -- 2:
+    - home-20260101-000000
+    - home-20260102-000000
+  target /mnt/backup/home -- 3:
+    - home-20260103-000000
+    - home-20260104-000000
+    - home-20260105-000000
+Proceed with deleting 5? [y/N]
+```
+
+Declining aborts with **zero** deletions. In a non-interactive context (cron, a pipe, a script)
+the prompt is skipped and the prune proceeds — use `--yes` to skip the prompt in an interactive
+terminal too.
+
+**Degenerate-policy guard.** A retention policy that would keep **only the latest snapshot** — all
+time buckets set to `0` **and** `min` ≤ 1 day — is almost always a misconfiguration that would
+delete your entire history. Prune **refuses** such a policy (deleting nothing, with a non-zero
+exit) unless you pass `--force`, and this refusal applies **even non-interactively** so a
+fat-fingered config cannot silently wipe your backups. A legitimate short-window policy (e.g.
+`min = "30d"` with all buckets `0`) is *not* degenerate and prunes normally.
 
 **Examples:**
 ```bash
-# Apply retention policies
+# Apply retention policies (prompts for confirmation on an interactive terminal)
 btrfs-backup-ng prune
 
-# See what would be deleted
+# See what would be deleted, change nothing
 btrfs-backup-ng prune --dry-run
+
+# Non-interactive / automation: skip the prompt
+btrfs-backup-ng prune --yes
+
+# Intentionally prune under a keep-only-latest policy
+btrfs-backup-ng prune --force
 ```
 
 ---

--- a/docs/MIGRATING-FROM-BTRBK.md
+++ b/docs/MIGRATING-FROM-BTRBK.md
@@ -128,7 +128,21 @@ btrbk's retention syntax can be confusing. Here's how it maps:
 
 **Important**: btrfs-backup-ng uses a simpler mental model:
 1. `min` - Keep everything for at least this duration
-2. Time buckets (hourly, daily, weekly, monthly, yearly) - Keep N snapshots per bucket
+2. Time buckets (hourly, daily, weekly, monthly, yearly) - Keep N snapshots per bucket, keeping
+   the **oldest** snapshot in each bucket (the same first-of-interval representative btrbk uses)
+
+A few semantics worth knowing when coming from btrbk:
+
+- `min` with **month/year** units (`"1M"`, `"1y"`) is **calendar-aware** — `min = "1M"` is one
+  calendar month (28–31 days), not a flat 30 days — so the minimum-retention window lines up with
+  the monthly/yearly bucket boundaries.
+- **Weekly** buckets use **ISO-8601** week numbering, so a week that straddles a calendar-year
+  boundary (late Dec / early Jan) is counted as one week, matching btrbk/snapper.
+- **`prune` safety.** On an interactive terminal, `btrfs-backup-ng prune` (see
+  [CLI Reference](CLI-REFERENCE.md#prune)) shows its deletion plan and asks for confirmation
+  before deleting (skip with `--yes` for cron/automation), and it **refuses** a degenerate policy
+  that would keep only the latest snapshot (all buckets `0` with `min ≤ 1d`) unless you pass
+  `--force` — a guard against a mistyped policy wiping your history.
 
 ### Volume and Subvolume Mapping
 

--- a/man/man1/btrfs-backup-ng-prune.1
+++ b/man/man1/btrfs-backup-ng-prune.1
@@ -1,5 +1,5 @@
 .\" Man page for btrfs-backup-ng prune
-.TH BTRFS-BACKUP-NG-PRUNE 1 "January 2026" "btrfs-backup-ng" "User Commands"
+.TH BTRFS-BACKUP-NG-PRUNE 1 "July 2026" "btrfs-backup-ng" "User Commands"
 .SH NAME
 btrfs-backup-ng-prune \- apply retention policies
 .SH SYNOPSIS
@@ -18,23 +18,66 @@ Retention is evaluated with these rules:
 Time buckets (hourly, daily, weekly, monthly, yearly) are evaluated
 newest-to-oldest.
 .IP 3. 3
-The first snapshot in each bucket is kept.
+The oldest snapshot in each time bucket is kept (the first-of-interval
+representative, matching the btrbk/snapper convention).
 .IP 4. 3
 The latest snapshot is always preserved.
 .IP 5. 3
-Snapshots needed for incremental backup chains are preserved.
+For raw (stream-file) targets, a parent stream that a kept incremental backup
+still needs is never deleted (deleting it would make the newer backup
+unrestorable). For btrfs targets a pruned parent simply forces the next backup
+to be a full send.
+.PP
+Note on durations:
+.BR min " values in months or years (" "1M" ", " "1y" ") are calendar-aware in"
+this version \(em
+.B 1M
+is one calendar month (aligned with the monthly bucket), not a flat 30 days.
+Weekly buckets use ISO\(hy8601 week numbering, so a week that straddles a year
+boundary is counted once. An invalid
+.B min
+value now fails loudly (the volume is skipped) rather than silently defaulting.
+.SH SAFETY
+On an interactive terminal, a real (non\(hy\fB\-\-dry-run\fR) prune prints the
+full deletion plan and prompts for confirmation before deleting anything;
+declining aborts with no deletions. In a non\(hyinteractive context (cron, a
+pipe) the prompt is skipped and prune proceeds \(em use
+.B \-\-yes
+to skip the prompt in an interactive terminal too.
+.PP
+A degenerate policy that would keep
+.B only
+the latest snapshot (all time buckets 0 and
+.BR min " \(<= 1 day)"
+is refused, deleting nothing, unless
+.B \-\-force
+is given \(em enforced even non\(hyinteractively, so a misconfiguration cannot
+silently wipe your history. A short\(hywindow policy with a real
+.BR min " (e.g. " "30d" " with zero buckets) is not degenerate."
 .SH OPTIONS
 .TP
 .B \-\-dry-run
 Show what would be deleted without making any changes. Highly recommended
 before running prune for the first time.
+.TP
+.BR \-\-yes ", " \-y
+Skip the interactive confirmation prompt (for automation).
+.TP
+.B \-\-force
+Prune even under a degenerate policy that would keep only the latest snapshot.
 .SH EXAMPLES
 .TP
 Show what would be pruned (dry run):
 .B btrfs-backup-ng prune --dry-run
 .TP
-Apply retention policies:
+Apply retention policies (prompts on an interactive terminal):
 .B btrfs-backup-ng prune
+.TP
+Non\(hyinteractive / automation (skip the prompt):
+.B btrfs-backup-ng prune --yes
+.TP
+Intentionally prune under a keep\(hyonly\(hylatest policy:
+.B btrfs-backup-ng prune --force
 .SH RETENTION CONFIGURATION
 Example retention settings in config.toml:
 .PP

--- a/man/man1/btrfs-backup-ng.1
+++ b/man/man1/btrfs-backup-ng.1
@@ -127,25 +127,35 @@ compress = "zstd"
 .fi
 .RE
 .SH RETENTION POLICIES
-Time-based retention uses these settings:
+Time-based retention (applied by the
+.BR btrfs-backup-ng-prune (1)
+command) uses these settings. For each bucket the
+.B oldest
+snapshot in the interval is kept (the first\(hyof\(hyinterval representative,
+matching the btrbk/snapper convention).
 .TP
 .B min
-Minimum retention period (e.g., "1d", "12h"). Nothing is deleted before this age.
+Minimum retention period (e.g., "1d", "12h", "1M", "1y"). Nothing is deleted
+before this age. Month and year units are calendar\(hyaware:
+.B 1M
+is one calendar month (not a flat 30 days) and
+.B 1y
+is one calendar year. An invalid value fails loudly and prunes nothing.
 .TP
 .B hourly
-Number of hourly snapshots to keep.
+Number of hourly snapshots to keep (one per clock hour).
 .TP
 .B daily
-Number of daily snapshots to keep.
+Number of daily snapshots to keep (one per day).
 .TP
 .B weekly
-Number of weekly snapshots to keep.
+Number of weekly snapshots to keep (one per ISO\(hy8601 week).
 .TP
 .B monthly
-Number of monthly snapshots to keep.
+Number of monthly snapshots to keep (one per calendar month).
 .TP
 .B yearly
-Number of yearly snapshots to keep.
+Number of yearly snapshots to keep (one per year).
 .SH COMPRESSION
 Supported compression methods for transfers:
 .TP


### PR DESCRIPTION
Documentation refresh so the docs match the shipped 0.9.0 behavior. **Docs-only, no code.** Findings came from a two-agent audit of README/CLI-REFERENCE and the man pages/guides.

### HIGH — the new `prune` CLI surface (R10d), previously undocumented
- **`docs/CLI-REFERENCE.md`** and **`man/man1/btrfs-backup-ng-prune.1`**: `--yes`/`-y` and `--force` flags; the interactive `[y/N]` confirmation (non-interactive/cron runs proceed without prompting); the degenerate-policy refusal (keep-only-latest ⇒ needs `--force`, even non-interactively).

### MEDIUM — retention semantics (R10a–c)
- **`README.md`**, **`man/man1/btrfs-backup-ng.1`**, **`docs/MIGRATING-FROM-BTRBK.md`**: `min="1M"`/`"1y"` are calendar months/years (not 30/365 days); weekly buckets use ISO weeks; the **oldest** snapshot per bucket is kept (btrbk/snapper first-of-interval); an invalid `min` now fails loudly.

### LOW
- **`README.md`** incremental-transfers bullet: parents matched by btrfs UUID correspondence (name for raw) — a re-created same-name snapshot is treated as new.

Man pages verified with `groff -man -z` (no warnings).

### Deliberately NOT changed here
The docs describe `run` as "snapshot + transfer + **prune**", but `run` does not currently prune (see the separate note I raised) — that's a behavior question, not a doc-accuracy fix, so it's left untouched pending a decision.