### PR TITLE
feat(run): apply retention after transfer — run = snapshot + transfer + prune (0.9.1)

### DIFF
--- a/src/btrfs_backup_ng/cli/prune.py
+++ b/src/btrfs_backup_ng/cli/prune.py
@@ -26,12 +26,13 @@ from .common import get_log_level, get_timestamp_format
 logger = logging.getLogger(__name__)
 
 
-def _is_degenerate_policy(retention: Any) -> bool:
+def is_degenerate_policy(retention: Any) -> bool:
     """A retention policy that would keep only the LATEST snapshot: no periodic buckets AND a
     near-zero ``min`` (<= 1 day). Such a policy is almost always a misconfiguration (fat-fingered
-    or all-zeroed config) that would prune essentially all history, so prune refuses it without
-    ``--force``. A legitimate short-window policy (e.g. ``min="30d"`` with zeroed buckets) is NOT
-    degenerate -- it deliberately keeps a time window."""
+    or all-zeroed config) that would prune essentially all history, so both the ``prune`` command
+    and the ``run`` pipeline refuse it (``prune`` unless ``--force``; ``run`` always, since an
+    intentional degenerate prune is an explicit ``prune --force``). A legitimate short-window
+    policy (e.g. ``min="30d"`` with zeroed buckets) is NOT degenerate -- it keeps a time window."""
     if any(
         c > 0
         for c in (
@@ -47,6 +48,49 @@ def _is_degenerate_policy(retention: Any) -> bool:
         return parse_duration(retention.min) <= timedelta(days=1)
     except ValueError:
         return False  # invalid min is rejected at config load / fails closed in apply_retention
+
+
+def plan_endpoint_retention(
+    endpoint_obj: Any, retention: Any, prefix: str, timestamp_format: str | None
+) -> tuple[list, list]:
+    """The shared, deterministic retention PLAN for one endpoint: list its snapshots, apply the
+    time-based policy, then protect incremental parents. Returns ``(to_keep, to_delete)``. Raises
+    ``RetentionError`` on an invalid ``min`` (fail-closed -- the caller prunes nothing and errors).
+    Both the ``prune`` command and the ``run`` pipeline use this, so they can never diverge."""
+    snapshots = endpoint_obj.list_snapshots()
+    if not snapshots:
+        return [], []
+    to_keep, to_delete = apply_retention(
+        snapshots,
+        retention,
+        get_name=lambda s: s.get_name(),
+        prefix=prefix,
+        timestamp_format=timestamp_format,
+    )
+    # Never prune a snapshot a kept one still needs as an incremental parent (no-op for btrfs;
+    # protects raw stream chains from becoming unrestorable).
+    return endpoint_obj.protect_incremental_parents(to_keep, to_delete)
+
+
+def execute_retention_deletes(
+    endpoint_obj: Any, to_delete: list
+) -> tuple[int, list[str]]:
+    """Delete ``to_delete`` on one endpoint, passing the full batch as the delete-session (so the
+    chain guard never mistakes a whole-chain delete for orphaning). Returns
+    ``(deleted_count, error_messages)`` -- a per-snapshot failure is recorded, not raised, so one
+    bad delete does not abort the rest."""
+    if not to_delete:
+        return 0, []
+    delete_session = {s.get_name() for s in to_delete}
+    deleted = 0
+    errors: list[str] = []
+    for snap in to_delete:
+        try:
+            endpoint_obj.delete_snapshots([snap], delete_session=delete_session)
+            deleted += 1
+        except Exception as e:  # noqa: BLE001 - record and continue
+            errors.append(f"Delete {snap.get_name()}: {e}")
+    return deleted, errors
 
 
 def execute_prune(args: argparse.Namespace) -> int:
@@ -127,7 +171,7 @@ def execute_prune(args: argparse.Namespace) -> int:
         # Degenerate-policy guardrail: refuse to prune a volume whose policy keeps only the
         # latest snapshot, unless --force -- enforced even non-interactively (the fat-fingered-
         # config-nukes-all-history backstop). Does not change pruning semantics, only gates them.
-        if _is_degenerate_policy(retention) and not force:
+        if is_degenerate_policy(retention) and not force:
             logger.error(
                 "  Refusing to prune %s: retention keeps ONLY the latest snapshot "
                 "(all buckets 0, min=%s). Re-run with --force if this is intended.",
@@ -179,28 +223,13 @@ def execute_prune(args: argparse.Namespace) -> int:
             )
             source_endpoint.prepare()
 
-            snapshots = source_endpoint.list_snapshots()
-            logger.info("  Source: %d snapshots", len(snapshots))
-
-            if snapshots:
-                # Apply time-based retention
-                to_keep, to_delete = apply_retention(
-                    snapshots,
-                    retention,
-                    get_name=lambda s: s.get_name(),
-                    prefix=prefix,
-                    timestamp_format=get_timestamp_format(config),
-                )
-                # Never prune a snapshot a kept one still needs as an incremental parent
-                # (no-op for btrfs; protects raw stream chains from becoming unrestorable).
-                to_keep, to_delete = source_endpoint.protect_incremental_parents(
-                    to_keep, to_delete
-                )
-
-                logger.info("  Keeping %d, deleting %d", len(to_keep), len(to_delete))
-                total_kept += len(to_keep)
-                if to_delete:
-                    plan.append((source_endpoint, to_delete, f"source {volume.path}"))
+            to_keep, to_delete = plan_endpoint_retention(
+                source_endpoint, retention, prefix, get_timestamp_format(config)
+            )
+            logger.info("  Keeping %d, deleting %d", len(to_keep), len(to_delete))
+            total_kept += len(to_keep)
+            if to_delete:
+                plan.append((source_endpoint, to_delete, f"source {volume.path}"))
 
         except Exception as e:
             logger.error("  Error pruning source: %s", e)
@@ -221,30 +250,13 @@ def execute_prune(args: argparse.Namespace) -> int:
                 )
                 dest_endpoint.prepare()
 
-                dest_snapshots = dest_endpoint.list_snapshots()
-                logger.info("  Target %s: %d backups", target.path, len(dest_snapshots))
-
-                if dest_snapshots:
-                    # Apply time-based retention
-                    to_keep, to_delete = apply_retention(
-                        dest_snapshots,
-                        retention,
-                        get_name=lambda s: s.get_name(),
-                        prefix=prefix,
-                        timestamp_format=get_timestamp_format(config),
-                    )
-                    # Never prune a backup a kept one still needs as an incremental parent
-                    # (no-op for btrfs; protects raw stream chains from becoming unrestorable).
-                    to_keep, to_delete = dest_endpoint.protect_incremental_parents(
-                        to_keep, to_delete
-                    )
-
-                    logger.info(
-                        "    Keeping %d, deleting %d", len(to_keep), len(to_delete)
-                    )
-                    total_kept += len(to_keep)
-                    if to_delete:
-                        plan.append((dest_endpoint, to_delete, f"target {target.path}"))
+                to_keep, to_delete = plan_endpoint_retention(
+                    dest_endpoint, retention, prefix, get_timestamp_format(config)
+                )
+                logger.info("    Keeping %d, deleting %d", len(to_keep), len(to_delete))
+                total_kept += len(to_keep)
+                if to_delete:
+                    plan.append((dest_endpoint, to_delete, f"target {target.path}"))
 
             except Exception as e:
                 logger.error("  Error pruning target %s: %s", target.path, e)
@@ -281,15 +293,12 @@ def execute_prune(args: argparse.Namespace) -> int:
             logger.info("Aborted; nothing deleted.")
         else:
             for ep, to_delete, label in plan:
-                delete_session = {s.get_name() for s in to_delete}
-                for snap in to_delete:
-                    try:
-                        ep.delete_snapshots([snap], delete_session=delete_session)
-                        logger.info("  Deleted (%s): %s", label, snap.get_name())
-                        total_deleted += 1
-                    except Exception as e:
-                        logger.error("  Failed to delete %s: %s", snap.get_name(), e)
-                        error_messages.append(f"Delete {snap.get_name()}: {e}")
+                deleted, errs = execute_retention_deletes(ep, to_delete)
+                total_deleted += deleted
+                logger.info("  Deleted %d (%s)", deleted, label)
+                for err in errs:
+                    logger.error("  %s", err)
+                error_messages.extend(errs)
 
     end_time = time.time()
     duration = end_time - start_time

--- a/src/btrfs_backup_ng/cli/run.py
+++ b/src/btrfs_backup_ng/cli/run.py
@@ -27,6 +27,7 @@ from ..notifications import (
 from ..notifications import (
     NotificationConfig as NotifConfig,
 )
+from ..retention import RetentionError
 from ..transaction import set_transaction_log
 from .common import (
     get_log_level,
@@ -35,6 +36,11 @@ from .common import (
     space_options_from_args,
     thread_raw_compression,
     thread_raw_encryption,
+)
+from .prune import (
+    execute_retention_deletes,
+    is_degenerate_policy,
+    plan_endpoint_retention,
 )
 
 logger = logging.getLogger(__name__)
@@ -234,6 +240,16 @@ def _dry_run(config: Config) -> int:
             print(
                 f"  Retention: min={retention.min}, hourly={retention.hourly}, daily={retention.daily}"
             )
+            if is_degenerate_policy(retention):
+                print(
+                    "  Retention: WOULD FAIL -- policy keeps only the latest snapshot "
+                    "(run `prune --force` to prune it deliberately)"
+                )
+            else:
+                print(
+                    "  Retention: applied after transfer "
+                    "(use `prune --dry-run` to preview exact deletions)"
+                )
 
         if volume.targets:
             print("  Targets:")
@@ -393,6 +409,9 @@ def _backup_volume(
 
     # Transfer to destinations
     all_success = True
+    # Targets whose transfer SUCCEEDED -- only these are pruned afterwards (fate-sharing: never
+    # prune on a broken backup).
+    succeeded_targets: list = []
 
     if parallel_targets > 1 and len(destination_endpoints) > 1:
         # Parallel target transfers
@@ -418,6 +437,7 @@ def _backup_volume(
                     success = future.result()
                     if success:
                         stats["completed"] += 1
+                        succeeded_targets.append((dest, target_cfg))
                     else:
                         stats["failed"] += 1
                         all_success = False
@@ -443,6 +463,7 @@ def _backup_volume(
                 )
                 if success:
                     stats["completed"] += 1
+                    succeeded_targets.append((dest_endpoint, target_config))
                 else:
                     stats["failed"] += 1
                     all_success = False
@@ -452,7 +473,72 @@ def _backup_volume(
                 errors.append(f"Transfer to {target_config.path}: {e}")
                 all_success = False
 
-    return all_success, stats, errors
+    # --- Retention (prune) phase ---
+    # run = snapshot -> transfer -> prune, as a strict pipeline. Apply the SAME time-based
+    # retention engine as the `prune` command (non-interactively), so `run` leaves the source and
+    # its successfully-transferred targets in a policy-compliant state instead of accumulating
+    # snapshots forever. Strict contract: a degenerate policy or an invalid `min` fails loudly
+    # (non-zero exit) rather than being silently skipped. Fate-sharing: the source is pruned (R3
+    # lock reconcile keeps a snapshot a failed transfer still needs), and only targets whose
+    # transfer SUCCEEDED are pruned.
+    prune_ok = _prune_after_transfer(
+        volume, config, source_endpoint, succeeded_targets, errors
+    )
+    return (all_success and prune_ok), stats, errors
+
+
+def _prune_after_transfer(
+    volume: VolumeConfig,
+    config: Config,
+    source_endpoint: Any,
+    succeeded_targets: list,
+    errors: list[str],
+) -> bool:
+    """The ``run`` pipeline's post-transfer retention phase (regular volumes).
+
+    Applies the SAME shared time-based retention engine as the ``prune`` command
+    (``plan_endpoint_retention`` + ``execute_retention_deletes``), non-interactively, to the
+    source and each successfully-transferred target. Returns True on success; returns False (with
+    messages appended to ``errors``) if the policy is degenerate or invalid, or a delete fails --
+    so ``run`` exits non-zero rather than silently skipping retention. ``run`` never forces a
+    degenerate prune: an intentional keep-only-latest prune is the explicit ``prune --force``.
+    """
+    retention = config.get_effective_retention(volume)
+    if is_degenerate_policy(retention):
+        logger.error(
+            "Refusing to prune %s: retention keeps ONLY the latest snapshot (all buckets 0, "
+            "min=%s). Fix the policy, or run `prune --force` to prune it deliberately.",
+            volume.path,
+            retention.min,
+        )
+        errors.append(f"Degenerate retention policy: {volume.path}")
+        return False
+
+    prefix = volume.snapshot_prefix
+    ts_format = get_timestamp_format(config)
+    ok = True
+    endpoints = [(source_endpoint, f"source {volume.path}")]
+    endpoints += [(ep, f"target {tc.path}") for ep, tc in succeeded_targets]
+    for ep, label in endpoints:
+        try:
+            _keep, to_delete = plan_endpoint_retention(ep, retention, prefix, ts_format)
+            deleted, del_errs = execute_retention_deletes(ep, to_delete)
+            if deleted:
+                logger.info("Pruned %d old snapshot(s) (%s)", deleted, label)
+            if del_errs:
+                for msg in del_errs:
+                    logger.error("  %s", msg)
+                errors.extend(del_errs)
+                ok = False
+        except RetentionError as e:
+            logger.error("Prune failed (%s): %s", label, e)
+            errors.append(f"Prune {label}: {e}")
+            ok = False
+        except Exception as e:  # noqa: BLE001 - record and continue to the next endpoint
+            logger.error("Prune error (%s): %s", label, e)
+            errors.append(f"Prune {label}: {e}")
+            ok = False
+    return ok
 
 
 def _backup_snapper_volume(

--- a/tests/test_r10d_prune_safety.py
+++ b/tests/test_r10d_prune_safety.py
@@ -10,21 +10,21 @@ from __future__ import annotations
 import argparse
 from datetime import datetime, timedelta
 
-from btrfs_backup_ng.cli.prune import _is_degenerate_policy, execute_prune
+from btrfs_backup_ng.cli.prune import is_degenerate_policy, execute_prune
 from btrfs_backup_ng.config.schema import RetentionConfig
 from btrfs_backup_ng.endpoint.local import LocalEndpoint
 
 
 # --------------------------------------------------------------------------- #
-# _is_degenerate_policy (pure)
+# is_degenerate_policy (pure)
 # --------------------------------------------------------------------------- #
 def test_degenerate_all_zero_buckets_with_tiny_min():
     """All buckets 0 AND a near-zero min (<=1d) keeps only the latest -> degenerate. Mutation
     guard: ignoring min (all-zero => degenerate) would misclassify a short-window policy."""
-    assert _is_degenerate_policy(
+    assert is_degenerate_policy(
         RetentionConfig(min="0s", hourly=0, daily=0, weekly=0, monthly=0, yearly=0)
     )
-    assert _is_degenerate_policy(
+    assert is_degenerate_policy(
         RetentionConfig(min="1d", hourly=0, daily=0, weekly=0, monthly=0, yearly=0)
     )
 
@@ -32,7 +32,7 @@ def test_degenerate_all_zero_buckets_with_tiny_min():
 def test_not_degenerate_short_window_policy():
     """All buckets 0 but a real min window (30d) is a legitimate short-retention policy, NOT
     degenerate. Mutation guard: an all-zero-only check flags this."""
-    assert not _is_degenerate_policy(
+    assert not is_degenerate_policy(
         RetentionConfig(min="30d", hourly=0, daily=0, weekly=0, monthly=0, yearly=0)
     )
 
@@ -40,7 +40,7 @@ def test_not_degenerate_short_window_policy():
 def test_not_degenerate_with_a_bucket():
     """Any positive bucket count means real periodic retention -> not degenerate. Mutation guard:
     dropping the bucket check flags a normal policy."""
-    assert not _is_degenerate_policy(
+    assert not is_degenerate_policy(
         RetentionConfig(min="1d", hourly=0, daily=7, weekly=0, monthly=0, yearly=0)
     )
 

--- a/tests/test_r6_cli_roundtrip.py
+++ b/tests/test_r6_cli_roundtrip.py
@@ -62,6 +62,9 @@ class TestRunThreadsEncryption:
         captured: dict = {}
         monkeypatch.setattr(run_mod.endpoint, "choose_endpoint", _spy_choose(captured))
         monkeypatch.setattr(run_mod, "_transfer_to_target", lambda *a, **k: True)
+        # This test targets encryption threading, not the post-transfer prune phase (which
+        # operates on the spy's mock endpoints); stub it to a clean success.
+        monkeypatch.setattr(run_mod, "_prune_after_transfer", lambda *a, **k: True)
 
         ok, _stats, errors = run_mod._backup_volume(volume, config, parallel_targets=1)
 
@@ -94,6 +97,8 @@ class TestRunThreadsEncryption:
         captured: dict = {}
         monkeypatch.setattr(run_mod.endpoint, "choose_endpoint", _spy_choose(captured))
         monkeypatch.setattr(run_mod, "_transfer_to_target", lambda *a, **k: True)
+        # Not exercising the prune phase here (spy endpoints); stub it to a clean success.
+        monkeypatch.setattr(run_mod, "_prune_after_transfer", lambda *a, **k: True)
 
         ok, _stats, errors = run_mod._backup_volume(volume, config, parallel_targets=1)
         assert ok, errors

--- a/tests/test_run_prunes.py
+++ b/tests/test_run_prunes.py
@@ -1,0 +1,122 @@
+"""0.9.1 Item #1: `run` composes `prune`.
+
+`run` is the strict pipeline snapshot -> transfer -> prune. Its post-transfer retention phase
+(`_prune_after_transfer`) applies the SAME shared engine as the `prune` command, non-interactively,
+with strict semantics: a degenerate or invalid policy fails loudly (returns False -> run exits
+non-zero) rather than being silently skipped, and only successfully-transferred targets are pruned.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from unittest.mock import MagicMock
+
+from btrfs_backup_ng.cli.run import _prune_after_transfer
+from btrfs_backup_ng.config.schema import RetentionConfig
+
+NORMAL = RetentionConfig(min="1d", hourly=0, daily=3, weekly=0, monthly=0, yearly=0)
+DEGENERATE = RetentionConfig(min="1d", hourly=0, daily=0, weekly=0, monthly=0, yearly=0)
+INVALID_MIN = RetentionConfig(
+    min="not-a-duration", hourly=0, daily=3, weekly=0, monthly=0, yearly=0
+)
+
+
+def _snap(name):
+    s = MagicMock()
+    s.get_name.return_value = name
+    return s
+
+
+def _endpoint(n_old):
+    """An endpoint whose list_snapshots returns n_old snapshots (2..n+2 days old), a pass-through
+    protect_incremental_parents, and a delete_snapshots that records what it deleted."""
+    ep = MagicMock()
+    now = _dt.datetime.now()
+    snaps = [
+        _snap(f"home-{(now - _dt.timedelta(days=d)).strftime('%Y%m%d-%H%M%S')}")
+        for d in range(2, 2 + n_old)
+    ]
+    ep.list_snapshots.return_value = snaps
+    ep.protect_incremental_parents.side_effect = lambda keep, delete: (keep, delete)
+    ep.deleted = []
+    ep.delete_snapshots.side_effect = lambda batch, **k: ep.deleted.extend(batch)
+    return ep
+
+
+def _volume():
+    v = MagicMock()
+    v.snapshot_prefix = "home-"
+    v.path = "/home"
+    return v
+
+
+def _config(retention):
+    c = MagicMock()
+    c.get_effective_retention.return_value = retention
+    return c
+
+
+def _no_ts_format(monkeypatch):
+    # get_timestamp_format(config) would return a MagicMock; force None so apply_retention parses
+    # with its built-in formats.
+    monkeypatch.setattr("btrfs_backup_ng.cli.run.get_timestamp_format", lambda c: None)
+
+
+def test_run_prunes_source_and_succeeded_target(monkeypatch):
+    """A normal policy prunes BOTH the source and a successfully-transferred target after the
+    transfer. Mutation guard: dropping the prune phase leaves both un-pruned (nothing deleted)."""
+    _no_ts_format(monkeypatch)
+    src, tgt = _endpoint(10), _endpoint(10)
+    tgt_cfg = MagicMock()
+    tgt_cfg.path = "/mnt/backup"
+    errors: list[str] = []
+    ok = _prune_after_transfer(
+        _volume(), _config(NORMAL), src, [(tgt, tgt_cfg)], errors
+    )
+    assert ok is True and errors == []
+    assert len(src.deleted) > 0  # source pruned per policy
+    assert len(tgt.deleted) > 0  # succeeded target pruned per policy
+
+
+def test_run_degenerate_policy_fails_loud_and_deletes_nothing(monkeypatch):
+    """A degenerate policy makes the prune phase FAIL (return False, error recorded) and delete
+    NOTHING -- fail-closed, not a silent skip. Mutation guard: removing the degenerate check prunes
+    almost everything (delete called); returning True instead of False fails the ok assertion."""
+    _no_ts_format(monkeypatch)
+    src = _endpoint(10)
+    errors: list[str] = []
+    ok = _prune_after_transfer(_volume(), _config(DEGENERATE), src, [], errors)
+    assert ok is False
+    assert errors  # loud
+    assert src.deleted == []  # nothing deleted
+    src.list_snapshots.assert_not_called()  # refused before even listing
+
+
+def test_run_invalid_min_fails_loud_and_deletes_nothing(monkeypatch):
+    """An invalid `min` (RetentionError) makes the prune phase fail loudly and delete nothing --
+    never delete on ambiguous config. Mutation guard: swallowing RetentionError as success fails
+    the ok assertion."""
+    _no_ts_format(monkeypatch)
+    src = _endpoint(5)
+    errors: list[str] = []
+    ok = _prune_after_transfer(_volume(), _config(INVALID_MIN), src, [], errors)
+    assert ok is False
+    assert errors
+    assert src.deleted == []
+
+
+def test_run_only_prunes_succeeded_targets(monkeypatch):
+    """Fate-sharing: only a successfully-transferred target is pruned; a target whose transfer
+    failed (absent from succeeded_targets) is never touched. Mutation guard: pruning all targets
+    regardless of transfer success would delete on the failed one."""
+    _no_ts_format(monkeypatch)
+    src = _endpoint(10)
+    ok_tgt = _endpoint(10)
+    ok_cfg = MagicMock()
+    ok_cfg.path = "/ok"
+    failed_tgt = _endpoint(10)  # transfer failed -> NOT in the succeeded list
+    errors: list[str] = []
+    _prune_after_transfer(_volume(), _config(NORMAL), src, [(ok_tgt, ok_cfg)], errors)
+    assert len(ok_tgt.deleted) > 0  # succeeded target pruned
+    assert failed_tgt.deleted == []  # failed target untouched
+    failed_tgt.list_snapshots.assert_not_called()


