### PR TITLE
fix(verify): metadata level validates structure, not just names (R8b)

### DIFF
--- a/man/man1/btrfs-backup-ng-verify.1
+++ b/man/man1/btrfs-backup-ng-verify.1
@@ -32,9 +32,15 @@ the stream rather than reporting a hollow pass from a directory listing. Valid l
 .RS
 .TP
 .B metadata
-Quick check of snapshot existence and parent chain integrity. Verifies that
-all snapshots exist and that incremental chains are complete (no missing
-parent snapshots). This is fast and non-destructive.
+Fast structural check that each backup is a real backup artifact, not merely a
+name-shaped entry. For a btrfs target, confirms each entry is a received read-only
+subvolume (an interrupted receive that left a plain directory FAILS rather than passing);
+an entry whose received status cannot be confirmed without privilege is reported
+\fBunverifiable\fR rather than failed. For a raw target, confirms an authoritative
+\fB.meta\fR sidecar is present and, when a snapshot records an incremental parent, that the
+parent actually exists among the backups (a recorded-but-absent parent is an unrestorable
+chain break and FAILS). This is fast and non-destructive; it does not read stream/file
+data (use \fBstream\fR or \fBfull\fR for that).
 .TP
 .B stream
 For a btrfs target, verify that a \fBbtrfs send\fR stream can be generated (uses
@@ -96,16 +102,21 @@ Output results in JSON format for scripting and automation.
 Suppress progress output.
 .SH VERIFICATION LEVELS
 .SS Metadata (Fast)
-Checks performed:
+Checks performed, per snapshot:
 .IP \(bu 2
-Snapshot existence at backup location
+Structural validity \(em that the entry is a REAL backup artifact: a received read-only
+btrfs subvolume (non-empty received UUID), or a raw stream with an authoritative
+\fB.meta\fR sidecar. A plain directory (e.g. an interrupted receive) FAILS; an entry whose
+backup identity cannot be confirmed without privilege is reported \fBunverifiable\fR, not
+failed \(em a good backup is never failed merely because the environment could not prove it.
 .IP \(bu 2
-Parent chain completeness (no missing incremental parents)
-.IP \(bu 2
-Optional comparison with source to find missing backups
+Authoritative incremental-parent continuity \(em for a raw snapshot that records its
+parent's name, that the parent actually exists among the backups (a recorded-but-absent
+parent is an unrestorable chain break and FAILS). btrfs snapshots carry no recorded parent
+name at this level, so their chain is validated by \fBfull\fR verification.
 .PP
-This level is suitable for routine checks and can verify hundreds of
-snapshots in seconds.
+This level is fast and non-destructive and can verify hundreds of snapshots in seconds; it
+does not read stream/file data.
 .SS Stream (Medium)
 In addition to metadata checks:
 .IP \(bu 2

--- a/src/btrfs_backup_ng/core/verify.py
+++ b/src/btrfs_backup_ng/core/verify.py
@@ -86,10 +86,18 @@ def verify_metadata(
 ) -> VerifyReport:
     """Verify backup metadata integrity.
 
-    Checks:
-    - Snapshots exist at backup location
-    - Parent chain is complete (no missing incremental parents)
-    - Optionally compares with source to find missing backups
+    Checks, per snapshot:
+    - Structural validity -- that the entry is a REAL backup artifact, not just a
+      name-shaped directory entry: a received read-only btrfs subvolume, or a raw stream
+      with an authoritative ``.meta`` sidecar. The endpoint checks its own kind via
+      ``verify_structure`` (polymorphic). A plain directory left by an interrupted receive
+      FAILS instead of passing; a subvolume whose received status cannot be confirmed
+      (missing privilege) is reported ``unverifiable`` rather than failed.
+    - Authoritative incremental-parent continuity -- for a raw snapshot that records its
+      parent's name in the sidecar, that the parent actually exists among the backups (a
+      recorded-but-absent parent is an unrestorable chain break). btrfs snapshots carry no
+      recorded parent name here, so their chain is validated at ``--level full``.
+    - Optionally compares with source to find missing backups.
 
     Args:
         backup_endpoint: Endpoint where backups are stored
@@ -125,8 +133,10 @@ def verify_metadata(
                 report.completed_at = time.time()
                 return report
 
-        # Build set of all snapshot names for chain checking
-        all_names = {s.get_name() for s in backup_snapshots}
+        # The set of names actually present at the backup -- the INDEPENDENT reference a
+        # recorded parent is checked against. (The old check drew the parent FROM this same
+        # list and then tested membership IN it: a tautology that could never fail.)
+        present_names = {s.get_name() for s in backup_snapshots}
 
         # Verify each snapshot
         for i, snap in enumerate(backup_snapshots, 1):
@@ -142,22 +152,31 @@ def verify_metadata(
                 passed=True,
             )
 
-            # Check 1: Snapshot exists (we already know it does from list)
-            result.details["exists"] = True
+            # Check 1: structural validity -- is this a REAL backup artifact (a received
+            # subvolume / a sidecar-backed raw stream), not merely a name-shaped entry?
+            # The endpoint validates its own kind (polymorphic verify_structure).
+            structure = backup_endpoint.verify_structure(snap)
+            result.details["structure"] = structure.status
+            result.message = structure.message
+            if structure.is_failure:
+                result.passed = False
+            # 'unverifiable' keeps passed=True (never fail a good backup the environment
+            # could not prove) but the message surfaces it -- not read as a clean pass.
 
-            # Check 2: Parent chain integrity
-            # Find what would be the parent for this snapshot
-            parent = _find_parent_snapshot(snap, backup_snapshots)
-            if parent:
-                parent_name = parent.get_name()
-                result.details["parent"] = parent_name
-                if parent_name not in all_names:
+            # Check 2: authoritative incremental-parent continuity. A raw snapshot records
+            # its parent's NAME in the sidecar; a parent recorded but absent from the
+            # backup is an unrestorable chain break. btrfs Snapshots carry no recorded
+            # parent name here (getattr -> None), so this is a no-op for them.
+            required_parent = getattr(snap, "parent_name", None)
+            if required_parent:
+                result.details["parent"] = required_parent
+                if required_parent not in present_names:
                     result.passed = False
-                    result.message = f"Missing parent: {parent_name}"
+                    miss = f"missing incremental parent: {required_parent}"
+                    result.message = (
+                        f"{result.message}; {miss}" if result.message else miss
+                    )
                     result.details["parent_missing"] = True
-            else:
-                result.details["parent"] = None
-                result.details["is_base"] = True  # This is a base snapshot
 
             result.duration_seconds = time.monotonic() - start
             report.results.append(result)

--- a/src/btrfs_backup_ng/endpoint/common.py
+++ b/src/btrfs_backup_ng/endpoint/common.py
@@ -16,6 +16,7 @@ from btrfs_backup_ng import __util__
 from btrfs_backup_ng.__logger__ import logger
 from btrfs_backup_ng.core.space import SpaceInfo
 from btrfs_backup_ng.core.space import get_space_info as _get_space_info
+from btrfs_backup_ng.endpoint.raw_metadata import StructureVerdict
 
 
 def require_source(method):
@@ -479,6 +480,51 @@ class Endpoint:
             if getattr(candidate, "received_uuid", "") == src_uuid:
                 return candidate
         return None
+
+    def verify_structure(self, snapshot: Any) -> StructureVerdict:
+        """Confirm ``snapshot`` is a real, valid backup ARTIFACT (not just a name-shaped
+        directory entry) -- the polymorphic structural check behind the ``verify`` metadata
+        level. This base implementation is the LOCAL btrfs semantics (Local endpoint);
+        SSH and raw endpoints override it.
+
+        A local backup is enumerated by ``iterdir`` (any directory entry whose NAME parses
+        as a snapshot), so an interrupted ``btrfs receive`` that left a plain directory, or
+        a hand-created folder, is listed like a real backup. This confirms otherwise:
+
+        - NOT a btrfs subvolume (``is_subvolume`` is a privilege-free inode check) ->
+          ``invalid``: deterministically not a backup (the interrupted-receive / plain-dir
+          case). This is the core false-pass this method closes.
+        - a subvolume with a non-empty ``received_uuid`` (set only by ``btrfs receive``,
+          and a received subvolume is read-only by construction) -> ``ok``.
+        - a subvolume whose ``received_uuid`` could not be confirmed (empty: a non-received
+          subvolume, or the best-effort ``btrfs subvolume show`` enrichment could not run
+          without privilege) -> ``unverifiable``: never fail a real subvolume just because
+          the environment could not prove it is a received backup.
+        """
+        try:
+            path = snapshot.get_path()
+        except Exception:  # noqa: BLE001 - a snapshot with no resolvable path is not ours
+            return StructureVerdict("unverifiable", "could not resolve snapshot path")
+        try:
+            is_subvol = __util__.is_subvolume(path)
+        except OSError as e:
+            # Could not stat the path (e.g. permission) -- cannot determine; do not fail.
+            return StructureVerdict(
+                "unverifiable", f"could not check subvolume status: {e}"
+            )
+        if not is_subvol:
+            return StructureVerdict(
+                "invalid",
+                "not a btrfs subvolume (a plain directory -- e.g. an interrupted "
+                "receive left a partial/empty backup)",
+            )
+        if getattr(snapshot, "received_uuid", ""):
+            return StructureVerdict("ok", "received read-only subvolume")
+        return StructureVerdict(
+            "unverifiable",
+            "a subvolume, but its received_uuid could not be confirmed "
+            "(not a received backup, or btrfs subvolume show needs privilege)",
+        )
 
     def set_lock(
         self, snapshot: Any, lock_id: Any, lock_state: bool, parent: bool = False

--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -37,6 +37,7 @@ from btrfs_backup_ng.endpoint.raw_metadata import (
     COMPRESSION_CONFIG,
     ChecksumVerdict,
     RawSnapshot,
+    StructureVerdict,
     _fsync_directory,
     discover_raw_snapshots,
     get_file_extension,
@@ -907,6 +908,30 @@ class RawEndpoint(Endpoint):
         if computed == recorded:
             return ChecksumVerdict("ok", recorded, computed, algorithm, remote)
         return ChecksumVerdict("corrupt", recorded, computed, algorithm, remote)
+
+    def verify_structure(self, snapshot: RawSnapshot) -> StructureVerdict:
+        """Confirm ``snapshot`` is a raw backup with AUTHORITATIVE metadata (the ``verify``
+        metadata-level structural check for a raw target). The stream file itself exists by
+        virtue of discovery; the structural question is whether it carries a real ``.meta``
+        sidecar:
+
+        - a native/backfilled/remediation sidecar (``provenance_origin`` is anything but
+          ``filename-inferred``) -> ``ok``: authoritative metadata is present.
+        - a filename-inferred stream (no ``.meta`` sidecar; metadata reconstructed from the
+          filename) -> ``unverifiable``: its pipeline and parentage are guesses, not a
+          failure but not a confirmed-authoritative backup either.
+
+        Byte integrity (the sealed sha256) is the ``stream``/``full`` level's job
+        (``verify_stream_checksum``); this level is the cheap structural check.
+        """
+        origin = getattr(snapshot, "provenance_origin", "native-write")
+        if origin == "filename-inferred":
+            return StructureVerdict(
+                "unverifiable",
+                "no .meta sidecar (metadata inferred from the filename -- run "
+                "'raw backfill-metadata' to write an authoritative sidecar)",
+            )
+        return StructureVerdict("ok", f"authoritative sidecar (origin={origin})")
 
     def sidecar_exists(self, snapshot: RawSnapshot) -> bool:
         """Whether ``snapshot``'s ``.meta`` sidecar exists now. Used by

--- a/src/btrfs_backup_ng/endpoint/raw_metadata.py
+++ b/src/btrfs_backup_ng/endpoint/raw_metadata.py
@@ -126,6 +126,45 @@ class ChecksumVerdict:
         return self.status == "ok"
 
 
+@dataclass(frozen=True)
+class StructureVerdict:
+    """The result of verifying one backup entry is a real, valid backup ARTIFACT (as
+    opposed to its byte content, which is ``ChecksumVerdict``'s job). Produced
+    polymorphically by ``Endpoint.verify_structure`` -- each endpoint knows how to
+    confirm its own kind of backup -- so the general ``verify`` metadata level validates
+    structure instead of trusting that a name-shaped directory entry is a backup:
+
+    - ``ok``           confirmed a real backup: a received read-only btrfs subvolume
+                       (non-empty ``received_uuid``), or a raw stream with an authoritative
+                       ``.meta`` sidecar.
+    - ``invalid``      DETERMINISTICALLY not a valid backup -- e.g. a plain directory left
+                       by an interrupted ``btrfs receive`` (not a subvolume at all). A
+                       failure.
+    - ``unverifiable`` a real subvolume/stream whose backup identity could NOT be confirmed
+                       -- ``received_uuid`` empty (a non-received subvolume, or an enrichment
+                       miss with no privilege) or a filename-inferred raw stream with no
+                       sidecar. NOT a failure: we never fail a good backup just because the
+                       environment (missing sudo) could not prove it.
+
+    ``invalid`` is reserved for what we can prove is wrong; anything merely unconfirmed is
+    ``unverifiable``. ``is_failure`` (invalid only) is the single source of truth for
+    PASS/FAIL, mirroring ``ChecksumVerdict``.
+    """
+
+    status: str
+    message: str = ""
+
+    @property
+    def is_failure(self) -> bool:
+        """Whether this verdict should count as a verification failure."""
+        return self.status == "invalid"
+
+    @property
+    def is_ok(self) -> bool:
+        """Whether the entry was positively confirmed a valid backup."""
+        return self.status == "ok"
+
+
 @functools.total_ordering
 @dataclass(eq=False, repr=False)
 class RawSnapshot:

--- a/src/btrfs_backup_ng/endpoint/ssh.py
+++ b/src/btrfs_backup_ng/endpoint/ssh.py
@@ -60,6 +60,7 @@ except ImportError:
 
 from btrfs_backup_ng import __util__  # noqa: E402
 from btrfs_backup_ng.__logger__ import logger  # noqa: E402
+from btrfs_backup_ng.endpoint.raw_metadata import StructureVerdict  # noqa: E402
 from btrfs_backup_ng.core.errors import (  # noqa: E402
     TransientNetworkError,
     classify_error,
@@ -2077,6 +2078,29 @@ print(json.dumps(result))
         logger.info(f"Found {len(snapshots)} remote snapshots at {path}")
         logger.debug(f"Remote snapshots: {[str(s) for s in snapshots]}")
         return snapshots
+
+    def verify_structure(self, snapshot: Any) -> StructureVerdict:
+        """Confirm ``snapshot`` is a real received backup on the remote (the ``verify``
+        metadata-level structural check for an ssh:// btrfs target).
+
+        Unlike the local endpoint (which enumerates with ``iterdir`` and so can list a
+        plain directory), the SSH endpoint enumerates with ``btrfs subvolume list``, which
+        returns ONLY real subvolumes -- so subvolume-ness is already guaranteed and the
+        plain-directory false-pass cannot arise here. The meaningful check is therefore the
+        ``received_uuid`` (parsed from the ``-R`` column at list time, computed on the
+        remote): non-empty -> ``ok`` (a received backup); empty -> ``unverifiable`` (a
+        non-received subvolume, not a backup this tool produced). We do not re-run
+        ``btrfs subvolume show`` here: it needs privilege the read-only verify path should
+        not require, and a failure could not be distinguished from a genuinely-absent
+        subvolume -- which would false-fail a good backup.
+        """
+        if getattr(snapshot, "received_uuid", ""):
+            return StructureVerdict("ok", "received subvolume")
+        return StructureVerdict(
+            "unverifiable",
+            "a subvolume, but received_uuid is empty (not a received backup, or the "
+            "remote listing could not read it)",
+        )
 
     def _verify_snapshot_exists(self, dest_path: str, snapshot_name: str) -> bool:
         """Verify a snapshot exists on the remote host at its exact path.

--- a/tests/integration/tier2/test_verify_structure_real.py
+++ b/tests/integration/tier2/test_verify_structure_real.py
@@ -1,0 +1,86 @@
+"""Tier 2 tests for R8b metadata structural validation with real btrfs.
+
+The unit tests (tests/test_verify.py::TestVerifyMetadataStructural) cover the cases
+reachable without root -- a plain directory is 'invalid', raw sidecar/parent logic. These
+cover the case that needs a REAL received subvolume: a genuinely received read-only
+subvolume must verify 'ok', and a locally-created (non-received) subvolume must be
+'unverifiable' (a subvolume, but not a backup this tool produced) -- never a false pass.
+"""
+
+import subprocess
+
+import pytest
+
+from btrfs_backup_ng.core.verify import verify_metadata
+from btrfs_backup_ng.endpoint.local import LocalEndpoint
+
+from .conftest import create_snapshot, requires_btrfs, send_snapshot
+
+
+@pytest.mark.tier2
+@requires_btrfs
+class TestVerifyStructureRealBtrfs:
+    """endpoint.verify_structure / verify_metadata against real btrfs subvolumes."""
+
+    def test_received_subvolume_verifies_ok(self, btrfs_source_and_dest):
+        """A real RECEIVED read-only subvolume (non-empty received_uuid) -> structure ok,
+        verify_metadata passes. Proves the received-backup path is not false-failed."""
+        source, dest = btrfs_source_and_dest
+        subvol = source / "data"
+        subprocess.run(
+            ["btrfs", "subvolume", "create", str(subvol)],
+            check=True,
+            capture_output=True,
+        )
+        (subvol / "file.txt").write_text("payload")
+        # A read-only snapshot named like a backup, then send/receive it into dest so the
+        # received copy carries a received_uuid (only btrfs receive sets that).
+        snap = source / "home-20260101-120000"
+        create_snapshot(subvol, snap, readonly=True)
+        send_snapshot(snap, dest)
+
+        ep = LocalEndpoint(config={"path": str(dest), "snap_prefix": "home-"})
+        (received,) = ep.list_snapshots(flush_cache=True)
+        verdict = ep.verify_structure(received)
+        assert verdict.status == "ok", verdict.message
+
+        report = verify_metadata(ep)
+        assert report.passed == 1 and report.failed == 0
+        assert report.results[0].details["structure"] == "ok"
+
+    def test_non_received_subvolume_is_unverifiable(self, btrfs_volume):
+        """A locally-CREATED subvolume (never received, empty received_uuid) named like a
+        backup -> 'unverifiable' (a subvolume, but not a received backup) -- NOT a false
+        'ok', and NOT a failure. This is the masquerade the received_uuid check catches."""
+        dest = btrfs_volume / "backups"
+        dest.mkdir()
+        local_subvol = dest / "home-20260101-120000"
+        subprocess.run(
+            ["btrfs", "subvolume", "create", str(local_subvol)],
+            check=True,
+            capture_output=True,
+        )
+
+        ep = LocalEndpoint(config={"path": str(dest), "snap_prefix": "home-"})
+        (snap,) = ep.list_snapshots(flush_cache=True)
+        verdict = ep.verify_structure(snap)
+
+        assert verdict.status == "unverifiable", verdict.message
+        # Not a failure (never fail on inability to prove), but not a clean 'ok' either.
+        report = verify_metadata(ep)
+        assert report.failed == 0
+        assert report.results[0].details["structure"] == "unverifiable"
+
+    def test_plain_directory_on_btrfs_is_invalid(self, btrfs_volume):
+        """A plain directory (not a subvolume) on a real btrfs filesystem -> 'invalid'
+        (inode != 256), failing verify_metadata -- the interrupted-receive leftover case
+        on the real filesystem type it occurs on."""
+        dest = btrfs_volume / "backups"
+        dest.mkdir()
+        (dest / "home-20260101-120000").mkdir()  # a plain directory, not a subvolume
+
+        ep = LocalEndpoint(config={"path": str(dest), "snap_prefix": "home-"})
+        report = verify_metadata(ep)
+
+        assert report.failed == 1 and report.passed == 0
+        assert report.results[0].details["structure"] == "invalid"

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from btrfs_backup_ng.endpoint.raw_metadata import StructureVerdict
 from btrfs_backup_ng.core.verify import (
     ParentViability,
     ParentViabilityResult,
@@ -182,12 +183,15 @@ class TestVerifyMetadata:
         assert "No snapshots found" in report.errors[0]
 
     def test_single_snapshot(self):
-        """Test verification of single snapshot."""
+        """A single snapshot the endpoint confirms structurally valid -> passes.
+        (Plumbing: the count/report; the real structural checks are exercised against
+        real filesystem objects in TestVerifyMetadataStructural.)"""
         mock_endpoint = MagicMock()
         mock_endpoint.list_snapshots.return_value = [
             MockSnapshot("snap-1"),
         ]
         mock_endpoint.config = {"path": "/backup"}
+        mock_endpoint.verify_structure.return_value = StructureVerdict("ok", "valid")
 
         report = verify_metadata(mock_endpoint)
 
@@ -195,8 +199,10 @@ class TestVerifyMetadata:
         assert report.passed == 1
         assert report.failed == 0
 
-    def test_complete_chain(self):
-        """Test verification of complete parent chain."""
+    def test_all_valid_snapshots_pass(self):
+        """N structurally-valid snapshots -> N passed. (Replaces the old 'complete chain'
+        test, which only passed because the parent check was a tautology that could never
+        fail; real chain-break detection is in TestVerifyMetadataStructural.)"""
         snapshots = make_snapshots(
             [
                 ("snap-1", "20260101-100000"),
@@ -208,6 +214,7 @@ class TestVerifyMetadata:
         mock_endpoint = MagicMock()
         mock_endpoint.list_snapshots.return_value = snapshots
         mock_endpoint.config = {"path": "/backup"}
+        mock_endpoint.verify_structure.return_value = StructureVerdict("ok", "valid")
 
         report = verify_metadata(mock_endpoint)
 
@@ -228,6 +235,7 @@ class TestVerifyMetadata:
         mock_endpoint = MagicMock()
         mock_endpoint.list_snapshots.return_value = snapshots
         mock_endpoint.config = {"path": "/backup"}
+        mock_endpoint.verify_structure.return_value = StructureVerdict("ok", "valid")
 
         report = verify_metadata(mock_endpoint, snapshot_name="snap-2")
 
@@ -257,6 +265,7 @@ class TestVerifyMetadata:
         mock_endpoint = MagicMock()
         mock_endpoint.list_snapshots.return_value = snapshots
         mock_endpoint.config = {"path": "/backup"}
+        mock_endpoint.verify_structure.return_value = StructureVerdict("ok", "valid")
 
         progress_calls = []
 
@@ -288,6 +297,7 @@ class TestVerifyMetadata:
         backup_ep = MagicMock()
         backup_ep.list_snapshots.return_value = backup_snapshots
         backup_ep.config = {"path": "/backup"}
+        backup_ep.verify_structure.return_value = StructureVerdict("ok", "valid")
 
         source_ep = MagicMock()
         source_ep.list_snapshots.return_value = source_snapshots
@@ -296,6 +306,62 @@ class TestVerifyMetadata:
 
         # Should report missing snapshot
         assert any("snap-3" in str(e) for e in report.errors)
+
+    def test_mixed_structural_verdicts_counted_correctly(self):
+        """A single run with invalid + ok + unverifiable snapshots -> `failed` counts ONLY
+        the invalid one; ok AND unverifiable both pass. This guards the aggregation rule
+        (is_failure == invalid only): mutating `if structure.is_failure` to
+        `if structure.status != "ok"` would wrongly fail the unverifiable one -- and every
+        other test would still pass, so only this mixed-report test catches it."""
+        snaps = [
+            MockSnapshot("s-invalid"),
+            MockSnapshot("s-ok"),
+            MockSnapshot("s-unver"),
+        ]
+        verdicts = {
+            "s-invalid": StructureVerdict("invalid", "not a subvolume"),
+            "s-ok": StructureVerdict("ok", "received subvolume"),
+            "s-unver": StructureVerdict("unverifiable", "no received_uuid"),
+        }
+        ep = MagicMock()
+        ep.list_snapshots.return_value = snaps
+        ep.config = {"path": "/backup"}
+        ep.verify_structure.side_effect = lambda s: verdicts[s.get_name()]
+
+        report = verify_metadata(ep)
+
+        assert report.total == 3
+        assert report.failed == 1  # only the invalid one
+        assert report.passed == 2  # ok + unverifiable both pass
+        by = {r.snapshot_name: r for r in report.results}
+        assert by["s-invalid"].passed is False
+        assert by["s-invalid"].details["structure"] == "invalid"
+        assert by["s-ok"].passed is True
+        assert by["s-ok"].details["structure"] == "ok"
+        assert by["s-unver"].passed is True  # unverifiable is NOT a failure
+        assert by["s-unver"].details["structure"] == "unverifiable"
+
+    def test_ssh_verify_structure_checks_received_uuid(self):
+        """SSHEndpoint.verify_structure: a received subvolume (non-empty received_uuid) ->
+        ok; a non-received one (empty received_uuid) -> unverifiable, NOT a failure. SSH
+        enumerates only real subvolumes, so the received_uuid is the masquerade check.
+        (self is unused, so the method is exercised without a live SSH connection.)
+        Mutation guard: dropping the received_uuid check makes the non-received case pass
+        as ok."""
+        from types import SimpleNamespace
+
+        from btrfs_backup_ng.endpoint.ssh import SSHEndpoint
+
+        received = SSHEndpoint.verify_structure(
+            None, SimpleNamespace(received_uuid="1111-2222")
+        )
+        non_received = SSHEndpoint.verify_structure(
+            None, SimpleNamespace(received_uuid="")
+        )
+
+        assert received.status == "ok"
+        assert non_received.status == "unverifiable"
+        assert non_received.is_failure is False
 
 
 class TestVerifyLevel:
@@ -1394,3 +1460,154 @@ def test_raw_checksums_list_failure_is_reported_not_raised():
     report = verify_raw_checksums(ep, VerifyLevel.STREAM)
     assert any("mount gone" in e for e in report.errors)
     assert report.total == 0
+
+
+# =============================================================================
+# verify_metadata STRUCTURAL validation (R8b): real filesystem objects, no mocks.
+# These exercise the actual endpoint.verify_structure + authoritative parent check
+# against real directories / real raw streams -- the audit's whole point was that the
+# old mock tests hid a byte-blind, tautological metadata level.
+# =============================================================================
+from btrfs_backup_ng.core.verify import verify_metadata as _verify_metadata  # noqa: E402
+from btrfs_backup_ng.endpoint.local import LocalEndpoint  # noqa: E402
+from btrfs_backup_ng.endpoint.raw import RawEndpoint  # noqa: E402
+
+
+def _build_raw_backup(path, name):
+    """Write a real raw backup (stream + authoritative .meta sidecar) at path."""
+    ep = RawEndpoint(config={"path": str(path)})
+    src = path / (name + ".src")
+    src.write_bytes(b"r8b-structural-" * 200)
+    with open(src, "rb") as f:
+        ep.receive(f, snapshot_name=name).communicate()
+    ep.commit_receive()
+    src.unlink()
+
+
+class TestVerifyMetadataStructural:
+    """R8b: metadata level validates real structure (F1) and authoritative parent
+    continuity (F2), against real filesystem objects."""
+
+    def test_local_plain_directory_fails_as_invalid(self, tmp_path):
+        """F1 end-to-end: a real LocalEndpoint over a directory holding plain (non-
+        subvolume) directories named like snapshots -> every entry FAILS as 'invalid'.
+        Before R8b these passed with a green 'All verifications passed'. Mutation guard:
+        revert verify_structure to hardcode exists=True and this reports all passed."""
+        backup = tmp_path / "backup"
+        backup.mkdir()
+        (backup / "home-20260101-120000").mkdir()  # interrupted-receive leftover
+        (backup / "home-20260102-120000").mkdir()
+        ep = LocalEndpoint(config={"path": str(backup), "snap_prefix": "home-"})
+
+        report = _verify_metadata(ep)
+
+        assert report.total == 2
+        assert report.failed == 2 and report.passed == 0
+        assert all("not a btrfs subvolume" in r.message for r in report.results)
+        assert all(r.details["structure"] == "invalid" for r in report.results)
+
+    def test_local_verify_structure_direct_on_plain_dir(self, tmp_path):
+        """The polymorphic check itself: LocalEndpoint.verify_structure on a real plain
+        directory -> invalid (a privilege-free inode check, no root needed)."""
+        backup = tmp_path / "b"
+        backup.mkdir()
+        (backup / "home-20260101-120000").mkdir()
+        ep = LocalEndpoint(config={"path": str(backup), "snap_prefix": "home-"})
+        (snap,) = ep.list_snapshots(flush_cache=True)
+
+        verdict = ep.verify_structure(snap)
+
+        assert verdict.status == "invalid" and verdict.is_failure
+
+    def test_local_is_subvolume_permission_error_is_unverifiable_not_fail(
+        self, tmp_path, monkeypatch
+    ):
+        """The false-negative-safety path: if is_subvolume cannot even stat the path (e.g.
+        permission denied), the entry is 'unverifiable' (passed=True), NEVER 'invalid' --
+        a good backup must not be failed just because the environment could not check it.
+        Mutation guard: removing the OSError catch (letting it raise / marking invalid)
+        breaks this."""
+        import btrfs_backup_ng.endpoint.common as common_mod
+
+        backup = tmp_path / "b"
+        backup.mkdir()
+        (backup / "home-20260101-120000").mkdir()
+        ep = LocalEndpoint(config={"path": str(backup), "snap_prefix": "home-"})
+        (snap,) = ep.list_snapshots(flush_cache=True)
+
+        def _denied(_path):
+            raise OSError(13, "Permission denied")
+
+        monkeypatch.setattr(common_mod.__util__, "is_subvolume", _denied)
+
+        verdict = ep.verify_structure(snap)
+
+        assert verdict.status == "unverifiable"
+        assert verdict.is_failure is False
+
+    def test_raw_authoritative_sidecar_passes(self, tmp_path):
+        """A raw backup with a real native-write sidecar -> structure ok -> passes."""
+        _build_raw_backup(tmp_path, "a.20260101T120000")
+        ep = RawEndpoint(config={"path": str(tmp_path)})
+
+        report = _verify_metadata(ep)
+
+        assert report.passed == 1 and report.failed == 0
+        assert report.results[0].details["structure"] == "ok"
+
+    def test_raw_filename_inferred_is_unverifiable_not_silent_pass(self, tmp_path):
+        """A raw stream with NO .meta sidecar (metadata inferred from the filename) is
+        'unverifiable' -- reported explicitly, not a silent clean pass and not a failure.
+        Mutation guard: treating filename-inferred as 'ok' loses the distinction."""
+        _build_raw_backup(tmp_path, "legacy.20260101T120000")
+        # Drop the sidecar so discovery falls back to filename inference.
+        (tmp_path / "legacy.20260101T120000.btrfs.meta").unlink()
+        ep = RawEndpoint(config={"path": str(tmp_path)})
+
+        report = _verify_metadata(ep)
+
+        assert report.total == 1
+        r = report.results[0]
+        assert r.passed is True  # unverifiable is not a failure
+        assert r.details["structure"] == "unverifiable"
+        assert "no .meta sidecar" in r.message
+
+    def test_raw_missing_incremental_parent_fails(self, tmp_path):
+        """F2 end-to-end: a raw snapshot whose sidecar records a parent_name that is NOT
+        present at the target -> FAIL 'missing incremental parent' (an unrestorable chain
+        break). This branch was UNREACHABLE before R8b (the tautology); the test proves it
+        now fires. Mutation guard: dropping the parent-continuity check makes this pass."""
+        import json
+
+        _build_raw_backup(tmp_path, "child.20260102T120000")
+        meta = tmp_path / "child.20260102T120000.btrfs.meta"
+        doc = json.loads(meta.read_text())
+        doc["parent_name"] = (
+            "ghost.20250101T000000"  # a parent that is not on the target
+        )
+        meta.write_text(json.dumps(doc))
+        ep = RawEndpoint(config={"path": str(tmp_path)})
+
+        report = _verify_metadata(ep)
+
+        r = report.results[0]
+        assert r.passed is False
+        assert "missing incremental parent: ghost.20250101T000000" in r.message
+        assert r.details["parent_missing"] is True
+
+    def test_raw_present_incremental_parent_passes(self, tmp_path):
+        """A valid raw chain (parent_name points at a snapshot that IS present) -> PASS.
+        Guards against false-failing a genuinely intact incremental chain."""
+        import json
+
+        _build_raw_backup(tmp_path, "base.20260101T120000")
+        _build_raw_backup(tmp_path, "child.20260102T120000")
+        meta = tmp_path / "child.20260102T120000.btrfs.meta"
+        doc = json.loads(meta.read_text())
+        doc["parent_name"] = "base.20260101T120000"  # present at the target
+        meta.write_text(json.dumps(doc))
+        ep = RawEndpoint(config={"path": str(tmp_path)})
+
+        report = _verify_metadata(ep)
+
+        assert report.failed == 0 and report.passed == 2

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1545,6 +1545,46 @@ class TestVerifyMetadataStructural:
         assert verdict.status == "unverifiable"
         assert verdict.is_failure is False
 
+    def test_local_verify_structure_ok_and_unverifiable_by_received_uuid(
+        self, tmp_path, monkeypatch
+    ):
+        """With is_subvolume True (a real subvolume), the received_uuid decides: non-empty
+        -> ok (a received backup); empty -> unverifiable (a subvolume, but not a received
+        backup). Covers the local ok/unverifiable branches without root; the tier2 suite
+        proves the same against a REAL received subvolume. Mutation guard: dropping the
+        received_uuid gate makes the empty case report ok."""
+        import btrfs_backup_ng.endpoint.common as common_mod
+        from types import SimpleNamespace
+
+        backup = tmp_path / "b"
+        backup.mkdir()
+        ep = LocalEndpoint(config={"path": str(backup), "snap_prefix": "home-"})
+        monkeypatch.setattr(common_mod.__util__, "is_subvolume", lambda _p: True)
+
+        received = SimpleNamespace(
+            get_path=lambda: backup / "recv", received_uuid="uuid-1234"
+        )
+        non_received = SimpleNamespace(
+            get_path=lambda: backup / "local", received_uuid=""
+        )
+
+        assert ep.verify_structure(received).status == "ok"
+        verdict = ep.verify_structure(non_received)
+        assert verdict.status == "unverifiable" and verdict.is_failure is False
+
+    def test_local_verify_structure_unresolvable_path_is_unverifiable(self, tmp_path):
+        """A snapshot whose path cannot be resolved -> unverifiable (not a crash, not an
+        invalid): a snapshot with no resolvable path is simply not ours to judge."""
+        from types import SimpleNamespace
+
+        ep = LocalEndpoint(config={"path": str(tmp_path), "snap_prefix": "home-"})
+
+        def _boom():
+            raise RuntimeError("no path")
+
+        verdict = ep.verify_structure(SimpleNamespace(get_path=_boom))
+        assert verdict.status == "unverifiable" and verdict.is_failure is False
+
     def test_raw_authoritative_sidecar_passes(self, tmp_path):
         """A raw backup with a real native-write sidecar -> structure ok -> passes."""
         _build_raw_backup(tmp_path, "a.20260101T120000")


### PR DESCRIPTION
## R8b — metadata level actually validates structure; kill the parent tautology

Second root of the **R8 verification-hardening** audit. The default `verify` level (metadata) trusted that any snapshot-named directory entry was a real backup:
- it **hardcoded** `details["exists"]=True` (comment: "we already know it does from list"), never checking that the entry is a btrfs subvolume;
- its "parent chain" check was a **tautology** — the parent was drawn from the *same* list it was then tested against, so the "missing parent" branch was unreachable dead code.

So a plain directory left by an interrupted `btrfs receive` reported **"All verifications passed"**, and a broken incremental chain was never detected. Every `verify_metadata` test was MagicMock-based and hid this.

### The fix
**Polymorphic `Endpoint.verify_structure(snapshot) -> StructureVerdict`** — each endpoint validates its own artifact:
- **local btrfs**: a received read-only subvolume (`is_subvolume` + non-empty `received_uuid`); a plain directory is **`invalid`** and fails.
- **ssh btrfs**: `received_uuid` (subvolume-ness is already guaranteed by `btrfs subvolume list`).
- **raw**: an authoritative `.meta` sidecar (a filename-inferred stream is `unverifiable`).

**De-tautologized parent check** — a raw snapshot records its parent's name in the sidecar (an *independent, authoritative* source); a recorded-but-absent parent is a **missing incremental parent** (unrestorable chain break) → FAIL. btrfs snapshots carry no recorded parent name here, so their chain is validated by `--level full` (honest, not a fake check).

**False-negative-safe (like R1):** `invalid` is reserved for what is *deterministically* not a backup (a plain directory — a privilege-free inode check). Anything merely unconfirmable (`received_uuid` unreadable without sudo, a permission error, a filename-inferred raw stream) is **`unverifiable`** — reported explicitly, never a failure. A good backup is never failed because the environment could not prove it.

### Verification
- **Tier1: 2533 passed** · **Tier2: 37 passed** (real loop-btrfs). ruff 0.15.22 + full mypy clean.
- **Tests use REAL filesystem objects, not mock endpoints** (the audit's core complaint): a real plain directory fails as `invalid`; real raw streams drive the sidecar/parent cases; a tier2 loop-btrfs test covers a genuinely received subvolume (`ok`) vs a locally-created non-received one (`unverifiable`).
- **Mutation-verified**: F1 (neuter `verify_structure` → plain dirs pass), F2 (drop the parent check → the *previously-unreachable* branch stops firing), aggregation (`is_failure` → `!= "ok"` wrongly fails unverifiable), and the OSError→unverifiable safety path.
- **Adversarial 4-lens review** (false-fail-safety / false-pass-completeness / polymorphism / test-theater), each finding adversarially verified: 4 nits/lows refuted, **3 real test-coverage gaps** fixed (SSH `verify_structure`, no-privilege OSError path, mixed-verdict aggregation) — no code defects; the safety model held.
- Manpage updated for the new metadata semantics.

### Scope
`check_parent_viability`, `verify_full`, `verify_stream`, and R8a's `verify_raw_checksums` are untouched. JSON `metadata.details` now carries `structure` (was the tautological `exists`/`is_base`). Later R8 roots: R8c (dead `ssh_client` branch + polymorphic btrfs stream), R8d (`verify_full` whole-chain), R8e (JSON verdict + `--source`).

No AI/tool attribution.