### PR TITLE
fix(verify): verify_full full-send restore; fixes F5 false-negative (R8d)

### DIFF
--- a/man/man1/btrfs-backup-ng-verify.1
+++ b/man/man1/btrfs-backup-ng-verify.1
@@ -50,10 +50,15 @@ stream's sha256 and compare it to the checksum sealed in its \fB.meta\fR sidecar
 detecting at-rest corruption.
 .TP
 .B full
-For a btrfs target, a complete restore test to a temporary location: actually restores
-snapshot(s) and verifies the restored subvolume is valid \(em the most thorough check,
-but the slowest; requires \fB--temp-dir\fR for remote backups. For a raw target, \fBfull\fR
-performs the same sealed-checksum verification as \fBstream\fR.
+For a btrfs target, a complete restore test to a temporary location: actually restores the
+target snapshot with a full \fBbtrfs send\fR (reading every data block, so btrfs's own
+checksums catch at-rest corruption) and verifies the restored subvolume is valid \(em the
+most thorough check, but the slowest, and for a remote backup it pulls the whole snapshot
+over the network. Requires \fB--temp-dir\fR on a local btrfs filesystem for remote backups,
+and root or passwordless sudo (it runs \fBbtrfs receive\fR). If the restore test cannot run
+\(em no privilege, or the target does not fit in the temp filesystem \(em the snapshot is
+reported \fBunverifiable\fR, not failed. For a raw target, \fBfull\fR performs the same
+sealed-checksum verification as \fBstream\fR.
 .RE
 .TP
 .BI \-\-snapshot " " \fINAME\fR
@@ -129,17 +134,21 @@ Does not transfer actual file data
 This level catches corruption in snapshot metadata that metadata-only
 checks might miss.
 .SS Full (Thorough)
-Performs actual restore:
+Performs an actual restore of the target snapshot:
 .IP \(bu 2
-Restores snapshot to temporary location
+Full \fBbtrfs send\fR of the target into a temp subvolume (no incremental parent needed \(em
+the backup's received subvolumes are already fully materialized), reading every data block
 .IP \(bu 2
-Verifies restored path is a valid btrfs subvolume
+Verifies the restored path is a valid btrfs subvolume
 .IP \(bu 2
-Tests the complete restore pipeline
+Reports \fBunverifiable\fR (not failed) if the environment cannot run the test (no
+root/sudo, or the target does not fit in the temp filesystem)
 .IP \(bu 2
-Cleans up after verification (unless \fB--no-cleanup\fR)
+Cleans up the restored subvolume afterward (unless \fB--no-cleanup\fR); a user-supplied
+\fB--temp-dir\fR is never removed, only the restored subvolumes within it
 .PP
-This is the definitive test that a backup can be restored.
+This is the definitive test that a backup can be restored. Requires root or passwordless
+sudo, and \fB--temp-dir\fR on a local btrfs filesystem for remote backups.
 .SS Raw targets (sealed checksum)
 For a \fBraw://\fR or \fBraw+ssh://\fR target, the \fBstream\fR and \fBfull\fR levels
 recompute each stored stream's sha256 and compare it to the checksum sealed in the

--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -276,7 +276,13 @@ def send_snapshot(
                 f"btrfs send/receive failed with return codes: {return_codes}"
             )
             logger.error(error_message)
-            _log_process_errors(send_process, receive_process)
+            send_err, recv_err = _log_process_errors(send_process, receive_process)
+            # Surface the real stderr in the exception so callers can classify the failure
+            # (e.g. ENOSPC vs a corrupt stream); otherwise it is lost to the log and every
+            # failure looks identical.
+            detail = (recv_err or send_err or "").strip()
+            if detail:
+                error_message = f"{error_message}: {detail}"
             raise __util__.SnapshotTransferError(error_message)
 
         # Durably publish the received data before declaring success. For raw
@@ -1131,8 +1137,16 @@ def _do_rich_progress_transfer(
         raise __util__.SnapshotTransferError(f"Transfer failed: {e}")
 
 
-def _log_process_errors(send_process, receive_process) -> None:
-    """Log stderr from send/receive processes."""
+def _log_process_errors(send_process, receive_process) -> tuple[str, str]:
+    """Log stderr from send/receive processes and RETURN it as (send_err, recv_err).
+
+    The stderr streams can only be read once, so returning what we read lets the caller
+    surface the real reason (e.g. 'No space left on device', 'cannot find parent
+    subvolume') in the raised error instead of losing it to the log -- callers that
+    classify the failure (verify's restore test) need the message, not just a return
+    code."""
+    send_err = ""
+    recv_err = ""
     if hasattr(send_process, "stderr") and send_process.stderr:
         send_err = send_process.stderr.read().decode("utf-8", errors="replace")
         if send_err:
@@ -1146,6 +1160,8 @@ def _log_process_errors(send_process, receive_process) -> None:
         recv_err = receive_process.stderr.read().decode("utf-8", errors="replace")
         if recv_err:
             logger.error("Receive process stderr: %s", recv_err)
+
+    return send_err, recv_err
 
 
 def _log_subprocess_error(e, destination_endpoint) -> None:

--- a/src/btrfs_backup_ng/core/verify.py
+++ b/src/btrfs_backup_ng/core/verify.py
@@ -9,7 +9,9 @@ and restorable:
 """
 
 import logging
+import os
 import shutil
+import subprocess
 import tempfile
 import time
 from dataclasses import dataclass, field
@@ -18,8 +20,71 @@ from pathlib import Path
 from typing import Any, Callable
 
 from .. import __util__
+from .errors import ErrorCategory, classify_error
 
 logger = logging.getLogger(__name__)
+
+
+def _can_run_btrfs_privileged() -> bool:
+    """Whether this process can run ``btrfs receive`` -- i.e. is root. Full verification
+    actually receives a send stream into a temp subvolume (needs CAP_SYS_ADMIN), so it
+    requires the PROCESS to be root. A non-root run with passwordless sudo is deliberately
+    NOT accepted here: the send/receive path escalates btrfs with a plain ``sudo`` (no
+    ``-n``), which prompts for a password in the receive pipe (no TTY) and hangs/fails --
+    so probing ``sudo -n`` would pass while the real receive breaks. Requiring root keeps
+    verification honest and non-interactive; run the command itself via ``sudo``. This is
+    a whole-run preflight: a lack of privilege is reported as an inability to verify (a
+    run-level error), never as a per-snapshot backup FAILURE."""
+    return os.geteuid() == 0
+
+
+def _estimate_temp_shortfall(snapshot, local_endpoint, temp_path) -> str | None:
+    """Best-effort local-temp space preflight for a full restore of ``snapshot``.
+
+    Returns a human-readable message if the restore would CONFIDENTLY not fit in
+    ``temp_path`` (applying the project's standard safety margin), else None. When the
+    size cannot be estimated -- e.g. a remote (ssh://) source, whose subvolume a LOCAL
+    ``btrfs`` command cannot measure -- returns None to PROCEED; an actual ENOSPC during
+    receive is then surfaced as unverifiable. Reuses the same estimator + space check the
+    transfer preflight uses (no new machinery)."""
+    from .estimate import estimate_snapshot_full_size, format_size
+    from .space import check_space_availability
+
+    try:
+        # verify_full is root-only, so no sudo is needed for the local estimate.
+        size, _method = estimate_snapshot_full_size(snapshot.get_path(), use_sudo=False)
+    except Exception:  # noqa: BLE001 - estimation is best-effort; proceed on any failure
+        return None
+    if size is None:
+        return None  # can't estimate (e.g. remote source) -> proceed, catch ENOSPC
+    try:
+        space_info = local_endpoint.get_space_info(str(temp_path))
+    except Exception:  # noqa: BLE001 - can't probe temp space -> proceed
+        return None
+    check = check_space_availability(space_info, size)
+    if check.sufficient:
+        return None
+    return check.warning_message or (
+        f"Insufficient temp space for restore test: ~{format_size(size)} needed, "
+        f"{format_size(space_info.effective_available)} available"
+    )
+
+
+def _delete_temp_subvolume(path: Path) -> None:
+    """Delete a restored subvolume from the verify temp dir. verify_full is root-only, so
+    no sudo escalation is needed (the subvolume was received as root, and we run as root).
+    Raises RuntimeError with the btrfs stderr on failure so the caller can log the real
+    reason rather than a bare exit code."""
+    result = subprocess.run(
+        ["btrfs", "subvolume", "delete", str(path)],
+        capture_output=True,
+        timeout=600,
+    )
+    if result.returncode != 0:
+        stderr = (result.stderr or b"").decode(errors="replace").strip()
+        raise RuntimeError(
+            stderr or f"btrfs subvolume delete exited {result.returncode}"
+        )
 
 
 class VerifyLevel(Enum):
@@ -304,9 +369,21 @@ def verify_full(
 ) -> VerifyReport:
     """Perform full restore verification.
 
-    Actually restores snapshot(s) to a temporary location and verifies
-    the restored subvolume is valid. This is the most thorough check
-    but also the slowest.
+    Actually restores snapshot(s) to a temporary btrfs location and verifies the restored
+    subvolume is valid -- the most thorough check (it reads every data block of the target,
+    so btrfs's own checksums catch at-rest corruption), but the slowest.
+
+    A target is restored with a FULL ``btrfs send`` (no ``-p``): a btrfs backup's received
+    subvolumes are already fully materialized, so a full send proves the target is a
+    complete, standalone, restorable subvolume -- and, unlike an incremental send into an
+    empty temp, it does not require a parent to be present (the old code sent ``-p parent``
+    into an empty temp where the parent was never restored, so ``btrfs receive`` failed and
+    a GOOD backup was reported FAIL).
+
+    False-negative-safe: a genuine restore failure (corrupt/rejected stream) is a FAILURE;
+    an environmental inability to run the test (no root/sudo, insufficient/undeterminable
+    temp space, temp not btrfs) is reported as UNVERIFIABLE or a run-level error, NEVER a
+    per-snapshot backup failure.
 
     Args:
         backup_endpoint: Endpoint where backups are stored
@@ -320,6 +397,18 @@ def verify_full(
     """
     location = str(backup_endpoint.config.get("path", "unknown"))
     report = VerifyReport(level=VerifyLevel.FULL, location=location)
+
+    # Whole-run privilege preflight: a restore test actually runs `btrfs receive`, which
+    # needs root or passwordless sudo. Without it we CANNOT verify -- report that inability
+    # (exit 2), never a per-snapshot FAIL (a good backup is not corrupt just because we
+    # lacked privilege to test it).
+    if not _can_run_btrfs_privileged():
+        report.errors.append(
+            "Full verification requires root privileges (it runs 'btrfs receive'); "
+            "run the command via sudo, e.g. 'sudo btrfs-backup-ng verify --level full ...'."
+        )
+        report.completed_at = time.time()
+        return report
 
     # Determine temp directory
     if temp_dir:
@@ -383,11 +472,9 @@ def verify_full(
         local_endpoint = endpoint.LocalEndpoint(
             {
                 "path": str(temp_path),
-                "snapshot_prefix": "",
+                "snap_prefix": "",
             }
         )
-
-        restored: list[Any] = []
 
         for i, snap in enumerate(to_verify, 1):
             name = snap.get_name()
@@ -402,13 +489,21 @@ def verify_full(
                 passed=True,
             )
 
-            try:
-                # Find parent
-                parent = _find_parent_snapshot(snap, backup_snapshots + restored)
+            # Per-snapshot space preflight (best-effort). A CONFIDENT shortfall is an
+            # inability to run the test -> UNVERIFIABLE (passed stays True), not a FAIL.
+            shortfall = _estimate_temp_shortfall(snap, local_endpoint, temp_path)
+            if shortfall is not None:
+                result.details["status"] = "unverifiable"
+                result.message = shortfall
+                result.duration_seconds = time.monotonic() - start
+                report.results.append(result)
+                continue
 
-                # Restore to temp location
-                logger.info("Test restoring %s...", name)
-                _test_restore(backup_endpoint, local_endpoint, snap, parent)
+            try:
+                # FULL send (no parent): materialize the target standalone in temp. Reads
+                # every data block of the target -> btrfs checksums catch corruption.
+                logger.info("Test restoring %s (full send)...", name)
+                _test_restore(backup_endpoint, local_endpoint, snap, None)
 
                 # Verify restored snapshot
                 restored_path = temp_path / name
@@ -421,16 +516,42 @@ def verify_full(
                     )
 
                 result.message = "Full restore verified successfully"
+                result.details["status"] = "ok"
                 result.details["restored_path"] = str(restored_path)
-                result.details["incremental"] = parent is not None
-
-                # Track for potential use as parent
-                restored.append(snap)
+                result.details["full_send"] = True
 
             except Exception as e:
-                result.passed = False
-                result.message = f"Full verification failed: {e}"
-                logger.error("Full verify failed for %s: %s", name, e)
+                # Distinguish an ENVIRONMENTAL inability from a GENUINE restore failure.
+                # Under root-only, the ONLY expected per-snapshot environmental condition is
+                # running OUT OF SPACE in the temp fs -- so ONLY a space signal maps to
+                # UNVERIFIABLE, and everything else (including corruption AND the anomalous
+                # permission error, which a root receive should never hit) is a real
+                # FAILURE. Mapping ONLY space (not permission) is deliberate: it means a
+                # corruption error whose stderr happens to mention "permission" can never be
+                # mis-downgraded to unverifiable and hide a bad backup.
+                #
+                # Two space signals: (a) the transfer's OWN preflight raises
+                # __util__.InsufficientSpaceError BEFORE the receive (its message is not "no
+                # space left", so match by TYPE); (b) a real ENOSPC during receive -- the
+                # enriched SnapshotTransferError now carries the btrfs stderr ("No space left
+                # on device"), which the structured classifier recognizes as TRANSIENT_SPACE.
+                out_of_space = (
+                    isinstance(e, __util__.InsufficientSpaceError)
+                    or classify_error(e).category == ErrorCategory.TRANSIENT_SPACE
+                )
+                if out_of_space:
+                    result.details["status"] = "unverifiable"
+                    result.message = (
+                        f"Restore test could not run (out of temp space): {e}"
+                    )
+                    logger.warning(
+                        "Full verify unverifiable (out of space) for %s", name
+                    )
+                else:
+                    result.passed = False
+                    result.details["status"] = "failed"
+                    result.message = f"Full verification failed: {e}"
+                    logger.error("Full verify failed for %s: %s", name, e)
 
             result.duration_seconds = time.monotonic() - start
             report.results.append(result)
@@ -440,20 +561,25 @@ def verify_full(
         logger.error("Full verification failed: %s", e)
 
     finally:
-        # Cleanup
-        if cleanup and own_temp:
-            logger.info("Cleaning up temp directory...")
-            try:
-                # Delete any restored subvolumes first
-                for snap in to_verify:
-                    snap_path = temp_path / snap.get_name()
+        # Cleanup. Delete EVERY restored subvolume regardless of who owns the temp dir --
+        # a user-supplied --temp-dir must never leak received subvolumes (which carry a
+        # received_uuid and could be mistaken for real backups). Only the temp DIRECTORY
+        # itself is removed just for a temp we created (never a user-supplied one).
+        if cleanup:
+            for snap in to_verify:
+                snap_path = temp_path / snap.get_name()
+                try:
                     if snap_path.exists() and __util__.is_subvolume(snap_path):  # type: ignore[attr-defined]
-                        __util__.delete_subvolume(snap_path)  # type: ignore[attr-defined]
-                # Remove temp dir
-                if temp_path.exists():
+                        _delete_temp_subvolume(snap_path)
+                except Exception as e:  # noqa: BLE001 - cleanup is best-effort
+                    logger.warning(
+                        "Could not delete restored subvolume %s: %s", snap_path, e
+                    )
+            if own_temp and temp_path.exists():
+                try:
                     shutil.rmtree(temp_path, ignore_errors=True)
-            except Exception as e:
-                logger.warning("Cleanup failed: %s", e)
+                except Exception as e:  # noqa: BLE001
+                    logger.warning("Could not remove temp directory: %s", e)
 
     report.completed_at = time.time()
     return report

--- a/tests/integration/tier2/test_verify_full_real.py
+++ b/tests/integration/tier2/test_verify_full_real.py
@@ -1,0 +1,164 @@
+"""Tier 2: verify_full does a REAL incremental-backup restore and passes (R8d).
+
+The unit tests mock _test_restore (test theater). These do a genuine send/receive of a
+base+incremental chain into a backup location, then run verify_full on the LATEST
+(incremental) snapshot and assert it PASSES. Before R8d, verify_full sent `-p parent` into
+the temp -> `btrfs receive` failed with "cannot find parent subvolume" -> a perfectly good
+backup was reported FAIL (the F5 false-negative). R8d does a FULL send of the target, which
+needs no parent present.
+
+EMPIRICAL NOTE (verified on real btrfs, matching the R10b lesson): F5 only manifests when
+the temp dir is on a DIFFERENT filesystem than the backup -- `btrfs receive` searches the
+WHOLE destination fs for the parent's received_uuid, so an incremental into a temp on the
+SAME fs as the backup finds the parent and (mis-)succeeds. It ALWAYS manifests for remote
+backups (temp is local, backup is remote = different fs). So these tests deliberately put
+the backup on the SOURCE loop fs and temp on the DEST loop fs (a separate filesystem), so
+the old `-p` behavior genuinely fails and Option B (full send) genuinely fixes it.
+"""
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from btrfs_backup_ng.core.verify import verify_full
+from btrfs_backup_ng.endpoint.local import LocalEndpoint
+
+from .conftest import LoopbackBtrfs, create_snapshot, requires_btrfs, send_snapshot
+
+
+def _run(*args):
+    subprocess.run(list(args), check=True, capture_output=True)
+
+
+@pytest.mark.tier2
+@requires_btrfs
+class TestVerifyFullRealBtrfs:
+    """verify_full against a real received base+incremental backup chain."""
+
+    def _build_backup(self, source):
+        """Materialize a base + incremental RECEIVED backup chain under source/backup (on
+        the SOURCE loop fs). The incremental SHARES a large extent with its base (the
+        common case). Returns (backup_dir, latest_name)."""
+        subvol = source / "data"
+        _run("btrfs", "subvolume", "create", str(subvol))
+        # A large shared file (unchanged between snapshots -> the incremental references
+        # the parent's extents; this is what makes an -p receive need the parent present).
+        _run(
+            "dd",
+            "if=/dev/urandom",
+            f"of={subvol}/big",
+            "bs=1M",
+            "count=32",
+            "status=none",
+        )
+
+        backup = source / "backup"
+        backup.mkdir()
+
+        base = source / "home-20260101-120000"
+        create_snapshot(subvol, base, readonly=True)
+        send_snapshot(base, backup)  # -> backup/home-20260101-120000 (received base)
+
+        (subvol / "small").write_text("incremental change")  # big UNCHANGED (shared)
+        incr = source / "home-20260102-120000"
+        create_snapshot(subvol, incr, readonly=True)
+        send_snapshot(incr, backup, parent=base)  # -> received incremental
+
+        return backup, "home-20260102-120000"
+
+    def test_verify_full_latest_incremental_passes(self, btrfs_source_and_dest):
+        """The latest (incremental) backup verifies via a FULL send -> PASS, with temp on a
+        SEPARATE fs from the backup. Mutation guard: re-introducing `-p parent` makes the
+        incremental receive fail ('cannot find parent subvolume' on the temp fs) -> this
+        asserts PASS, so the F5 regression is caught."""
+        source, dest = btrfs_source_and_dest
+        backup, latest = self._build_backup(source)
+        temp = dest / "verify-temp"  # DEST fs -- a DIFFERENT filesystem than the backup
+        temp.mkdir()
+
+        ep = LocalEndpoint(config={"path": str(backup), "snap_prefix": "home-"})
+        report = verify_full(ep, temp_dir=temp, cleanup=True)
+
+        assert report.total == 1
+        assert report.passed == 1 and report.failed == 0, report.results[0].message
+        r = report.results[0]
+        assert r.snapshot_name == latest
+        assert r.details["status"] == "ok"
+        assert r.details["full_send"] is True
+
+    def test_verify_full_cleanup_no_leak_in_user_temp(self, btrfs_source_and_dest):
+        """With a user-supplied --temp-dir, the restored subvolume is DELETED (no leak)
+        while the user's temp DIRECTORY itself remains. Mutation guard: the old
+        own_temp-gated deletion would leave the received subvolume behind."""
+        source, dest = btrfs_source_and_dest
+        backup, latest = self._build_backup(source)
+        temp = dest / "user-temp"  # a DIFFERENT fs than the backup (source fs)
+        temp.mkdir()
+
+        ep = LocalEndpoint(config={"path": str(backup), "snap_prefix": "home-"})
+        report = verify_full(ep, temp_dir=temp, cleanup=True)
+        assert report.passed == 1, report.results[0].message
+
+        restored = temp / latest
+        assert not restored.exists(), "restored subvolume leaked into user --temp-dir"
+        assert temp.exists(), "user-supplied temp dir must not be removed"
+
+    def test_verify_full_non_subvolume_target_fails(self, btrfs_source_and_dest):
+        """A backup entry that is NOT a real subvolume (e.g. an interrupted receive left a
+        plain directory) -> `btrfs send` fails -> FAIL, not a false pass and not swallowed
+        as unverifiable. Proves a genuine restore failure is caught."""
+        _source, dest = btrfs_source_and_dest
+        backup = dest / "backup"
+        backup.mkdir()
+        # A plain directory named like a snapshot (the interrupted-receive leftover).
+        (backup / "home-20260101-120000").mkdir()
+
+        ep = LocalEndpoint(config={"path": str(backup), "snap_prefix": "home-"})
+        temp = dest / "verify-temp"
+        temp.mkdir()
+        report = verify_full(ep, temp_dir=temp, cleanup=True)
+
+        assert report.failed == 1
+        assert report.results[0].passed is False
+        assert report.results[0].details["status"] == "failed"
+
+    def test_verify_full_insufficient_temp_space_is_unverifiable(self):
+        """A restore whose target does not fit in the temp filesystem -> UNVERIFIABLE, not
+        FAIL. On real btrfs the transfer's own space preflight raises
+        __util__.InsufficientSpaceError before the receive; verify_full must classify that
+        (by TYPE -- its message is not 'no space left') as environmental, never as a backup
+        failure. Guards the review's exact finding: a good backup that couldn't be restored
+        for lack of space must not be reported corrupt."""
+        # A 200 MiB target restored into a 150 MiB temp fs -> guaranteed ENOSPC. The
+        # source fs must hold data (200) + its received backup copy (200), so 600 MiB.
+        with (
+            LoopbackBtrfs(size_mb=600, label="src") as src,
+            LoopbackBtrfs(size_mb=150, label="tinytmp") as tmp,
+        ):
+            subvol = src / "data"
+            _run("btrfs", "subvolume", "create", str(subvol))
+            _run(
+                "dd",
+                "if=/dev/urandom",
+                f"of={subvol}/big",
+                "bs=1M",
+                "count=200",
+                "status=none",
+            )
+            backup = src / "backup"
+            backup.mkdir()
+            snap = src / "home-20260101-120000"
+            create_snapshot(subvol, snap, readonly=True)
+            send_snapshot(snap, backup)
+
+            ep = LocalEndpoint(config={"path": str(backup), "snap_prefix": "home-"})
+            # Force past the space preflight so the REAL receive hits ENOSPC.
+            with patch(
+                "btrfs_backup_ng.core.verify._estimate_temp_shortfall",
+                return_value=None,
+            ):
+                report = verify_full(ep, temp_dir=tmp / "t", cleanup=True)
+
+        assert report.failed == 0, report.results[0].message
+        assert report.results[0].details["status"] == "unverifiable"

--- a/tests/test_atomic_commit_wiring.py
+++ b/tests/test_atomic_commit_wiring.py
@@ -104,3 +104,24 @@ def test_chunked_transfer_commits_on_success(monkeypatch, tmp_path):
         chunked_manager=manager,
     )
     dest.commit_receive.assert_called_once()
+
+
+class _StderrProc:
+    """A process double whose stderr yields fixed bytes once (read-once contract)."""
+
+    def __init__(self, data: bytes):
+        self.stderr = io.BytesIO(data)
+
+
+def test_log_process_errors_returns_captured_stderr():
+    """R8d enrichment: _log_process_errors RETURNS the (send_err, recv_err) it read, so a
+    caller can surface the real btrfs reason in the raised error rather than losing it to
+    the log. Mutation guard: reverting it to return None makes the tuple-unpack fail, and
+    the caller could no longer classify ENOSPC vs corruption."""
+    send = _StderrProc(b"")
+    recv = _StderrProc(b"ERROR: No space left on device\n")
+
+    send_err, recv_err = ops._log_process_errors(send, recv)
+
+    assert send_err == ""
+    assert "No space left on device" in recv_err

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -514,7 +514,25 @@ class TestVerifyStream:
 
 
 class TestVerifyFull:
-    """Tests for verify_full function."""
+    """Tests for verify_full function (plumbing; real restore is in tier2)."""
+
+    @pytest.fixture(autouse=True)
+    def _env(self):
+        """These unit tests exercise verify_full's plumbing, not the environment gates:
+        mock the privilege probe to available and the space preflight to no-shortfall so
+        the tests are hermetic and CI-safe (CI is non-root without passwordless sudo). The
+        gates themselves are tested in TestVerifyFullEnvironment."""
+        with (
+            patch(
+                "btrfs_backup_ng.core.verify._can_run_btrfs_privileged",
+                return_value=True,
+            ),
+            patch(
+                "btrfs_backup_ng.core.verify._estimate_temp_shortfall",
+                return_value=None,
+            ),
+        ):
+            yield
 
     @patch("btrfs_backup_ng.core.verify.__util__.is_btrfs")
     def test_empty_backup_location(self, mock_is_btrfs):
@@ -768,6 +786,145 @@ class TestVerifyFull:
 
             assert len(progress_calls) == 1
             assert progress_calls[0] == (1, 1, "snap-1")
+
+
+class TestVerifyFullEnvironment:
+    """R8d false-negative-safety: verify_full must NEVER report a good backup as FAILED
+    just because the environment could not run the restore test. Missing privilege, a
+    space shortfall, ENOSPC, or a permission error are UNVERIFIABLE / run-level errors,
+    not per-snapshot failures. A GENUINE restore failure is still a FAIL."""
+
+    def _endpoint(self, tmpdir):
+        ep = MagicMock()
+        ep.list_snapshots.return_value = [MockSnapshot("snap-1")]
+        ep.config = {"path": tmpdir}
+        return ep
+
+    def test_no_privilege_is_run_error_not_failure(self):
+        """Not root -> the whole run is a reported error (exit 2), and ZERO snapshots are
+        marked failed. Mutation guard: dropping the privilege gate would attempt a real
+        restore (and, in CI, fail the snapshot)."""
+        import tempfile
+
+        with (
+            patch(
+                "btrfs_backup_ng.core.verify._can_run_btrfs_privileged",
+                return_value=False,
+            ),
+            tempfile.TemporaryDirectory() as tmpdir,
+        ):
+            report = verify_full(self._endpoint(tmpdir), temp_dir=Path(tmpdir))
+
+        assert report.total == 0
+        assert report.failed == 0
+        assert any("requires root" in e for e in report.errors)
+
+    def test_privilege_gate_is_root_only(self):
+        """_can_run_btrfs_privileged is strictly euid==0 (root-only): a non-root run does
+        NOT attempt to probe/accept passwordless sudo (the receive escalates with a plain,
+        prompting sudo that would hang in the pipe). Mutation guard: re-adding a sudo -n
+        acceptance path would make this return True off-root."""
+        import btrfs_backup_ng.core.verify as vmod
+
+        with patch.object(vmod.os, "geteuid", return_value=0):
+            assert vmod._can_run_btrfs_privileged() is True
+        with patch.object(vmod.os, "geteuid", return_value=1000):
+            assert vmod._can_run_btrfs_privileged() is False
+
+    @patch("btrfs_backup_ng.core.verify.__util__.is_btrfs", return_value=True)
+    @patch("btrfs_backup_ng.core.verify._can_run_btrfs_privileged", return_value=True)
+    def test_space_shortfall_is_unverifiable_not_failure(self, _priv, _btrfs):
+        """A confident temp-space shortfall -> the snapshot is UNVERIFIABLE (passed=True,
+        status unverifiable), NOT failed, and the restore is never attempted. Mutation
+        guard: treating the shortfall as a failure flips passed/failed."""
+        import tempfile
+
+        with (
+            patch(
+                "btrfs_backup_ng.core.verify._estimate_temp_shortfall",
+                return_value="Insufficient temp space for restore test: ~50 GiB needed, "
+                "1 GiB available",
+            ),
+            patch("btrfs_backup_ng.core.verify._test_restore") as mock_restore,
+            tempfile.TemporaryDirectory() as tmpdir,
+        ):
+            report = verify_full(self._endpoint(tmpdir), temp_dir=Path(tmpdir))
+
+        assert report.failed == 0 and report.passed == 1
+        r = report.results[0]
+        assert r.details["status"] == "unverifiable"
+        assert "Insufficient temp space" in r.message
+        mock_restore.assert_not_called()  # never started a doomed restore
+
+    @patch("btrfs_backup_ng.core.verify._estimate_temp_shortfall", return_value=None)
+    @patch("btrfs_backup_ng.core.verify.__util__.is_btrfs", return_value=True)
+    @patch("btrfs_backup_ng.core.verify._can_run_btrfs_privileged", return_value=True)
+    def test_enospc_during_restore_is_unverifiable(self, _priv, _btrfs, _short):
+        """An ENOSPC raised DURING receive -> unverifiable, not a backup failure."""
+        import tempfile
+
+        with (
+            patch(
+                "btrfs_backup_ng.core.verify._test_restore",
+                side_effect=Exception(
+                    "btrfs send/receive failed with return codes: [1, 0]: "
+                    "ERROR: No space left on device"
+                ),
+            ),
+            tempfile.TemporaryDirectory() as tmpdir,
+        ):
+            report = verify_full(self._endpoint(tmpdir), temp_dir=Path(tmpdir))
+
+        assert report.failed == 0
+        assert report.results[0].details["status"] == "unverifiable"
+
+    @patch("btrfs_backup_ng.core.verify._estimate_temp_shortfall", return_value=None)
+    @patch("btrfs_backup_ng.core.verify.__util__.is_btrfs", return_value=True)
+    @patch("btrfs_backup_ng.core.verify._can_run_btrfs_privileged", return_value=True)
+    def test_genuine_restore_failure_is_a_failure(self, _priv, _btrfs, _short):
+        """A genuine restore failure (a rejected/corrupt stream) IS a FAIL -- the
+        unverifiable escape hatch must not swallow real corruption. Mutation guard:
+        mapping every error to unverifiable would let this pass a broken backup."""
+        import tempfile
+
+        with (
+            patch(
+                "btrfs_backup_ng.core.verify._test_restore",
+                side_effect=Exception("ERROR: unexpected end of stream / invalid data"),
+            ),
+            tempfile.TemporaryDirectory() as tmpdir,
+        ):
+            report = verify_full(self._endpoint(tmpdir), temp_dir=Path(tmpdir))
+
+        assert report.failed == 1
+        assert report.results[0].passed is False
+        assert report.results[0].details["status"] == "failed"
+
+    @patch("btrfs_backup_ng.core.verify._estimate_temp_shortfall", return_value=None)
+    @patch("btrfs_backup_ng.core.verify.__util__.is_btrfs", return_value=True)
+    @patch("btrfs_backup_ng.core.verify._can_run_btrfs_privileged", return_value=True)
+    def test_corruption_mentioning_permission_still_fails(self, _priv, _btrfs, _short):
+        """A GENUINE corruption error whose stderr happens to contain 'permission' must
+        still be a FAIL, never downgraded to unverifiable. Only OUT-OF-SPACE maps to
+        unverifiable (under root-only, a permission error is anomalous, not environmental).
+        Mutation guard: re-adding PERMANENT_PERMISSION to the unverifiable set makes this
+        pass a corrupt backup."""
+        import tempfile
+
+        with (
+            patch(
+                "btrfs_backup_ng.core.verify._test_restore",
+                side_effect=Exception(
+                    "ERROR: crc32 mismatch in received stream; permission denied"
+                ),
+            ),
+            tempfile.TemporaryDirectory() as tmpdir,
+        ):
+            report = verify_full(self._endpoint(tmpdir), temp_dir=Path(tmpdir))
+
+        assert report.failed == 1
+        assert report.results[0].passed is False
+        assert report.results[0].details["status"] == "failed"
 
 
 class TestEndpointTestSendStream:

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -927,6 +927,92 @@ class TestVerifyFullEnvironment:
         assert report.results[0].details["status"] == "failed"
 
 
+class TestVerifyFullHelpers:
+    """Unit coverage for the R8d preflight/cleanup helpers, mutation-guarded without root
+    (the real paths are exercised on real btrfs in tier2)."""
+
+    def test_estimate_temp_shortfall_none_when_cannot_estimate(self):
+        """Size unmeasurable (e.g. a remote source) -> None (proceed, catch ENOSPC)."""
+        import btrfs_backup_ng.core.verify as vmod
+
+        with (
+            patch.object(
+                vmod, "_estimate_temp_shortfall", vmod._estimate_temp_shortfall
+            ),
+            patch(
+                "btrfs_backup_ng.core.estimate.estimate_snapshot_full_size",
+                return_value=(None, "none"),
+            ),
+        ):
+            assert (
+                vmod._estimate_temp_shortfall(MagicMock(), MagicMock(), Path("/t"))
+                is None
+            )
+
+    def test_estimate_temp_shortfall_none_when_sufficient(self):
+        """Enough space -> None (proceed with the restore)."""
+        import btrfs_backup_ng.core.verify as vmod
+
+        ep = MagicMock()
+        ep.get_space_info.return_value = MagicMock(effective_available=10**12)
+        with (
+            patch(
+                "btrfs_backup_ng.core.estimate.estimate_snapshot_full_size",
+                return_value=(1000, "du"),
+            ),
+            patch(
+                "btrfs_backup_ng.core.space.check_space_availability",
+                return_value=MagicMock(sufficient=True),
+            ),
+        ):
+            assert vmod._estimate_temp_shortfall(MagicMock(), ep, Path("/t")) is None
+
+    def test_estimate_temp_shortfall_message_when_short(self):
+        """A confident shortfall -> a human message (drives UNVERIFIABLE upstream)."""
+        import btrfs_backup_ng.core.verify as vmod
+
+        ep = MagicMock()
+        ep.get_space_info.return_value = MagicMock(effective_available=1)
+        with (
+            patch(
+                "btrfs_backup_ng.core.estimate.estimate_snapshot_full_size",
+                return_value=(10**12, "du"),
+            ),
+            patch(
+                "btrfs_backup_ng.core.space.check_space_availability",
+                return_value=MagicMock(
+                    sufficient=False, warning_message="short by lots"
+                ),
+            ),
+        ):
+            msg = vmod._estimate_temp_shortfall(MagicMock(), ep, Path("/t"))
+        assert msg == "short by lots"
+
+    def test_delete_temp_subvolume_ok(self):
+        """A successful delete does not raise."""
+        import btrfs_backup_ng.core.verify as vmod
+
+        with patch.object(
+            vmod.subprocess,
+            "run",
+            return_value=MagicMock(returncode=0, stderr=b""),
+        ):
+            vmod._delete_temp_subvolume(Path("/t/sub"))  # must not raise
+
+    def test_delete_temp_subvolume_raises_with_stderr(self):
+        """A failed delete raises RuntimeError carrying the btrfs stderr (not a bare code).
+        Mutation guard: swallowing the failure would let a leaked subvolume go unreported."""
+        import btrfs_backup_ng.core.verify as vmod
+
+        with patch.object(
+            vmod.subprocess,
+            "run",
+            return_value=MagicMock(returncode=1, stderr=b"ERROR: could not delete"),
+        ):
+            with pytest.raises(RuntimeError, match="could not delete"):
+                vmod._delete_temp_subvolume(Path("/t/sub"))
+
+
 class TestEndpointTestSendStream:
     """R8c: the polymorphic endpoint.test_send_stream replaces the deleted module-level
     _test_send_stream (and its dead ssh_client branch). Local runs `btrfs send --no-data`


### PR DESCRIPTION
## R8d — `verify_full` genuinely proves restore viability

Fourth root of the **R8 verification-hardening** audit. `verify_full` restored the latest snapshot with an **incremental** send (`btrfs send -p parent`) into a temp dir. When temp is on a **different filesystem** than the backup — **always** for a remote (`ssh://`) backup, and whenever `--temp-dir` is a separate fs — `btrfs receive` can't find the parent (it resolves the parent by `received_uuid` across the whole destination fs) and fails → a **perfectly good backup reported FAIL**. Every `verify_full` test mocked `_test_restore`, so this was never caught.

### Empirical grounding (the interesting part)
F5 did **not** reproduce when temp shares the backup's fs (receive finds the parent across the fs — the R10b lesson). It reproduces only on a **separate fs**, which is **always** the case for remote full-verify. Proven **before/after on the real .70 btrfs box**: same `verify ssh://.70 --level full` command PASSES with the fix, FAILS with the old `-p`.

### The fix — Option B: full send
`verify_full` now does a **full `btrfs send`** (no `-p`) of the target. A btrfs backup's received subvolumes are fully materialized, so a full send proves the target is a complete, standalone, restorable subvolume — needs no parent present, and reads **every data block** (btrfs checksums catch at-rest corruption). (Round-table chose B over whole-chain restore: A's temp footprint is the cumulative chain, which can be far larger than the target.)

### Root-only + false-negative-safe
- **Root-only** (it runs `btrfs receive`); non-root → a **run-level error (exit 2)**, never a per-snapshot FAIL. (Non-root+passwordless-sudo is deliberately not accepted: the receive escalates with a plain, prompting `sudo` that hangs in the no-TTY pipe — a pre-existing transfer-path limitation.)
- **Space preflight** reusing the transfer preflight's own machinery (`estimate_snapshot_full_size` + `get_space_info` + `check_space_availability`) → confident shortfall = **UNVERIFIABLE**, restore not attempted.
- **Real ENOSPC during receive** is also UNVERIFIABLE: `_log_process_errors` now returns the receive stderr and `SnapshotTransferError` carries it, so the structured **`classify_error`** recognizes it (and `__util__.InsufficientSpaceError` from the transfer preflight, matched by type). **Only out-of-space → unverifiable; everything else — including corruption whose stderr merely mentions "permission" — is a real FAILURE** (never hide a bad backup).
- **Cleanup** deletes every restored subvolume unconditionally; `rmtree` only for an auto-temp — a user `--temp-dir` never leaks received subvolumes.

### Verification
- **Tier1 2527 / Tier2 41**; ruff 0.15.22 + full mypy clean.
- **Real-btrfs tier2 tests** (not mocked): incremental backup verifies via full send with temp on a **separate loop fs** — **mutation-verified** (re-add `-p` → the incremental receive fails); non-subvolume target → FAIL; oversized target → UNVERIFIABLE; `--temp-dir` leaves no leaked subvolume.
- **Hardware-proven on real remote .70, BOTH privilege paths**: root → PASS; non-root → clean "requires root" run-error, no false FAIL.
- **Adversarial 4-lens review (2 rounds)**: found + fixed a broken sudo model and an ENOSPC-masking bug (both would have re-introduced false-negatives), plus narrowed the corruption classification to space-only. Also enriched `SnapshotTransferError` with stderr (a shared improvement — better transfer errors too).

### Scope
btrfs (local + ssh) only — raw stream/full routes to `verify_raw_checksums` (R8a). Deferred to **R8e** (the last R8 root): "verified 1 of N (latest only)" honesty in the summary/JSON + `--all` (which also becomes the whole-chain-history verification path).

No AI/tool attribution.