### PR TITLE
feat(verify): honest output, top-level verdict, and chain-wide --all (R8e)

### DIFF
--- a/man/man1/btrfs-backup-ng-verify.1
+++ b/man/man1/btrfs-backup-ng-verify.1
@@ -62,7 +62,13 @@ sealed-checksum verification as \fBstream\fR.
 .RE
 .TP
 .BI \-\-snapshot " " \fINAME\fR
-Verify only the specified snapshot instead of all snapshots.
+Verify only the named snapshot. Mutually exclusive with \fB\-\-all\fR.
+.TP
+.B \-\-all
+Verify EVERY snapshot at the backup location. The \fBstream\fR and \fBfull\fR levels check
+only the latest snapshot by default (fast); \fB\-\-all\fR verifies the whole chain. The
+\fBmetadata\fR level and raw targets already check all snapshots, so \fB\-\-all\fR is a
+no-op there. Mutually exclusive with \fB\-\-snapshot\fR.
 .TP
 .BI \-\-temp-dir " " \fIPATH\fR
 Temporary directory for full verification. Must be on a btrfs filesystem.
@@ -168,16 +174,34 @@ For a \fBraw+ssh://\fR target the sha256 is recomputed \fBon the (untrusted) rem
 host\fR, so an \fBok\fR verdict evidences at-rest consistency, not authenticity \(em a
 compromised target could forge a match. Verify a locally-mounted \fBraw://\fR copy for
 tamper-evidence.
+.SH VERDICT AND COUNTS
+Every run reports one of three verdicts (the \fBverdict\fR field in \fB\-\-json\fR; the
+final line in human output):
+.IP \(bu 2
+\fBpass\fR \(em every snapshot that was checked verified successfully.
+.IP \(bu 2
+\fBunverifiable\fR \(em no failures, but one or more snapshots could not be confirmed (an
+environmental limit, e.g. no privilege or a legacy backup with no recorded checksum). This
+is NOT a failure; a good backup is never reported bad because it could not be checked.
+.IP \(bu 2
+\fBfail\fR \(em at least one snapshot failed, or a run-level error occurred.
+.PP
+The summary counts \fBverified\fR (positively confirmed), \fBfailed\fR, and
+\fBunverifiable\fR separately \(em an unverifiable snapshot is never counted as verified.
+It also states how many snapshots were \fBchecked\fR of how many are \fBavailable\fR; when
+only a subset was checked (the latest, at \fBstream\fR/\fBfull\fR level), it hints to pass
+\fB\-\-all\fR to verify the whole chain.
 .SH EXIT STATUS
 .TP
 .B 0
-All verifications passed.
+Verdict \fBpass\fR or \fBunverifiable\fR (no failure detected; an environmental inability to
+verify does not raise an alarm).
 .TP
 .B 1
-One or more verifications failed.
+Verdict \fBfail\fR \(em one or more verifications failed.
 .TP
 .B 2
-Error during verification (could not complete).
+Run-level error (bad arguments, no snapshots found, temp directory unusable, etc.).
 .SH EXAMPLES
 .TP
 Quick metadata check of local backup:
@@ -204,20 +228,21 @@ Verify a remote raw target over SSH:
 Verify specific snapshot:
 .B btrfs-backup-ng verify /mnt/backup/home --snapshot home-20260104-120000
 .TP
+Verify the ENTIRE chain (every snapshot), not just the latest:
+.B btrfs-backup-ng verify /mnt/backup/home --level stream --all
+.TP
 JSON output for automation:
 .B btrfs-backup-ng verify /mnt/backup/home --json
 .SH OUTPUT
-The verify command displays a table of results showing:
-.IP \(bu 2
-Snapshot name
-.IP \(bu 2
-Pass/Fail status
-.IP \(bu 2
-Details (parent snapshot, error messages)
-.PP
-Summary shows total passed, failed, and duration.
+The verify command displays a table of per-snapshot results with a distinct status of
+\fBPASS\fR (green), \fBUNVERIFIABLE\fR (yellow), or \fBFAIL\fR (red), followed by a summary
+with the verified/failed/unverifiable counts, the checked-of-available count, and the
+verdict.
 .PP
 With \fB--json\fR, output is a JSON object containing:
+.IP \(bu 2
+verdict: the authoritative top-level result \(em \fBpass\fR, \fBunverifiable\fR, or
+\fBfail\fR. Monitoring should gate on this rather than re-deriving from counts.
 .IP \(bu 2
 level: Verification level used
 .IP \(bu 2
@@ -225,20 +250,24 @@ location: Backup location
 .IP \(bu 2
 duration_seconds: Total verification time
 .IP \(bu 2
-summary: Counts of passed, failed, total
+summary: verified, failed, unverifiable, checked, and available counts (passed and total
+are retained as back-compat aliases: passed = not-failed, total = checked)
 .IP \(bu 2
-results: Array of individual snapshot results
+results: Array of individual snapshot results, each with a \fBstatus\fR of ok/failed/unverifiable
 .IP \(bu 2
-errors: Array of error messages
+errors: Array of run-level error messages
 .SH AUTOMATION
-For automated backup verification in scripts or cron:
+For automated backup verification in scripts or cron, gate on the \fBverdict\fR field:
 .PP
 .RS
 .nf
 #!/bin/bash
-if ! btrfs-backup-ng verify /mnt/backup/home --json > /tmp/verify.json; then
-    # Send alert on failure
-    cat /tmp/verify.json | mail -s "Backup verification failed" admin@example.com
+report=$(btrfs-backup-ng verify /mnt/backup/home --all --json)
+verdict=$(printf '%s' "$report" | jq -r .verdict)
+if [ "$verdict" = "fail" ]; then
+    printf '%s' "$report" | mail -s "Backup verification FAILED" admin@example.com
+elif [ "$verdict" = "unverifiable" ]; then
+    printf '%s' "$report" | mail -s "Backup could not be fully verified" admin@example.com
 fi
 .fi
 .RE

--- a/src/btrfs_backup_ng/cli/dispatcher.py
+++ b/src/btrfs_backup_ng/cli/dispatcher.py
@@ -782,10 +782,18 @@ Examples:
         help="Verification level (default: metadata for btrfs targets; stream, which "
         "checks the sealed sha256, for raw:// and raw+ssh:// targets)",
     )
-    verify_parser.add_argument(
+    verify_selection = verify_parser.add_mutually_exclusive_group()
+    verify_selection.add_argument(
         "--snapshot",
         metavar="NAME",
-        help="Verify specific snapshot only",
+        help="Verify only this specific snapshot",
+    )
+    verify_selection.add_argument(
+        "--all",
+        action="store_true",
+        help="Verify EVERY snapshot at the backup location. stream/full default to the "
+        "latest only (fast); --all checks the whole chain. metadata and raw targets "
+        "already check all snapshots, so --all is a no-op there.",
     )
     verify_parser.add_argument(
         "--temp-dir",

--- a/src/btrfs_backup_ng/cli/verify.py
+++ b/src/btrfs_backup_ng/cli/verify.py
@@ -137,6 +137,7 @@ def execute(args: argparse.Namespace) -> int:
                 backup_ep,
                 snapshot_name=args.snapshot,
                 on_progress=on_progress if human else None,
+                all_snapshots=getattr(args, "all", False),
             )
 
         else:  # level == VerifyLevel.FULL
@@ -155,6 +156,7 @@ def execute(args: argparse.Namespace) -> int:
                 temp_dir=Path(args.temp_dir) if args.temp_dir else None,
                 cleanup=not args.no_cleanup,
                 on_progress=on_progress if human else None,
+                all_snapshots=getattr(args, "all", False),
             )
 
     except KeyboardInterrupt:
@@ -193,10 +195,15 @@ def _display_report(report: VerifyReport, args: argparse.Namespace):
         table.add_column("Details")
 
         for result in report.results:
-            if result.passed:
-                status = "[green]PASS[/green]"
-            else:
+            # An unverifiable result is NOT a pass -- give it a distinct (yellow) status so
+            # it is never read as a clean green PASS.
+            status_key = result.details.get("status")
+            if not result.passed:
                 status = "[red]FAIL[/red]"
+            elif status_key == "unverifiable":
+                status = "[yellow]UNVERIFIABLE[/yellow]"
+            else:
+                status = "[green]PASS[/green]"
 
             details = result.message
             if not details and result.details:
@@ -221,15 +228,42 @@ def _display_report(report: VerifyReport, args: argparse.Namespace):
     console.print(f"  Location: {report.location}")
     console.print(f"  Level: {report.level.value}")
     console.print(f"  Duration: {report.duration:.1f}s")
-    console.print(
-        f"  Results: [green]{report.passed} passed[/green], "
-        f"[red]{report.failed} failed[/red] "
-        f"(of {report.total} total)"
-    )
+    # Honest counts: 'verified' is positively-confirmed (status ok), separate from
+    # 'unverifiable' (not a failure, but not confirmed) -- never lumped into a green pass.
+    # Skipped for a run that verified nothing (empty/errored) -- the errors above say why.
+    if report.results:
+        console.print(
+            f"  Results: [green]{report.verified_ok} verified[/green], "
+            f"[red]{report.failed} failed[/red], "
+            f"[yellow]{report.unverifiable} unverifiable[/yellow] "
+            f"(checked {report.total} of {report.available} snapshots)"
+        )
+    # If only a subset was checked (stream/full default to the latest), make the sampling
+    # visible and actionable -- otherwise "verified" reads as if the whole history passed.
+    # Suppressed when the user explicitly named one snapshot (--all is mutually exclusive
+    # with --snapshot, so the hint would be unfollowable) or when nothing was checked.
+    if (
+        report.results
+        and report.available > report.total
+        and not report.errors
+        and not getattr(args, "snapshot", None)
+    ):
+        console.print(
+            f"  [dim]Only the latest {report.total} of {report.available} checked -- "
+            f"pass --all to verify every snapshot.[/dim]"
+        )
 
-    if report.failed == 0 and not report.errors:
-        console.print("\n[green bold]✓ All verifications passed[/green bold]")
-    else:
+    verdict = report.verdict
+    if verdict == "pass":
+        console.print(
+            f"\n[green bold]✓ All {report.total} checked snapshot(s) verified[/green bold]"
+        )
+    elif verdict == "unverifiable":
+        console.print(
+            f"\n[yellow bold]⚠ {report.verified_ok} verified, {report.unverifiable} "
+            f"could not be verified (no failures)[/yellow bold]"
+        )
+    else:  # fail
         console.print("\n[red bold]✗ Verification found issues[/red bold]")
 
 
@@ -240,15 +274,30 @@ def _display_json(report: VerifyReport):
     data = {
         "level": report.level.value,
         "location": report.location,
+        # Authoritative top-level tri-state for monitoring: gate on this instead of
+        # re-deriving from counts (a naive summary.failed==0 treats an empty/errored run as
+        # success). 'fail' = a real failure or run error; 'unverifiable' = no failures but
+        # something could not be confirmed; 'pass' = every checked snapshot verified.
+        "verdict": report.verdict,
         "duration_seconds": report.duration,
         "summary": {
-            "passed": report.passed,
+            "verified": report.verified_ok,
             "failed": report.failed,
-            "total": report.total,
+            "unverifiable": report.unverifiable,
+            "passed": report.passed,  # back-compat: not-failed (verified + unverifiable)
+            "checked": report.total,
+            "available": report.available,
+            "total": report.total,  # back-compat alias for checked
         },
         "results": [
             {
                 "snapshot": r.snapshot_name,
+                # Every verify path sets details["status"]; the fallback NEVER guesses "ok"
+                # for a status-less passed result (that would falsely claim a snapshot was
+                # verified) -- an unset status degrades to the honest "unverifiable".
+                "status": r.details.get(
+                    "status", "failed" if not r.passed else "unverifiable"
+                ),
                 "passed": r.passed,
                 "message": r.message,
                 "duration_seconds": r.duration_seconds,

--- a/src/btrfs_backup_ng/core/verify.py
+++ b/src/btrfs_backup_ng/core/verify.py
@@ -117,9 +117,15 @@ class VerifyReport:
     completed_at: float = 0.0
     results: list[VerifyResult] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
+    # Total snapshots present at the backup location -- may exceed len(results) when only
+    # a subset was checked (stream/full default to the latest only). Lets the report say
+    # honestly "checked N of M" instead of implying the whole history was verified.
+    available: int = 0
 
     @property
     def passed(self) -> int:
+        """Results that are not failures (positively verified OR unverifiable). Kept for
+        back-compat; prefer ``verified_ok`` for 'confirmed good'."""
         return sum(1 for r in self.results if r.passed)
 
     @property
@@ -127,8 +133,33 @@ class VerifyReport:
         return sum(1 for r in self.results if not r.passed)
 
     @property
+    def verified_ok(self) -> int:
+        """Results POSITIVELY confirmed good (status == 'ok') -- not merely 'not failed'
+        (which would also count the unverifiable)."""
+        return sum(1 for r in self.results if r.details.get("status") == "ok")
+
+    @property
+    def unverifiable(self) -> int:
+        """Results that could not be confirmed (status == 'unverifiable'): not a failure,
+        but not a clean pass -- surfaced separately so it is never read as verified."""
+        return sum(1 for r in self.results if r.details.get("status") == "unverifiable")
+
+    @property
     def total(self) -> int:
+        """Number of snapshots actually checked this run (== len(results))."""
         return len(self.results)
+
+    @property
+    def verdict(self) -> str:
+        """Authoritative tri-state for monitoring: 'fail' if any result FAILED or a
+        run-level error occurred; else 'unverifiable' if any checked snapshot could not be
+        confirmed (or nothing was checked); else 'pass' (every checked snapshot positively
+        verified). Exit codes: fail->1 (or 2 on a run error), unverifiable/pass->0."""
+        if self.failed > 0 or self.errors:
+            return "fail"
+        if self.unverifiable > 0 or self.total == 0:
+            return "unverifiable"
+        return "pass"
 
     @property
     def duration(self) -> float:
@@ -187,6 +218,7 @@ def verify_metadata(
             return report
 
         logger.info("Found %d snapshot(s) at backup location", len(backup_snapshots))
+        report.available = len(backup_snapshots)
 
         # Filter to specific snapshot if requested
         if snapshot_name:
@@ -243,6 +275,15 @@ def verify_metadata(
                     )
                     result.details["parent_missing"] = True
 
+            # Unified per-result verdict (ok/failed/unverifiable) -- the single status the
+            # report/summary/JSON read uniformly across all verify levels.
+            if not result.passed:
+                result.details["status"] = "failed"
+            elif structure.status == "unverifiable":
+                result.details["status"] = "unverifiable"
+            else:
+                result.details["status"] = "ok"
+
             result.duration_seconds = time.monotonic() - start
             report.results.append(result)
 
@@ -281,6 +322,7 @@ def verify_stream(
     backup_endpoint,
     snapshot_name: str | None = None,
     on_progress: Callable[[int, int, str], None] | None = None,
+    all_snapshots: bool = False,
 ) -> VerifyReport:
     """Verify btrfs send stream can be generated.
 
@@ -290,8 +332,9 @@ def verify_stream(
 
     Args:
         backup_endpoint: Endpoint where backups are stored
-        snapshot_name: Specific snapshot to verify (None = latest only)
+        snapshot_name: Specific snapshot to verify (None = latest only unless all_snapshots)
         on_progress: Progress callback
+        all_snapshots: Verify EVERY snapshot (not just the latest) -- the --all flag
 
     Returns:
         VerifyReport with results
@@ -307,6 +350,8 @@ def verify_stream(
             report.completed_at = time.time()
             return report
 
+        report.available = len(backup_snapshots)
+
         # Filter or select snapshots
         if snapshot_name:
             to_verify = [s for s in backup_snapshots if s.get_name() == snapshot_name]
@@ -314,8 +359,11 @@ def verify_stream(
                 report.errors.append(f"Snapshot '{snapshot_name}' not found")
                 report.completed_at = time.time()
                 return report
+        elif all_snapshots:
+            to_verify = list(backup_snapshots)
         else:
-            # Default: verify latest snapshot only (stream check is slower)
+            # Default: verify latest snapshot only (stream check is slower). The summary
+            # says "checked 1 of N" so the sampling is never invisible.
             to_verify = [backup_snapshots[-1]]
 
         for i, snap in enumerate(to_verify, 1):
@@ -340,12 +388,14 @@ def verify_stream(
                 # local target, ON THE REMOTE for an ssh:// target), raising on failure.
                 backup_endpoint.test_send_stream(snap, parent)
                 result.message = "Stream verified successfully"
+                result.details["status"] = "ok"
                 result.details["incremental"] = parent is not None
                 if parent:
                     result.details["parent"] = parent.get_name()
 
             except Exception as e:
                 result.passed = False
+                result.details["status"] = "failed"
                 result.message = f"Stream verification failed: {e}"
                 logger.error("Stream verify failed for %s: %s", name, e)
 
@@ -366,6 +416,7 @@ def verify_full(
     temp_dir: Path | None = None,
     cleanup: bool = True,
     on_progress: Callable[[int, int, str], None] | None = None,
+    all_snapshots: bool = False,
 ) -> VerifyReport:
     """Perform full restore verification.
 
@@ -455,6 +506,8 @@ def verify_full(
             report.completed_at = time.time()
             return report
 
+        report.available = len(backup_snapshots)
+
         # Filter or select snapshots
         if snapshot_name:
             to_verify = [s for s in backup_snapshots if s.get_name() == snapshot_name]
@@ -462,8 +515,11 @@ def verify_full(
                 report.errors.append(f"Snapshot '{snapshot_name}' not found")
                 report.completed_at = time.time()
                 return report
+        elif all_snapshots:
+            to_verify = list(backup_snapshots)
         else:
-            # Default: verify latest snapshot only
+            # Default: verify latest snapshot only (a full restore is slow). The summary
+            # says "checked 1 of N" so the sampling is never invisible.
             to_verify = [backup_snapshots[-1]]
 
         # Create local endpoint for receiving
@@ -617,6 +673,8 @@ def verify_raw_checksums(
             report.completed_at = time.time()
             return report
 
+        report.available = len(backup_snapshots)
+
         if snapshot_name:
             backup_snapshots = [
                 s for s in backup_snapshots if s.get_name() == snapshot_name
@@ -646,6 +704,13 @@ def verify_raw_checksums(
             result.details["checksum_recorded"] = verdict.recorded
             result.details["checksum_computed"] = verdict.computed
             result.details["checksum_algorithm"] = verdict.algorithm
+            # Map the checksum taxonomy onto the unified per-result status the report reads.
+            result.details["status"] = {
+                "ok": "ok",
+                "corrupt": "failed",
+                "error": "failed",
+                "unverifiable": "unverifiable",
+            }.get(verdict.status, "failed")
             if verdict.remote_untrusted:
                 # A raw+ssh digest is computed by the untrusted remote: consistency, not
                 # authenticity. Surface it so an operator does not read `ok` as tamper-proof.

--- a/tests/test_cli_verify.py
+++ b/tests/test_cli_verify.py
@@ -19,20 +19,28 @@ def _make_result(
     details=None,
     duration=0.0,
     level=VerifyLevel.METADATA,
+    status=None,
 ):
-    """Helper to create VerifyResult with required fields."""
+    """Helper to create VerifyResult with required fields. Sets the unified
+    details['status'] (ok when passed, failed otherwise) unless overridden."""
+    details = dict(details or {})
+    details.setdefault("status", status or ("ok" if passed else "failed"))
     return VerifyResult(
         snapshot_name=name,
         level=level,
         passed=passed,
         message=message,
         duration_seconds=duration,
-        details=details or {},
+        details=details,
     )
 
 
 def _make_report(
-    level=VerifyLevel.METADATA, location="/backup", results=None, errors=None
+    level=VerifyLevel.METADATA,
+    location="/backup",
+    results=None,
+    errors=None,
+    available=None,
 ):
     """Helper to create VerifyReport with results."""
     report = VerifyReport(level=level, location=location)
@@ -40,6 +48,7 @@ def _make_report(
         report.results.extend(results)
     if errors:
         report.errors.extend(errors)
+    report.available = available if available is not None else len(report.results)
     return report
 
 
@@ -424,9 +433,10 @@ class TestDisplayReport:
         assert "snap-1" in captured.out
         assert "snap-2" in captured.out
         assert "PASS" in captured.out
-        assert "2 passed" in captured.out
+        assert "2 verified" in captured.out
         assert "0 failed" in captured.out
-        assert "All verifications passed" in captured.out
+        assert "checked 2 of 2 snapshots" in captured.out
+        assert "All 2 checked snapshot(s) verified" in captured.out
 
     def test_display_failing_results(self, capsys):
         """Test displaying failing verification results."""
@@ -451,7 +461,7 @@ class TestDisplayReport:
         assert "PASS" in captured.out
         assert "FAIL" in captured.out
         assert "Stream corrupted" in captured.out
-        assert "1 passed" in captured.out
+        assert "1 verified" in captured.out
         assert "1 failed" in captured.out
         assert "found issues" in captured.out
 
@@ -915,3 +925,140 @@ class TestGeneralVerifyAgainstRawTarget:
         assert captured.get("ssh_key") == "/k/id"
         assert captured.get("ssh_auth_sock") == "/run/agent.sock"
         assert "path" not in captured  # a raw scheme must not get a resolved local path
+
+
+class TestR8eHonestOutput:
+    """R8e: unverifiable is visually distinct (not green PASS), the summary is honest about
+    'checked N of M' with a --all hint, and the JSON carries a top-level tri-state verdict."""
+
+    def test_unverifiable_is_distinct_from_pass(self, capsys):
+        """A report with ok + unverifiable + failed renders three DISTINCT statuses, and
+        the conclusion is NOT 'All verified' (unverifiable is not a clean pass). Mutation
+        guard: rendering unverifiable as green PASS / counting it as verified breaks this."""
+        report = _make_report(
+            level=VerifyLevel.FULL,
+            results=[
+                _make_result("ok-snap", passed=True, status="ok", message="verified"),
+                _make_result(
+                    "unv-snap", passed=True, status="unverifiable", message="no room"
+                ),
+                _make_result(
+                    "bad-snap", passed=False, status="failed", message="corrupt"
+                ),
+            ],
+        )
+        args = argparse.Namespace(json=False)
+        _display_report(report, args)
+
+        out = capsys.readouterr().out
+        assert "UNVERIFIABLE" in out
+        assert "1 verified" in out and "1 failed" in out and "1 unverifiable" in out
+        assert "found issues" in out  # a failure present -> verdict fail
+        assert "All" not in out.split("Summary")[-1] or "verified" in out
+
+    def test_summary_states_checked_of_available_with_all_hint(self, capsys):
+        """When only a subset was checked (available > checked), the summary says so and
+        points at --all. Mutation guard: dropping report.available or the hint hides the
+        sampling."""
+        report = _make_report(
+            level=VerifyLevel.STREAM,
+            results=[_make_result("latest", passed=True, status="ok")],
+            available=7,
+        )
+        args = argparse.Namespace(json=False)
+        _display_report(report, args)
+
+        out = capsys.readouterr().out
+        assert "checked 1 of 7 snapshots" in out
+        assert "--all" in out
+
+    def test_json_verdict_pass(self, capsys):
+        import json
+
+        report = _make_report(
+            results=[_make_result("a", passed=True, status="ok")], available=1
+        )
+        _display_json(report)
+        data = json.loads(capsys.readouterr().out)
+        assert data["verdict"] == "pass"
+        assert data["summary"]["verified"] == 1
+        assert data["summary"]["available"] == 1
+        assert data["results"][0]["status"] == "ok"
+
+    def test_json_verdict_unverifiable(self, capsys):
+        import json
+
+        report = _make_report(
+            results=[_make_result("a", passed=True, status="unverifiable")]
+        )
+        _display_json(report)
+        data = json.loads(capsys.readouterr().out)
+        assert data["verdict"] == "unverifiable"
+        assert data["summary"]["unverifiable"] == 1
+
+    def test_json_verdict_fail_on_empty_errored_run(self, capsys):
+        """The audit's exact false-positive: an empty/errored run must NOT read as success.
+        verdict=='fail' even though summary.failed==0. Mutation guard: a naive
+        success=failed==0 would say pass here."""
+        import json
+
+        report = _make_report(results=[], errors=["No snapshots found"])
+        _display_json(report)
+        data = json.loads(capsys.readouterr().out)
+        assert data["verdict"] == "fail"
+        assert data["summary"]["failed"] == 0  # the trap the verdict avoids
+        assert data["errors"] == ["No snapshots found"]
+
+
+class TestR8eReviewFixes:
+    """Guards for the R8e adversarial-review fixes."""
+
+    def test_all_hint_suppressed_when_snapshot_named(self, capsys):
+        """--snapshot is mutually exclusive with --all, so the 'pass --all' hint must NOT
+        appear when the user named one snapshot (it would be unfollowable). Mutation guard:
+        dropping the args.snapshot check prints the misleading hint."""
+        report = _make_report(
+            level=VerifyLevel.STREAM,
+            results=[_make_result("snap-3", passed=True, status="ok")],
+            available=9,
+        )
+        args = argparse.Namespace(json=False, snapshot="snap-3")
+        _display_report(report, args)
+        out = capsys.readouterr().out
+        assert "--all" not in out
+
+    def test_all_hint_shown_without_snapshot(self, capsys):
+        """Without --snapshot, a subset check DOES show the --all hint (control for above)."""
+        report = _make_report(
+            level=VerifyLevel.STREAM,
+            results=[_make_result("latest", passed=True, status="ok")],
+            available=9,
+        )
+        args = argparse.Namespace(json=False, snapshot=None)
+        _display_report(report, args)
+        assert "--all" in capsys.readouterr().out
+
+    def test_empty_errored_run_has_no_misleading_results_line(self, capsys):
+        """An empty/errored run shows the error, NOT a 'checked 0 of 0' Results line that
+        reads like 'no backups exist'."""
+        report = _make_report(errors=["Verification failed: connection refused"])
+        args = argparse.Namespace(json=False)
+        _display_report(report, args)
+        out = capsys.readouterr().out
+        assert "connection refused" in out
+        assert "checked 0 of 0" not in out
+
+    def test_json_status_fallback_never_falsely_ok(self, capsys):
+        """A passed result with NO details['status'] must NOT be reported 'ok' in JSON
+        (that would falsely claim it was verified) -- it degrades to 'unverifiable'.
+        Mutation guard: the old 'ok' if passed fallback would report 'ok' here."""
+        import json
+
+        # A result deliberately missing details['status'] (simulates a future path drift).
+        r = VerifyResult("x", VerifyLevel.METADATA, passed=True, details={})
+        report = _make_report(results=[r])
+        report.results[0].details.pop("status", None)  # ensure absent
+        _display_json(report)
+        data = json.loads(capsys.readouterr().out)
+        assert data["results"][0]["status"] != "ok"
+        assert data["results"][0]["status"] == "unverifiable"

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -215,6 +215,9 @@ class TestVerifyMetadata:
         assert report.total == 3
         assert report.passed == 3
         assert report.failed == 0
+        # R8e: metadata sets the unified status; all-ok structure -> verdict pass.
+        assert all(r.details["status"] == "ok" for r in report.results)
+        assert report.verdict == "pass" and report.available == 3
 
     def test_specific_snapshot(self):
         """Test verification of specific snapshot only."""
@@ -511,6 +514,79 @@ class TestVerifyStream:
 
         assert len(report.errors) > 0
         assert "Connection failed" in report.errors[0]
+
+
+class TestVerifyReportVerdictAndCounts:
+    """R8e: the report's tri-state verdict + honest counts (verified/failed/unverifiable,
+    checked-of-available) are the single source of truth for the display and JSON."""
+
+    def _report(self, statuses, errors=None, available=None):
+        rep = VerifyReport(
+            level=VerifyLevel.STREAM, location="/b", errors=list(errors or [])
+        )
+        for i, s in enumerate(statuses):
+            rep.results.append(
+                VerifyResult(
+                    f"snap-{i}",
+                    VerifyLevel.STREAM,
+                    passed=(s != "failed"),
+                    details={"status": s},
+                )
+            )
+        rep.available = available if available is not None else len(statuses)
+        return rep
+
+    def test_verdict_pass_when_all_ok(self):
+        r = self._report(["ok", "ok"])
+        assert r.verdict == "pass"
+        assert r.verified_ok == 2 and r.failed == 0 and r.unverifiable == 0
+
+    def test_verdict_unverifiable_when_some_unverifiable_no_fail(self):
+        """Any unverifiable (and no failure) -> verdict 'unverifiable', NOT 'pass' -- an
+        unverifiable result is never counted as verified. Mutation guard: counting
+        unverifiable as ok would flip the verdict to pass."""
+        r = self._report(["ok", "unverifiable"])
+        assert r.verdict == "unverifiable"
+        assert r.verified_ok == 1 and r.unverifiable == 1
+
+    def test_verdict_fail_on_any_failure(self):
+        r = self._report(["ok", "failed"])
+        assert r.verdict == "fail" and r.failed == 1
+
+    def test_verdict_fail_on_run_error(self):
+        """An empty/errored run is 'fail', never a naive success (the audit's exact
+        false-positive: summary.failed==0 on an empty run)."""
+        r = self._report([], errors=["No snapshots found"])
+        assert r.verdict == "fail" and r.total == 0
+
+
+class TestVerifyStreamSelection:
+    """R8e: latest-only default vs --all, and report.available reflects the whole set."""
+
+    def _endpoint(self, n):
+        snaps = make_snapshots(
+            [(f"snap-{i}", f"2026010{i}-120000") for i in range(1, n + 1)]
+        )
+        ep = MagicMock()
+        ep.list_snapshots.return_value = snaps
+        ep.config = {"path": "/backup"}
+        return ep
+
+    def test_latest_only_by_default_but_available_is_full(self):
+        """Default checks ONLY the latest, but records how many exist so the summary can
+        say 'checked 1 of N'. Mutation guard: dropping report.available loses the honesty."""
+        report = verify_stream(self._endpoint(5))
+        assert report.total == 1
+        assert report.available == 5
+        assert report.results[0].snapshot_name == "snap-5"  # the latest
+        assert report.results[0].details["status"] == "ok"
+
+    def test_all_snapshots_checks_every_one(self):
+        """--all verifies every snapshot. Mutation guard: ignoring all_snapshots leaves
+        total==1."""
+        report = verify_stream(self._endpoint(5), all_snapshots=True)
+        assert report.total == 5 and report.available == 5
+        assert all(r.details["status"] == "ok" for r in report.results)
 
 
 class TestVerifyFull:
@@ -1329,6 +1405,8 @@ def test_raw_checksums_error_status_fails_with_message():
     assert r.passed is False
     assert "could not be read" in r.message
     assert report.failed == 1
+    # R8e: the checksum taxonomy maps onto the unified status (error/corrupt -> failed).
+    assert r.details["status"] == "failed"
 
 
 def test_raw_checksums_unverifiable_is_not_a_failure():
@@ -1339,6 +1417,10 @@ def test_raw_checksums_unverifiable_is_not_a_failure():
     assert r.passed is True
     assert "Unverifiable" in r.message
     assert report.failed == 0
+    # R8e: unverifiable maps to the unified 'unverifiable' status (not 'ok'), so the report
+    # verdict is 'unverifiable', never a clean pass.
+    assert r.details["status"] == "unverifiable"
+    assert report.verdict == "unverifiable"
 
 
 def test_raw_checksums_remote_ok_carries_trust_caveat():


### PR DESCRIPTION
## R8e — honest verification output + chain-wide `--all` (the final R8 root)

Closes the R8 verification-hardening series. With the engines now rock-solid (R8a–d), R8e fixes **how results are communicated and selected**:

1. **"Verified 1 of N" was invisible** — `stream`/`full` default to the latest snapshot only, but the summary read as if the whole history passed.
2. **Unverifiable masqueraded as PASS** — an unverifiable result (not a failure, but not confirmed) rendered green "PASS" and counted as passed; an all-unverifiable run printed "✓ All verifications passed."
3. **No top-level JSON verdict** — a monitor gating on `summary.failed==0` treated an empty/errored run (failed==0, total==0) as success.

### The enabling seam
A **unified per-result `details["status"]`** (`ok`/`failed`/`unverifiable`) across all four verify functions — read uniformly by the report, summary, and JSON.

### Deliverables
- **`VerifyReport`**: `available` (total at location), `verified_ok`/`unverifiable` counts, and an authoritative tri-state **`verdict`** (`pass`/`fail`/`unverifiable`).
- **Human output**: distinct yellow **UNVERIFIABLE** status; summary *"X verified, Y failed, Z unverifiable (checked C of A snapshots)"*; a **`--all` hint** when a subset was checked (suppressed when `--snapshot` is named); a verdict-based conclusion.
- **JSON**: top-level **`verdict`** for monitoring, enriched summary (verified/failed/unverifiable/checked/available; `passed`/`total` kept as back-compat aliases), per-result `status`. An empty/errored run is `verdict: fail`. Exit codes unchanged (fail→1, run error→2, else 0).
- **`--all`** (mutually exclusive with `--snapshot`) → verify every snapshot at stream/full level (metadata/raw already do) — the whole-chain-history validation deferred from R8d's A-vs-B.

### Verification
- **Tier1 2547 passed**; ruff 0.15.22 + full mypy clean. No tier2/hardware needed (output/selection logic; the engines are already hardware-proven).
- **Mutation-verified**: the tri-state verdict (count unverifiable as ok → verdict flips) and `--all` (ignore the flag → total stays 1).
- **Real-CLI proven**: `verdict=pass`/`fail`, honest "checked N of M" counts, `--all` (all snapshots), `--snapshot` (1 of N, no misleading hint).
- **Adversarial 3-lens review** (each finding verified): fixed a high (JSON status fallback never guesses "ok" for a status-less passed result → degrades to unverifiable), a medium (suppress the `--all` hint under `--snapshot`), and a low (no "checked 0 of 0" on an empty run) — all mutation-guarded.
- Manpage updated: verdict/counts section, `--all`, JSON `verdict`, and a jq-based monitoring example.

### Back-compat
`VerifyReport.passed`/`total` and the JSON `summary.passed`/`total` are retained (passed = not-failed; total = checked) so existing consumers keep working; the new fields are additive.

No AI/tool attribution.