### PR DESCRIPTION
## 0.9.1 Item #1 — `run` composes `prune`

**The bug:** `run` (the command the docs tell users to put on a systemd timer / cron) transferred but **never pruned** — `sync_snapshots(keep_num_backups=0)` with no `apply_retention` anywhere in `run.py` — so scheduled backups accumulated snapshots forever, even though README, the man page, and `run`'s own dry-run all describe `run` as "snapshot + transfer + **prune**". A regression from the count-engine deprecation.

**The design** (arrived at with the sounding board — strict composition, not a pile of flags): `run` is the strict composition of the orthogonal primitives `snapshot` / `transfer` / `prune`, reusing **one** shared prune engine so a second divergent implementation can't recur.

- **Shared engine:** `is_degenerate_policy`, `plan_endpoint_retention`, `execute_retention_deletes` extracted and used by **both** `prune` and `run` (the interactive confirmation stays a thin UI layer on the standalone `prune` command).
- **`run`'s post-transfer phase** (`_prune_after_transfer`) prunes the **source** and each **succeeded** target with the same time-based engine, non-interactively.
- **Strict semantics, no soft skips:** a degenerate policy or an invalid `min` **fails the run** (non-zero exit) — like a full destination disk — never a silent skip that lies to cron.
- **Fate-sharing:** a target whose transfer failed is not pruned; the source is safe via R3's presence-based lock reconcile.
- **No new flags.** Transfer-only is the existing `transfer` command; an intentional keep-only-latest prune is the explicit `prune --force`.

The docs already described this behavior — the **code now matches them** (no doc change needed; the earlier docs-refresh PR deliberately left the `run`-prunes claim intact pending this).

### Validation
- Full gate: **2500 passed**, ruff/mypy clean.
- **Mutation-verified** (`tests/test_run_prunes.py`): run prunes source + succeeded target; degenerate policy fails loud + deletes nothing; invalid `min` fails loud + deletes nothing; fate-sharing (failed target untouched). Mutations bypassing the prune phase, the degenerate check, or swallowing `RetentionError` all fail.
- **Hardware (real btrfs):** 12 aged source snapshots pruned to the policy (→ 4) after a real `run`, raw target populated; a degenerate policy exits non-zero and deletes nothing.
- `prune`'s R10d behavior is unchanged (its 11 tests + the retention-flow integration all green after the refactor onto the shared engine).

### Follow-up
Snapper-sourced volumes aren't pruned by `run` yet (their source is snapper-managed; pruning snapper *targets* in `run` is a small follow-up). The standalone `prune` command still covers them.