### PR TITLE
fix(verify): general verify checks the sealed sha256 on raw targets (R8a)

### DIFF
--- a/man/man1/btrfs-backup-ng-verify.1
+++ b/man/man1/btrfs-backup-ng-verify.1
@@ -1,5 +1,5 @@
 .\" Man page for btrfs-backup-ng verify
-.TH BTRFS-BACKUP-NG-VERIFY 1 "January 2026" "btrfs-backup-ng" "User Commands"
+.TH BTRFS-BACKUP-NG-VERIFY 1 "July 2026" "btrfs-backup-ng" "User Commands"
 .SH NAME
 btrfs-backup-ng-verify \- verify backup integrity
 .SH SYNOPSIS
@@ -10,16 +10,25 @@ Verify that backups at a given location are valid and restorable. This command
 provides multiple levels of verification to check backup integrity, from quick
 metadata checks to full restore tests.
 .PP
-Verification works with both local backup directories and remote SSH locations.
+Verification works with btrfs backup subvolumes (local directories and remote SSH
+locations) and with raw targets (\fBraw://\fR and \fBraw+ssh://\fR), which store
+\fBbtrfs send\fR streams as files. For a raw target, verification recomputes each
+stream's sha256 and compares it to the checksum sealed in the stream's \fB.meta\fR
+sidecar \(em the same integrity check performed by \fBbtrfs-backup-ng raw verify\fR
+and before every raw restore.
 .SH ARGUMENTS
 .TP
 .I LOCATION
-Backup location to verify. Can be a local path (e.g., /mnt/backup/home) or
-an SSH URL (e.g., ssh://user@host:/path/to/backup).
+Backup location to verify. Can be a local path (e.g., /mnt/backup/home), an SSH URL
+(e.g., ssh://user@host:/path/to/backup), or a raw target
+(e.g., raw:///mnt/usb/backups or raw+ssh://user@host:/backups).
 .SH OPTIONS
 .TP
 .BI \-\-level " " \fILEVEL\fR
-Verification level. Default: metadata. Valid levels:
+Verification level. Default: \fBmetadata\fR for a btrfs target, \fBstream\fR (the
+sealed-checksum check) for a raw target \(em a raw backup's integrity is whether its
+stored bytes still match what was written, so a bare \fBverify\fR on a raw target reads
+the stream rather than reporting a hollow pass from a directory listing. Valid levels:
 .RS
 .TP
 .B metadata
@@ -28,14 +37,17 @@ all snapshots exist and that incremental chains are complete (no missing
 parent snapshots). This is fast and non-destructive.
 .TP
 .B stream
-Verify that btrfs send stream can be generated. Uses \fBbtrfs send --no-data\fR
-to test stream generation without transferring actual file data. This validates
-that snapshot metadata is intact.
+For a btrfs target, verify that a \fBbtrfs send\fR stream can be generated (uses
+\fBbtrfs send --no-data\fR to test stream generation without transferring file data,
+validating that snapshot metadata is intact). For a raw target, recompute the stored
+stream's sha256 and compare it to the checksum sealed in its \fB.meta\fR sidecar,
+detecting at-rest corruption.
 .TP
 .B full
-Complete restore test to a temporary location. Actually restores snapshot(s)
-and verifies the restored subvolume is valid. This is the most thorough check
-but also the slowest. Requires \fB--temp-dir\fR for remote backups.
+For a btrfs target, a complete restore test to a temporary location: actually restores
+snapshot(s) and verifies the restored subvolume is valid \(em the most thorough check,
+but the slowest; requires \fB--temp-dir\fR for remote backups. For a raw target, \fBfull\fR
+performs the same sealed-checksum verification as \fBstream\fR.
 .RE
 .TP
 .BI \-\-snapshot " " \fINAME\fR
@@ -117,6 +129,25 @@ Tests the complete restore pipeline
 Cleans up after verification (unless \fB--no-cleanup\fR)
 .PP
 This is the definitive test that a backup can be restored.
+.SS Raw targets (sealed checksum)
+For a \fBraw://\fR or \fBraw+ssh://\fR target, the \fBstream\fR and \fBfull\fR levels
+recompute each stored stream's sha256 and compare it to the checksum sealed in the
+stream's \fB.meta\fR sidecar. Every stream is checked (not just the latest). Per-snapshot
+status is one of:
+.IP \(bu 2
+\fBok\fR \(em the stream matches its sealed checksum (intact).
+.IP \(bu 2
+\fBcorrupt\fR \(em the stream on disk no longer matches (fails; exit 1).
+.IP \(bu 2
+\fBerror\fR \(em the stream could not be read to hash it (fails; exit 1).
+.IP \(bu 2
+\fBunverifiable\fR \(em no sha256 checksum was recorded (a legacy backup); not a failure,
+but reported explicitly rather than as a silent pass.
+.PP
+For a \fBraw+ssh://\fR target the sha256 is recomputed \fBon the (untrusted) remote
+host\fR, so an \fBok\fR verdict evidences at-rest consistency, not authenticity \(em a
+compromised target could forge a match. Verify a locally-mounted \fBraw://\fR copy for
+tamper-evidence.
 .SH EXIT STATUS
 .TP
 .B 0
@@ -143,6 +174,12 @@ Full restore test:
 .TP
 Full verification of remote backup:
 .B btrfs-backup-ng verify ssh://server:/backups/home --level full --temp-dir /mnt/test
+.TP
+Verify a raw target (checks the sealed sha256 of every stream):
+.B btrfs-backup-ng verify raw:///mnt/usb/backups
+.TP
+Verify a remote raw target over SSH:
+.B btrfs-backup-ng verify raw+ssh://backup@server:/backups --ssh-sudo
 .TP
 Verify specific snapshot:
 .B btrfs-backup-ng verify /mnt/backup/home --snapshot home-20260104-120000

--- a/src/btrfs_backup_ng/cli/dispatcher.py
+++ b/src/btrfs_backup_ng/cli/dispatcher.py
@@ -739,11 +739,18 @@ Config-driven restore:
         epilog="""
 Verification levels:
   metadata  Quick check of snapshot existence and parent chain integrity
-  stream    Verify btrfs send stream can be generated (no data transfer)
+  stream    btrfs targets: verify a send stream can be generated (no data transfer).
+            raw:// / raw+ssh:// targets: recompute each stream's sha256 and compare it
+            to the checksum sealed in the .meta sidecar (detects at-rest corruption).
   full      Complete restore test to temporary location (most thorough)
 
+For a raw:// or raw+ssh:// target the default level is 'stream' (the sealed-checksum
+check), since a raw backup's integrity IS whether its stored bytes still match what was
+written. NOTE: a raw+ssh checksum is recomputed BY the (untrusted) remote, so it detects
+corruption, not tampering -- verify a raw:// copy for tamper-evidence.
+
 Examples:
-  # Quick metadata check
+  # Quick metadata check (btrfs target)
   btrfs-backup-ng verify /mnt/backup/home
 
   # Verify remote backup over SSH
@@ -751,6 +758,10 @@ Examples:
 
   # Stream integrity check
   btrfs-backup-ng verify /mnt/backup/home --level stream
+
+  # Verify a raw target (checks the sealed sha256 of every stream)
+  btrfs-backup-ng verify raw:///mnt/usb/backups
+  btrfs-backup-ng verify raw+ssh://backup@server:/backups --ssh-sudo
 
   # Full restore test (requires temp dir on btrfs)
   btrfs-backup-ng verify ssh://...:/backups/home --level full --temp-dir /mnt/test
@@ -767,8 +778,9 @@ Examples:
     verify_parser.add_argument(
         "--level",
         choices=["metadata", "stream", "full"],
-        default="metadata",
-        help="Verification level (default: metadata)",
+        default=None,
+        help="Verification level (default: metadata for btrfs targets; stream, which "
+        "checks the sealed sha256, for raw:// and raw+ssh:// targets)",
     )
     verify_parser.add_argument(
         "--snapshot",

--- a/src/btrfs_backup_ng/cli/raw_cmd.py
+++ b/src/btrfs_backup_ng/cli/raw_cmd.py
@@ -174,28 +174,13 @@ def _raw_verify(args: argparse.Namespace) -> int:
 
     results = []
     for s in snapshots:
-        recorded = s.checksum_value
-        algorithm = getattr(s, "checksum_algorithm", "sha256")
-        if not recorded:
-            status, computed = "unverifiable", None
-        elif algorithm != "sha256":
-            # We only compute sha256; comparing it to a digest of another algorithm
-            # would false-flag an intact stream as corrupt. Cannot check -> unverifiable.
-            status, computed = "unverifiable", None
-        else:
-            computed = ep.compute_stream_checksum(s)
-            if computed is None:
-                status = "error"
-            elif computed == recorded:
-                status = "ok"
-            else:
-                status = "corrupt"
+        verdict = ep.verify_stream_checksum(s)
         results.append(
             {
                 "name": s.name,
-                "status": status,
-                "recorded": recorded,
-                "computed": computed,
+                "status": verdict.status,
+                "recorded": verdict.recorded,
+                "computed": verdict.computed,
             }
         )
 

--- a/src/btrfs_backup_ng/cli/verify.py
+++ b/src/btrfs_backup_ng/cli/verify.py
@@ -13,6 +13,7 @@ from ..core.verify import (
     VerifyReport,
     verify_full,
     verify_metadata,
+    verify_raw_checksums,
     verify_stream,
 )
 from .common import get_fs_checks_mode, resolve_timestamp_format
@@ -30,9 +31,6 @@ def execute(args: argparse.Namespace) -> int:
     Returns:
         Exit code (0 = success, 1 = failures found, 2 = error)
     """
-    # Determine verification level
-    level = VerifyLevel(args.level)
-
     # Build endpoint kwargs. Thread timestamp_format so custom-named snapshots
     # are parsed (otherwise verify silently skips them and can report success).
     endpoint_kwargs = {
@@ -46,7 +44,7 @@ def execute(args: argparse.Namespace) -> int:
         ),
     }
 
-    # SSH options
+    # SSH / raw options
     if args.location.startswith("ssh://"):
         if args.ssh_sudo:
             endpoint_kwargs["ssh_sudo"] = True
@@ -54,6 +52,18 @@ def execute(args: argparse.Namespace) -> int:
             endpoint_kwargs["ssh_identity_file"] = args.ssh_key
         if getattr(args, "ssh_auth_sock", None):
             endpoint_kwargs["ssh_auth_sock"] = args.ssh_auth_sock
+    elif args.location.startswith(("raw://", "raw+ssh://")):
+        # Raw target: choose_endpoint parses the path (and host, for raw+ssh) from the
+        # spec itself, so do NOT set 'path' -- Path().resolve() on a raw:// URL would
+        # mangle it. Thread ssh creds for raw+ssh (SSHRawEndpoint reads
+        # ssh_sudo/ssh_key/ssh_auth_sock from config); the base RawEndpoint ignores them.
+        if args.location.startswith("raw+ssh://"):
+            if args.ssh_sudo:
+                endpoint_kwargs["ssh_sudo"] = True
+            if args.ssh_key:
+                endpoint_kwargs["ssh_key"] = args.ssh_key
+            if getattr(args, "ssh_auth_sock", None):
+                endpoint_kwargs["ssh_auth_sock"] = args.ssh_auth_sock
     else:
         # For local paths, set 'path' for LocalEndpoint
         endpoint_kwargs["path"] = Path(args.location).resolve()
@@ -71,30 +81,62 @@ def execute(args: argparse.Namespace) -> int:
         console.print(f"[red]Error:[/red] Cannot access backup location: {e}")
         return 2
 
+    # A raw:// or raw+ssh:// target stores send STREAMS, not subvolumes, so its
+    # verification is the sealed-checksum check (not btrfs send/restore).
+    from ..endpoint.raw import (
+        RawEndpoint,
+    )  # local import: avoid an endpoint import cycle
+
+    is_raw = isinstance(backup_ep, RawEndpoint)
+
+    # Resolve level: an explicit --level wins; otherwise default to metadata for a btrfs
+    # target, but stream (the sealed-checksum check) for a raw target -- a bare
+    # `verify raw://X` must read the stored bytes, not report a hollow pass from a listing.
+    if args.level:
+        level = VerifyLevel(args.level)
+    else:
+        level = VerifyLevel.STREAM if is_raw else VerifyLevel.METADATA
+
+    # In --json mode stdout must be machine-readable, so the human header/progress
+    # lines (which go to stdout) are suppressed just like under --quiet -- otherwise a
+    # `verify ... --json` consumer gets unparseable output unless they also pass --quiet.
+    human = not args.quiet and not args.json
+
     # Progress callback
     def on_progress(current: int, total: int, name: str):
-        if not args.quiet:
+        if human:
             console.print(f"  [{current}/{total}] Verifying {name}...")
 
     # Run verification based on level
     report: VerifyReport
     try:
-        if not args.quiet:
+        if human:
             console.print(f"\n[bold]Verifying backups at:[/bold] {args.location}")
             console.print(f"[bold]Level:[/bold] {level.value}\n")
 
-        if level == VerifyLevel.METADATA:
+        if is_raw and level in (VerifyLevel.STREAM, VerifyLevel.FULL):
+            # For a raw target, stream/full verification means recompute each stream's
+            # sha256 and compare it to the sealed sidecar checksum (a raw backup is a
+            # stored stream, not a subvolume -- btrfs send/restore cannot operate on it).
+            report = verify_raw_checksums(
+                backup_ep,
+                level,
+                snapshot_name=args.snapshot,
+                on_progress=on_progress if human else None,
+            )
+
+        elif level == VerifyLevel.METADATA:
             report = verify_metadata(
                 backup_ep,
                 snapshot_name=args.snapshot,
-                on_progress=on_progress if not args.quiet else None,
+                on_progress=on_progress if human else None,
             )
 
         elif level == VerifyLevel.STREAM:
             report = verify_stream(
                 backup_ep,
                 snapshot_name=args.snapshot,
-                on_progress=on_progress if not args.quiet else None,
+                on_progress=on_progress if human else None,
             )
 
         else:  # level == VerifyLevel.FULL
@@ -112,7 +154,7 @@ def execute(args: argparse.Namespace) -> int:
                 snapshot_name=args.snapshot,
                 temp_dir=Path(args.temp_dir) if args.temp_dir else None,
                 cleanup=not args.no_cleanup,
-                on_progress=on_progress if not args.quiet else None,
+                on_progress=on_progress if human else None,
             )
 
     except KeyboardInterrupt:

--- a/src/btrfs_backup_ng/core/verify.py
+++ b/src/btrfs_backup_ng/core/verify.py
@@ -438,6 +438,102 @@ def verify_full(
     return report
 
 
+def verify_raw_checksums(
+    backup_endpoint,
+    level: VerifyLevel,
+    snapshot_name: str | None = None,
+    on_progress: Callable[[int, int, str], None] | None = None,
+) -> VerifyReport:
+    """Verify a raw target by recomputing each stream's sha256 and comparing it to the
+    checksum sealed in the ``.meta`` sidecar.
+
+    This is what ``stream``/``full`` verification MEANS for a raw:// or raw+ssh:// target
+    (a raw backup is a stored send stream, not a subvolume, so ``btrfs send`` cannot be
+    run on it). It routes through ``RawEndpoint.verify_stream_checksum`` -- the SAME
+    primitive ``raw verify`` and the restore-time integrity guard use -- so the
+    ok/corrupt/error/unverifiable classification cannot drift between them.
+
+    A ``corrupt`` (bytes changed) or ``error`` (stream unreadable) snapshot FAILS; an
+    ``unverifiable`` one (no recorded checksum, or a non-sha256 algorithm) is not a
+    failure but is reported as such (never a silent green). All snapshots are checked,
+    not just the latest -- the sealed-checksum compare is cheap, so there is no reason
+    to leave a blind spot in the chain.
+    """
+    location = str(backup_endpoint.config.get("path", "unknown"))
+    report = VerifyReport(level=level, location=location)
+
+    try:
+        backup_snapshots = backup_endpoint.list_snapshots()
+
+        if not backup_snapshots:
+            report.errors.append("No snapshots found at backup location")
+            report.completed_at = time.time()
+            return report
+
+        if snapshot_name:
+            backup_snapshots = [
+                s for s in backup_snapshots if s.get_name() == snapshot_name
+            ]
+            if not backup_snapshots:
+                report.errors.append(f"Snapshot '{snapshot_name}' not found")
+                report.completed_at = time.time()
+                return report
+
+        for i, snap in enumerate(backup_snapshots, 1):
+            name = snap.get_name()
+
+            if on_progress:
+                on_progress(i, len(backup_snapshots), name)
+
+            start = time.monotonic()
+            verdict = backup_endpoint.verify_stream_checksum(snap)
+
+            result = VerifyResult(
+                snapshot_name=name,
+                level=level,
+                # ok/unverifiable pass; corrupt/error fail -- the single source of
+                # truth (ChecksumVerdict.is_failure) shared with `raw verify`'s exit code.
+                passed=not verdict.is_failure,
+            )
+            result.details["checksum_status"] = verdict.status
+            result.details["checksum_recorded"] = verdict.recorded
+            result.details["checksum_computed"] = verdict.computed
+            result.details["checksum_algorithm"] = verdict.algorithm
+            if verdict.remote_untrusted:
+                # A raw+ssh digest is computed by the untrusted remote: consistency, not
+                # authenticity. Surface it so an operator does not read `ok` as tamper-proof.
+                result.details["trust"] = "consistency-only (remote hash)"
+
+            if verdict.status == "ok":
+                result.message = "Checksum verified"
+                if verdict.remote_untrusted:
+                    result.message += " (consistency-only: remote hash)"
+            elif verdict.status == "corrupt":
+                rec = (verdict.recorded or "-")[:12]
+                comp = (verdict.computed or "-")[:12]
+                result.message = (
+                    f"CORRUPT: stored stream no longer matches its sealed checksum "
+                    f"(recorded={rec}... computed={comp}...)"
+                )
+            elif verdict.status == "error":
+                result.message = "Stream could not be read to verify its checksum"
+            else:  # unverifiable
+                result.message = (
+                    "Unverifiable: no sha256 checksum was recorded for this stream "
+                    "(a legacy backup or one sealed before checksums existed)"
+                )
+
+            result.duration_seconds = time.monotonic() - start
+            report.results.append(result)
+
+    except Exception as e:
+        report.errors.append(f"Verification failed: {e}")
+        logger.error("Raw checksum verification failed: %s", e)
+
+    report.completed_at = time.time()
+    return report
+
+
 def _find_parent_snapshot(snapshot, all_snapshots: list):
     """Find the parent snapshot for incremental operations.
 

--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -35,6 +35,7 @@ from btrfs_backup_ng.__logger__ import logger
 from btrfs_backup_ng.endpoint.common import Endpoint
 from btrfs_backup_ng.endpoint.raw_metadata import (
     COMPRESSION_CONFIG,
+    ChecksumVerdict,
     RawSnapshot,
     _fsync_directory,
     discover_raw_snapshots,
@@ -868,6 +869,45 @@ class RawEndpoint(Endpoint):
         subclass overrides this to hash on the remote host (no re-download)."""
         return _sha256_file(snapshot.stream_path)
 
+    # False for a local raw:// target (we hash with this host's own kernel, so an
+    # ``ok`` is tamper-evident). Overridden to True on the raw+ssh subclass, where the
+    # digest is computed BY the untrusted remote (corruption-detection only).
+    _checksum_is_remote: bool = False
+
+    def verify_stream_checksum(self, snapshot: RawSnapshot) -> ChecksumVerdict:
+        """Verify ``snapshot``'s stream against its sealed sha256 and classify the
+        result. THE single checksum-verification path -- ``raw verify``, the
+        restore-time integrity guard, and the general ``verify`` command all call this,
+        so the ok/corrupt/error/unverifiable taxonomy cannot drift between them.
+
+        Never raises (a report collects findings; it does not abort mid-scan): an
+        unreadable stream is ``error``, a missing/non-sha256 checksum is
+        ``unverifiable``, and the caller decides how severe each is. Skips the recompute
+        entirely for the unverifiable cases -- there is nothing to compare against, so
+        there is no reason to pay the read.
+
+        Dispatch is polymorphic via ``compute_stream_checksum`` (local ``_sha256_file``
+        for raw://, remote ``_remote_sha256`` for raw+ssh); ``remote_untrusted`` records
+        which, so a raw+ssh verdict can be labelled consistency-only."""
+        recorded = snapshot.checksum_value
+        algorithm = getattr(snapshot, "checksum_algorithm", "sha256")
+        remote = self._checksum_is_remote
+        if not recorded:
+            # Legacy backup, or a best-effort write-time seal that failed to record.
+            return ChecksumVerdict("unverifiable", recorded, None, algorithm, remote)
+        if algorithm != "sha256":
+            # We only recompute sha256; comparing it to a digest of another algorithm
+            # would false-flag an intact stream as corrupt. Cannot check.
+            return ChecksumVerdict("unverifiable", recorded, None, algorithm, remote)
+        computed = self.compute_stream_checksum(snapshot)
+        if computed is None:
+            # The recorded checksum exists and is sha256, but the current stream on
+            # disk (or on the remote) could not be read/hashed.
+            return ChecksumVerdict("error", recorded, None, algorithm, remote)
+        if computed == recorded:
+            return ChecksumVerdict("ok", recorded, computed, algorithm, remote)
+        return ChecksumVerdict("corrupt", recorded, computed, algorithm, remote)
+
     def sidecar_exists(self, snapshot: RawSnapshot) -> bool:
         """Whether ``snapshot``'s ``.meta`` sidecar exists now. Used by
         ``raw backfill-metadata`` to re-check just before writing, so a sidecar that
@@ -1132,11 +1172,12 @@ class RawEndpoint(Endpoint):
                 snapshot.name,
             )
             return
-        recorded = snapshot.checksum_value
-        if not recorded or snapshot.checksum_algorithm != "sha256":
+        verdict = self.verify_stream_checksum(snapshot)
+        if verdict.status == "unverifiable":
+            # Nothing to compare against (legacy backup, or a non-sha256 algorithm) --
+            # the restore's own decode step still surfaces a genuinely unreadable stream.
             return
-        computed = self.compute_stream_checksum(snapshot)
-        if computed is None:
+        if verdict.status == "error":
             # Could not hash the stream -- do not BLOCK the restore on an inability to
             # verify (the decode step will surface a real read error); just note it.
             logger.warning(
@@ -1144,14 +1185,14 @@ class RawEndpoint(Endpoint):
                 snapshot.name,
             )
             return
-        if computed != recorded:
+        if verdict.status == "corrupt":
             raise __util__.AbortError(
                 f"Refusing to restore {snapshot.name}: the stored stream is CORRUPT "
-                f"(its sha256 {computed} does not match {recorded}, sealed when it was "
-                "backed up). The backup on disk has changed since it was written. "
-                "Restore an intact copy if you have one; if this is the only copy, "
-                "'restore --skip-verify' will attempt it anyway (the result may be "
-                "incomplete). Run 'raw verify' to inspect the target."
+                f"(its sha256 {verdict.computed} does not match {verdict.recorded}, "
+                "sealed when it was backed up). The backup on disk has changed since it "
+                "was written. Restore an intact copy if you have one; if this is the "
+                "only copy, 'restore --skip-verify' will attempt it anyway (the result "
+                "may be incomplete). Run 'raw verify' to inspect the target."
             )
 
     def _build_restore_pipeline(self, snapshot: RawSnapshot) -> list[list[str]]:
@@ -1563,6 +1604,9 @@ class SSHRawEndpoint(RawEndpoint):
         self.ssh_key = config.get("ssh_key")
         self.ssh_opts = config.get("ssh_opts", [])
         self.ssh_sudo = config.get("ssh_sudo", False)
+        # An explicit ssh-agent socket (e.g. `--ssh-auth-sock`), useful under sudo where
+        # SSH_AUTH_SOCK is not inherited. None -> rely on ssh's own agent discovery.
+        self.ssh_auth_sock = config.get("ssh_auth_sock")
 
         self._is_remote = True
 
@@ -1625,6 +1669,12 @@ class SSHRawEndpoint(RawEndpoint):
 
         if self.ssh_key:
             cmd.extend(["-i", self.ssh_key])
+
+        if self.ssh_auth_sock:
+            # Point ssh at the explicit agent socket (mirrors the btrfs SSHEndpoint's
+            # IdentityAgent handling) so agent auth works under sudo, where the inherited
+            # SSH_AUTH_SOCK is typically stripped.
+            cmd.extend(["-o", f"IdentityAgent={self.ssh_auth_sock}"])
 
         user_host = (
             f"{self.username}@{self.hostname}" if self.username else self.hostname
@@ -1838,6 +1888,10 @@ class SSHRawEndpoint(RawEndpoint):
             self.write_sidecar(self._sidecar_snapshot(final_path, size, checksum))
         except Exception as e:
             logger.warning("Failed to write remote sidecar for %s: %s", final_path, e)
+
+    # The digest is computed BY the untrusted remote, so a raw+ssh ``ok`` verdict is
+    # corruption-detection only, not tamper-evidence (see ChecksumVerdict).
+    _checksum_is_remote: bool = True
 
     def compute_stream_checksum(self, snapshot: RawSnapshot) -> str | None:
         """Hash ``snapshot``'s stream ON the remote host (see ``_remote_sha256``),

--- a/src/btrfs_backup_ng/endpoint/raw_metadata.py
+++ b/src/btrfs_backup_ng/endpoint/raw_metadata.py
@@ -83,6 +83,49 @@ def _fsync_directory(directory: Path) -> None:
         pass
 
 
+@dataclass(frozen=True)
+class ChecksumVerdict:
+    """The result of verifying one raw stream against its sealed sha256.
+
+    The single classification shared by every checksum caller (``raw verify``, the
+    restore-time integrity guard, and the general ``verify`` command) so the taxonomy
+    lives in ONE place and cannot drift between them:
+
+    - ``ok``           the recomputed digest matches the sealed checksum -- intact.
+    - ``corrupt``      it does NOT match -- the stream on disk differs from what was
+                       backed up (the one status an operator must investigate).
+    - ``error``        the stream could not be read/hashed (recorded checksum exists
+                       and is sha256, but the current stream is inaccessible).
+    - ``unverifiable`` nothing to compare against: no checksum was recorded (a legacy
+                       backup or a best-effort seal that failed) or it used a non-sha256
+                       algorithm we cannot recompute. NOT a failure.
+
+    ``is_failure`` (corrupt/error) is the single source of truth for "does this count
+    against the run" -- exit codes, restore aborts, and verify PASS/FAIL all derive
+    from it, so they can never disagree.
+    """
+
+    status: str
+    recorded: str | None
+    computed: str | None
+    algorithm: str
+    # True for a raw+ssh target: the digest was computed BY the (untrusted) remote, so
+    # an ``ok`` verdict evidences at-rest CONSISTENCY, not authenticity -- a compromised
+    # target could forge a match. Callers surface this caveat; hash a raw:// copy for
+    # tamper-evidence.
+    remote_untrusted: bool = False
+
+    @property
+    def is_failure(self) -> bool:
+        """Whether this verdict should count as a verification failure."""
+        return self.status in ("corrupt", "error")
+
+    @property
+    def is_verified(self) -> bool:
+        """Whether the stream was positively confirmed intact."""
+        return self.status == "ok"
+
+
 @functools.total_ordering
 @dataclass(eq=False, repr=False)
 class RawSnapshot:

--- a/tests/test_cli_verify.py
+++ b/tests/test_cli_verify.py
@@ -705,3 +705,213 @@ class TestProgressCallback:
 
         call_kwargs = mock_verify.call_args[1]
         assert call_kwargs["on_progress"] is None
+
+
+class TestGeneralVerifyAgainstRawTarget:
+    """R8a: the GENERAL ``verify`` command (not ``raw verify``) must consult the sealed
+    sha256 on raw:// targets. Before R8a a bare ``verify raw://X`` ran the metadata level
+    and reported 'All verifications passed' for a CORRUPT stream -- a false all-clear.
+    These drive the real ``execute()`` with a real RawEndpoint (choose_endpoint builds
+    it), mocking nothing about the checksum path -- closing the exact coverage gap the
+    R8 audit flagged (no test drove general verify against any raw target)."""
+
+    @staticmethod
+    def _build_raw(path, name):
+        from btrfs_backup_ng.endpoint.raw import RawEndpoint
+
+        ep = RawEndpoint(config={"path": str(path)})
+        src = path / (name + ".src")
+        src.write_bytes(b"cli-verify-payload-" * 300)
+        with open(src, "rb") as f:
+            ep.receive(f, snapshot_name=name).communicate()
+        ep.commit_receive()
+        src.unlink()
+
+    @staticmethod
+    def _args(location, **kw):
+        base = dict(
+            level=None,
+            location=location,
+            prefix="",
+            fs_checks="auto",
+            snapshot=None,
+            quiet=True,
+            json=False,
+            temp_dir=None,
+            no_cleanup=False,
+            ssh_sudo=False,
+            ssh_key=None,
+            ssh_auth_sock=None,
+            timestamp_format=None,
+        )
+        base.update(kw)
+        return argparse.Namespace(**base)
+
+    def test_default_level_detects_raw_corruption(self, tmp_path, capsys):
+        """THE gap test: seal a checksum, corrupt the stream, run the GENERAL verify at
+        its DEFAULT level against raw://<dir> -> exit 1 + CORRUPT. Mutation guard: revert
+        the raw-branch wiring (falls back to metadata) and this reports success (exit 0)."""
+        self._build_raw(tmp_path, "good")
+        self._build_raw(tmp_path, "bad")
+        bad = tmp_path / "bad.btrfs"
+        bad.write_bytes(bad.read_bytes() + b"CORRUPTION")
+
+        rc = execute(self._args(f"raw://{tmp_path}"))
+
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "CORRUPT" in out
+
+    def test_default_level_resolves_to_stream_and_passes_on_intact_raw(
+        self, tmp_path, capsys
+    ):
+        """An intact raw backup passes at the default level (exit 0), and the default
+        actually resolved to the sealed-checksum check (report level == stream, status
+        ok) -- not the byte-blind metadata listing."""
+        import json
+
+        self._build_raw(tmp_path, "ok1")
+
+        rc = execute(self._args(f"raw://{tmp_path}", json=True))
+
+        data = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert data["level"] == "stream"  # default -> the checksum check, not metadata
+        assert data["results"][0]["details"]["checksum_status"] == "ok"
+
+    def test_legacy_no_checksum_is_unverifiable_not_false_pass(self, tmp_path, capsys):
+        """A legacy stream with no recorded checksum is reported 'unverifiable' (exit 0
+        but explicitly not a clean 'verified') -- never a silent green on an unchecked
+        stream. Mutation guard: reporting it as ok/passed with no status fails."""
+        import json
+
+        self._build_raw(tmp_path, "legacy")
+        meta = tmp_path / "legacy.btrfs.meta"
+        doc = json.loads(meta.read_text())
+        doc["checksum"]["value"] = None
+        meta.write_text(json.dumps(doc))
+
+        rc = execute(self._args(f"raw://{tmp_path}", json=True))
+
+        data = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert data["results"][0]["details"]["checksum_status"] == "unverifiable"
+
+    def test_explicit_metadata_level_bypasses_raw_checksum_branch(self, tmp_path):
+        """An explicit --level metadata on a raw target still routes to verify_metadata
+        (an operator override); the raw-checksum branch owns only stream/full. Proves the
+        default->stream RESOLUTION is what closes the false-pass, not a blanket override."""
+        self._build_raw(tmp_path, "m1")
+        with (
+            patch("btrfs_backup_ng.cli.verify.verify_metadata") as mv,
+            patch("btrfs_backup_ng.cli.verify.verify_raw_checksums") as mrc,
+        ):
+            mv.return_value = _make_report(results=[_make_result("m1", passed=True)])
+            execute(self._args(f"raw://{tmp_path}", level="metadata"))
+            mv.assert_called_once()
+            mrc.assert_not_called()
+
+    def test_json_output_is_clean_stdout_without_quiet(self, tmp_path, capsys):
+        """`verify raw://X --json` (WITHOUT --quiet) must emit ONLY parseable JSON on
+        stdout -- the human header/progress lines are suppressed in json mode. Mutation
+        guard: reverting the `human` gate re-pollutes stdout so json.loads raises."""
+        import json
+
+        self._build_raw(tmp_path, "j1")
+
+        execute(self._args(f"raw://{tmp_path}", json=True, quiet=False))
+
+        out = capsys.readouterr().out
+        data = json.loads(out)  # would raise if the header lines leaked onto stdout
+        assert data["level"] == "stream"
+        assert data["results"][0]["details"]["checksum_status"] == "ok"
+
+    def test_explicit_stream_level_on_raw_routes_to_checksums(self, tmp_path, capsys):
+        """An EXPLICIT --level stream on a raw target routes to the sealed-checksum check
+        (not btrfs send on a stream file): a corrupt stream -> exit 1 + CORRUPT. Mutation
+        guard: narrowing the raw routing to exclude STREAM would call verify_stream (btrfs
+        send), producing a non-CORRUPT failure and tripping the assertion."""
+        self._build_raw(tmp_path, "s")
+        stream = tmp_path / "s.btrfs"
+        stream.write_bytes(stream.read_bytes() + b"CORRUPTION")
+        rc = execute(self._args(f"raw://{tmp_path}", level="stream"))
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "CORRUPT" in out
+
+    def test_explicit_full_level_on_raw_routes_to_checksums_not_restore(
+        self, tmp_path, capsys
+    ):
+        """An EXPLICIT --level full on a raw target ALSO routes to the sealed-checksum
+        check, NOT verify_full's btrfs restore (which cannot restore a raw stream into a
+        temp subvolume). Mutation guard: if the raw routing check were `level == STREAM`,
+        full would fall through to verify_full and fail with a restore/temp-dir error,
+        not a CORRUPT verdict."""
+        self._build_raw(tmp_path, "f")
+        stream = tmp_path / "f.btrfs"
+        stream.write_bytes(stream.read_bytes() + b"CORRUPTION")
+        rc = execute(self._args(f"raw://{tmp_path}", level="full"))
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "CORRUPT" in out
+
+    def test_raw_ssh_corrupt_verdict_surfaces_via_general_verify(
+        self, tmp_path, capsys
+    ):
+        """End-to-end through the general verify stack for raw+ssh: a mismatching remote
+        digest -> exit 1, 'corrupt' status, and the consistency-only trust caveat (the
+        digest came from an untrusted remote). Guards the general-verify -> SSHRawEndpoint
+        -> verify_raw_checksums chain, not just the primitive in isolation."""
+        import json
+
+        from btrfs_backup_ng.endpoint.raw import SSHRawEndpoint
+        from btrfs_backup_ng.endpoint.raw_metadata import RawSnapshot
+
+        ep = SSHRawEndpoint(config={"path": "/backups", "hostname": "nas"})
+        snap = RawSnapshot(
+            name="r", stream_path=Path("/backups/r.btrfs"), checksum_value="a" * 64
+        )
+        ep.list_snapshots = lambda flush_cache=False: [snap]
+        ep.compute_stream_checksum = lambda s: "b" * 64  # remote reports a mismatch
+        ep.prepare = lambda: None
+
+        with patch(
+            "btrfs_backup_ng.cli.verify.endpoint.choose_endpoint", return_value=ep
+        ):
+            rc = execute(self._args("raw+ssh://nas/backups", json=True))
+
+        data = json.loads(capsys.readouterr().out)
+        assert rc == 1
+        res = data["results"][0]
+        assert res["details"]["checksum_status"] == "corrupt"
+        assert res["details"]["trust"] == "consistency-only (remote hash)"
+
+    def test_raw_ssh_location_recognized_and_threads_ssh_creds(self, tmp_path):
+        """A raw+ssh:// location is recognized (NOT mangled into a local path) and threads
+        ssh_sudo/ssh_key/ssh_auth_sock into the endpoint kwargs. Mutation guard: dropping
+        the raw+ssh routing branch drops the ssh creds (a sudo/agent-required remote verify
+        would silently fail) and stuffs a bogus 'path' from Path(url).resolve()."""
+        captured: dict = {}
+
+        def fake_choose(location, kwargs, source=False):
+            captured.update(kwargs)
+            raise RuntimeError("stop after capturing kwargs")
+
+        with patch(
+            "btrfs_backup_ng.cli.verify.endpoint.choose_endpoint",
+            side_effect=fake_choose,
+        ):
+            rc = execute(
+                self._args(
+                    "raw+ssh://backup@nas:/backups",
+                    ssh_sudo=True,
+                    ssh_key="/k/id",
+                    ssh_auth_sock="/run/agent.sock",
+                )
+            )
+
+        assert rc == 2  # choose_endpoint raised -> caught -> return 2
+        assert captured.get("ssh_sudo") is True
+        assert captured.get("ssh_key") == "/k/id"
+        assert captured.get("ssh_auth_sock") == "/run/agent.sock"
+        assert "path" not in captured  # a raw scheme must not get a resolved local path

--- a/tests/test_raw_verify.py
+++ b/tests/test_raw_verify.py
@@ -228,6 +228,125 @@ def test_open_target_construction_error_keeps_prefix(capsys):
     assert "Cannot open raw target:" in capsys.readouterr().out
 
 
+# --------------------------------------------------------------------------- #
+# verify_stream_checksum primitive (R8a): the ONE classification shared by
+# `raw verify`, the restore guard, and the general `verify` command.
+# --------------------------------------------------------------------------- #
+def test_primitive_ok_on_intact_stream(tmp_path):
+    """A fresh backup's stream matches its sealed checksum -> ok / is_verified.
+    Mutation guard: breaking the computed==recorded compare drops this to corrupt."""
+    _build(tmp_path, "s1")
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    (snap,) = ep.list_snapshots(flush_cache=True)
+    v = ep.verify_stream_checksum(snap)
+    assert v.status == "ok"
+    assert v.is_verified and not v.is_failure
+    assert v.recorded == v.computed == snap.checksum_value
+    assert v.remote_untrusted is False  # local raw:// hash is tamper-evident
+
+
+def test_primitive_corrupt_on_changed_bytes(tmp_path):
+    """A stream whose bytes changed after backup -> corrupt / is_failure.
+    Mutation guard: skipping the recompute (returning ok) fails is_failure."""
+    _build(tmp_path, "bad")
+    (tmp_path / "bad.btrfs").write_bytes(
+        (tmp_path / "bad.btrfs").read_bytes() + b"CORRUPTION"
+    )
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    (snap,) = ep.list_snapshots(flush_cache=True)
+    v = ep.verify_stream_checksum(snap)
+    assert v.status == "corrupt"
+    assert v.is_failure and not v.is_verified
+    assert v.recorded != v.computed and v.computed is not None
+
+
+def test_primitive_unverifiable_when_no_recorded_checksum(tmp_path):
+    """No recorded checksum -> unverifiable (not a failure), and the recompute is
+    SKIPPED (no reason to read a stream we cannot compare). Mutation guard: folding
+    unverifiable into is_failure, or computing anyway, fails."""
+    _build(tmp_path, "legacy")
+    meta = tmp_path / "legacy.btrfs.meta"
+    doc = json.loads(meta.read_text())
+    doc["checksum"]["value"] = None
+    meta.write_text(json.dumps(doc))
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    ep.compute_stream_checksum = MagicMock(
+        side_effect=AssertionError("must not hash an unverifiable stream")
+    )
+    (snap,) = ep.list_snapshots(flush_cache=True)
+    v = ep.verify_stream_checksum(snap)
+    assert v.status == "unverifiable"
+    assert not v.is_failure and not v.is_verified
+    ep.compute_stream_checksum.assert_not_called()
+
+
+def test_primitive_unverifiable_on_foreign_algorithm_skips_read(tmp_path):
+    """A non-sha256 algorithm -> unverifiable WITHOUT recomputing (comparing a sha256
+    to a foreign digest would false-flag corruption). Mutation guard: dropping the
+    algorithm gate would compute and mis-classify."""
+    _build(tmp_path, "other")
+    meta = tmp_path / "other.btrfs.meta"
+    doc = json.loads(meta.read_text())
+    doc["checksum"]["algorithm"] = "blake2b"
+    meta.write_text(json.dumps(doc))
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    ep.compute_stream_checksum = MagicMock(
+        side_effect=AssertionError("must not hash a foreign-algorithm stream")
+    )
+    (snap,) = ep.list_snapshots(flush_cache=True)
+    v = ep.verify_stream_checksum(snap)
+    assert v.status == "unverifiable"
+    ep.compute_stream_checksum.assert_not_called()
+
+
+@pytest.mark.skipif(
+    os.geteuid() == 0, reason="root bypasses chmod 0o000, so the stream stays readable"
+)
+def test_primitive_error_when_stream_unreadable(tmp_path):
+    """A recorded sha256 but an unreadable stream -> error / is_failure (distinct from
+    corrupt). Mutation guard: mapping a None recompute to ok/unverifiable fails."""
+    _build(tmp_path, "locked")
+    stream = tmp_path / "locked.btrfs"
+    stream.chmod(0o000)
+    try:
+        ep = RawEndpoint(config={"path": str(tmp_path)})
+        (snap,) = ep.list_snapshots(flush_cache=True)
+        v = ep.verify_stream_checksum(snap)
+        assert v.status == "error"
+        assert v.is_failure and v.computed is None
+    finally:
+        stream.chmod(0o600)
+
+
+def test_primitive_ssh_marks_remote_untrusted(tmp_path):
+    """A raw+ssh verdict carries remote_untrusted=True (the digest was computed BY the
+    untrusted remote -> consistency, not authenticity). Mutation guard: hardcoding the
+    flag False would erase the trust caveat the report surfaces."""
+    ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+    snap = RawSnapshot(
+        name="s", stream_path=Path("/backup/s.btrfs"), checksum_value="a" * 64
+    )
+    ep._remote_sha256 = lambda p: "a" * 64  # remote reports a match
+    v = ep.verify_stream_checksum(snap)
+    assert v.status == "ok"
+    assert v.remote_untrusted is True
+
+
+def test_ssh_auth_sock_renders_as_identity_agent():
+    """An explicit ssh_auth_sock (from `verify --ssh-auth-sock`) is rendered as an
+    `-o IdentityAgent=<sock>` ssh option so agent auth works under sudo (SSH_AUTH_SOCK is
+    stripped there). Mutation guard: dropping the _build_ssh_command handling omits the
+    option; absent config must add NOTHING (zero behavior change for the common case)."""
+    ep = SSHRawEndpoint(
+        config={"path": "/b", "hostname": "nas", "ssh_auth_sock": "/run/agent.sock"}
+    )
+    cmd = ep._build_ssh_command()
+    assert "-o" in cmd and "IdentityAgent=/run/agent.sock" in cmd
+
+    ep_none = SSHRawEndpoint(config={"path": "/b", "hostname": "nas"})
+    assert not any("IdentityAgent" in tok for tok in ep_none._build_ssh_command())
+
+
 def test_dispatcher_parses_raw_verify():
     """The real parser recognizes `raw verify TARGET --snapshot ... --json
     --ssh-sudo`. A missing subparser registration would fail here."""

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1288,3 +1288,109 @@ class TestValidateTransferChain:
         # Second can use 20240102 (which will be present after first transfer)
         _, result2 = results[1]
         assert result2.parent_name == "root-20240102"
+
+
+# =============================================================================
+# verify_raw_checksums (R8a): raw-target checksum verification branches
+# =============================================================================
+from btrfs_backup_ng.core.verify import verify_raw_checksums  # noqa: E402
+from btrfs_backup_ng.endpoint.raw_metadata import ChecksumVerdict  # noqa: E402
+
+
+class _FakeRawEndpoint:
+    """Minimal raw endpoint: returns preset snapshots and a preset verdict per name."""
+
+    def __init__(self, verdicts, path="/raw", raises=None):
+        # verdicts: dict name -> ChecksumVerdict
+        self._verdicts = verdicts
+        self.config = {"path": path}
+        self._raises = raises
+
+    def list_snapshots(self):
+        if self._raises:
+            raise self._raises
+        return [MockSnapshot(name) for name in self._verdicts]
+
+    def verify_stream_checksum(self, snap):
+        return self._verdicts[snap.get_name()]
+
+
+def _v(status, recorded="a" * 64, computed=None, remote=False):
+    return ChecksumVerdict(status, recorded, computed, "sha256", remote)
+
+
+def test_raw_checksums_empty_target_reports_error():
+    """No snapshots -> a reported error (exit 2 upstream), not a silent empty pass."""
+    ep = _FakeRawEndpoint({})
+    report = verify_raw_checksums(ep, VerifyLevel.STREAM)
+    assert report.errors == ["No snapshots found at backup location"]
+    assert report.total == 0
+
+
+def test_raw_checksums_snapshot_filter_selects_one():
+    """--snapshot NAME verifies only that stream."""
+    ep = _FakeRawEndpoint(
+        {"a": _v("ok", computed="a" * 64), "b": _v("corrupt", computed="b" * 64)}
+    )
+    report = verify_raw_checksums(ep, VerifyLevel.STREAM, snapshot_name="a")
+    assert report.total == 1
+    assert report.results[0].snapshot_name == "a"
+    assert report.results[0].passed is True
+
+
+def test_raw_checksums_snapshot_filter_missing_reports_error():
+    """--snapshot NAME for an absent snapshot -> reported error, no results."""
+    ep = _FakeRawEndpoint({"a": _v("ok", computed="a" * 64)})
+    report = verify_raw_checksums(ep, VerifyLevel.STREAM, snapshot_name="nope")
+    assert report.total == 0
+    assert any("nope" in e for e in report.errors)
+
+
+def test_raw_checksums_invokes_on_progress():
+    """The on_progress callback fires once per verified snapshot."""
+    ep = _FakeRawEndpoint({"a": _v("ok", computed="a" * 64)})
+    seen = []
+    verify_raw_checksums(
+        ep, VerifyLevel.STREAM, on_progress=lambda i, n, name: seen.append((i, n, name))
+    )
+    assert seen == [(1, 1, "a")]
+
+
+def test_raw_checksums_error_status_fails_with_message():
+    """An unreadable stream -> error verdict -> failed result with an explanatory message."""
+    ep = _FakeRawEndpoint({"a": _v("error", computed=None)})
+    report = verify_raw_checksums(ep, VerifyLevel.STREAM)
+    r = report.results[0]
+    assert r.passed is False
+    assert "could not be read" in r.message
+    assert report.failed == 1
+
+
+def test_raw_checksums_unverifiable_is_not_a_failure():
+    """No recorded checksum -> unverifiable -> passes (not a failure) with a clear message."""
+    ep = _FakeRawEndpoint({"a": ChecksumVerdict("unverifiable", None, None, "sha256")})
+    report = verify_raw_checksums(ep, VerifyLevel.STREAM)
+    r = report.results[0]
+    assert r.passed is True
+    assert "Unverifiable" in r.message
+    assert report.failed == 0
+
+
+def test_raw_checksums_remote_ok_carries_trust_caveat():
+    """A raw+ssh 'ok' verdict passes AND its message/details carry the consistency-only
+    caveat (the digest came from the untrusted remote)."""
+    ep = _FakeRawEndpoint({"a": _v("ok", computed="a" * 64, remote=True)})
+    report = verify_raw_checksums(ep, VerifyLevel.STREAM)
+    r = report.results[0]
+    assert r.passed is True
+    assert "consistency-only" in r.message
+    assert r.details["trust"] == "consistency-only (remote hash)"
+
+
+def test_raw_checksums_list_failure_is_reported_not_raised():
+    """A list_snapshots failure is captured as a report error (exit 2 upstream), never
+    propagated as an unhandled exception."""
+    ep = _FakeRawEndpoint({}, raises=OSError("mount gone"))
+    report = verify_raw_checksums(ep, VerifyLevel.STREAM)
+    assert any("mount gone" in e for e in report.errors)
+    assert report.total == 0


### PR DESCRIPTION
## R8a — shared checksum primitive + raw-aware `verify`

First root of the **R8 verification-hardening** audit. Closes the audit's CRITICAL finding: running the general `verify` command on a raw target (`raw://` / `raw+ssh://`) never consulted the R6b sealed sha256, so a **corrupt or truncated raw backup reported "All verifications passed" and exited 0** — a false all-clear. Symmetrically, `--level stream`/`full` on a raw target ran `btrfs send` against a stream *file* and **false-FAILed every good raw backup**.

### Root cause
Two disjoint verifiers: the real content check lived only in `raw verify` and the restore-time integrity guard; the general `verify` was a strictly-weaker, byte-blind copy.

### The fix — one primitive, three callers
- **`ChecksumVerdict`** (frozen dataclass, `raw_metadata.py`) — the single `ok`/`corrupt`/`error`/`unverifiable` taxonomy; `is_failure` (corrupt/error) is the one source of truth behind exit codes, restore aborts, and verify PASS/FAIL.
- **`RawEndpoint.verify_stream_checksum()`** — recompute the stream's sha256 (local for `raw://`, on the remote for `raw+ssh://`) and classify. Never raises. `_checksum_is_remote` marks the raw+ssh trust asymmetry.
- Routed through it: **`raw verify`** (JSON/exit contract unchanged), the **restore guard** (`AbortError`-on-corrupt preserved), and the **new `verify_raw_checksums()`** wired into the general `verify`.

### General `verify` behavior
- Raw `stream`/`full` → sealed-checksum check (no more `btrfs send` on a stream file).
- **Default level resolves to `stream` for raw targets** — a bare `verify raw://X` reads the bytes instead of reporting a hollow pass from a directory listing. This closes the CRITICAL default false-PASS.
- `raw://` & `raw+ssh://` locations recognized (were mangled into a local path); `ssh_sudo`/`ssh_key`/`ssh_auth_sock` threaded for raw+ssh (`SSHRawEndpoint` now honors an explicit agent socket via `IdentityAgent`, so agent auth works under sudo).
- Checks **every** snapshot, not just the latest.
- Surfaces the raw+ssh trust caveat (digest computed by the untrusted remote = consistency, not authenticity).
- `--json` emits clean machine-readable stdout without needing `--quiet` (pre-existing footgun fixed, since this PR recommends that path).

### Verification
- **Full suite: 2516 passed, 1 skipped.** ruff 0.15.22 + full mypy clean.
- **16 new tests, each mutation-verified** — primitive taxonomy (5 branches), general-verify-on-raw end-to-end (the exact coverage gap the audit flagged: seal → corrupt → general `verify` → exit 1 + CORRUPT), explicit `stream`/`full` routing, raw+ssh corrupt verdict via the general stack, `ssh_auth_sock`→`IdentityAgent`.
- **Adversarial 4-lens review** (behavior-drift / CLI-routing / checksum-security / test-theater), each finding adversarially verified: 7 nits/lows refuted, 4 real findings fixed (ssh_auth_sock threading+consumption; 3 test-coverage gaps).
- **Hardware-proven** with real `btrfs send` streams over `raw://` (local hash) and `raw+ssh://` (remote sha256 over real ssh): intact → pass, corruption injected on-target → exit 1; raw+ssh verify works with an explicit `--ssh-auth-sock`.

### Scope
Behavior-preserving for the two pre-existing callers. Later R8 roots (btrfs metadata structural validation + parent tautology, dead `ssh_client` branch, `verify_full` whole-chain, JSON top-level verdict) are separate PRs.

No AI/tool attribution.