### PR TITLE
feat(persistence): atomic state, manifest & lock writes via one shared primitive (R7)

### DIFF
--- a/src/btrfs_backup_ng/__util__.py
+++ b/src/btrfs_backup_ng/__util__.py
@@ -2,6 +2,7 @@
 Common utility code shared between modules.
 """
 
+import contextlib
 import functools
 import json
 import os
@@ -26,6 +27,7 @@ __all__ = [
     "get_mount_info",
     "read_locks",
     "write_locks",
+    "atomic_write_bytes",
     "delete_subvolume",
     "DATE_FORMAT",
     "MOUNTS_FILE",
@@ -457,6 +459,68 @@ def get_mount_info(path):
     else:
         logger.debug("  -> No mount info found")
     return best_match
+
+
+def atomic_write_bytes(path, data, *, mode=0o600, fsync=True):
+    """Crash-atomically replace ``path`` with ``data``.
+
+    Writes a sibling temp file (in the SAME directory, so ``os.replace`` is a
+    same-filesystem rename and can never fail with ``EXDEV``), fsyncs it, atomically
+    renames it over the target, then fsyncs the parent directory so the rename itself
+    survives a power loss. A crash at any point leaves either the OLD complete file or
+    the NEW complete file -- never a half-written / truncated one. This is the single
+    atomic-write primitive shared by lock files, raw ``.meta`` sidecars, operation
+    state, and transfer manifests (R7): a torn state/manifest would break resume and a
+    torn lock file would be misread as "no locks" and let retention prune a locked
+    snapshot.
+
+    The temp is opened ``O_CREAT|O_EXCL|O_NOFOLLOW`` at ``mode``: ``O_NOFOLLOW`` refuses
+    a symlink planted at the temp path (defense when writing into a directory that may
+    hold untrusted content, e.g. a raw target walked as root), ``O_EXCL`` refuses a
+    pre-existing temp, and any stale temp left by a prior crash is unlinked first (the
+    temp name is a fixed ``<name>.tmp`` sibling, so it is reclaimed rather than left to
+    accumulate). Callers writing the SAME target concurrently must serialize themselves
+    (the lock writer does, via its FileLock); the atomic replace still guarantees no
+    torn file even if such a race occurs.
+
+    ``data`` may be ``str`` (encoded UTF-8) or ``bytes``. Raises ``OSError`` on any
+    failure, after removing the temp; the target file is left untouched. Set
+    ``fsync=False`` only where durability is not required (e.g. throwaway test dirs) --
+    the atomic replace still holds, only the power-loss durability guarantee is dropped.
+    """
+    path = Path(path)
+    if isinstance(data, str):
+        data = data.encode("utf-8")
+    tmp = path.with_name(path.name + ".tmp")
+    try:
+        # Clear a leftover temp from a prior crash so the O_EXCL create below succeeds.
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        fd = os.open(
+            str(tmp),
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            mode,
+        )
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+            f.flush()
+            if fsync:
+                os.fsync(f.fileno())
+        os.replace(str(tmp), str(path))
+        # fsync the parent directory: the content fsync above does not guarantee the new
+        # directory entry (the rename) survives a crash, and a lost rename would silently
+        # revert to the old file.
+        if fsync:
+            with contextlib.suppress(OSError):
+                dfd = os.open(str(path.parent), os.O_RDONLY)
+                try:
+                    os.fsync(dfd)
+                finally:
+                    os.close(dfd)
+    except OSError:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
 
 
 def read_locks(s):

--- a/src/btrfs_backup_ng/cli/restore.py
+++ b/src/btrfs_backup_ng/cli/restore.py
@@ -800,8 +800,15 @@ def _execute_unlock(args: argparse.Namespace, lock_id: str) -> int:
 
     # Write updated locks
     try:
-        with open(lock_file_path, "w", encoding="utf-8") as f:
-            f.write(__util__.write_locks(new_locks))  # type: ignore[attr-defined]
+        # Atomic replace via the shared primitive (R7): the previous plain open("w")
+        # bypassed the endpoint's crash-safe lock writer, so a crash mid-write could
+        # leave a torn lock file -- which is then misread as "no locks" and lets
+        # retention prune a snapshot that is still locked.
+        __util__.atomic_write_bytes(  # type: ignore[attr-defined]
+            lock_file_path,
+            __util__.write_locks(new_locks),  # type: ignore[attr-defined]
+            mode=0o600,
+        )
     except Exception as e:
         logger.error("Could not write lock file: %s", e)
         return 1

--- a/src/btrfs_backup_ng/core/chunked_transfer.py
+++ b/src/btrfs_backup_ng/core/chunked_transfer.py
@@ -57,6 +57,7 @@ from enum import Enum
 from pathlib import Path
 from typing import IO, Any, Callable, Iterator, Optional
 
+from .. import __util__
 from .errors import (
     ChunkChecksumError,
     PermanentCorruptedError,
@@ -252,10 +253,21 @@ class TransferManifest:
         return manifest
 
     def save(self, path: Path) -> None:
-        """Save manifest to file."""
+        """Save manifest to file.
+
+        Crash-atomic + best-effort (R7): written via the shared atomic-write primitive
+        (temp -> fsync -> os.replace), so a crash mid-write can never leave a torn
+        manifest that ``load()`` would reject -- which would force a full retransmit of
+        an already-partial (potentially GB-scale) chunked transfer. On an I/O failure the
+        previous complete manifest is left intact and we log + continue; the on-disk
+        manifest is then at worst one state-transition stale, so resume merely redoes one
+        idempotent, checksum-guarded chunk."""
         self.updated_at = datetime.now().isoformat()
-        with open(path, "w") as f:
-            json.dump(self.to_dict(), f, indent=2)
+        payload = json.dumps(self.to_dict(), indent=2)
+        try:
+            __util__.atomic_write_bytes(path, payload)  # type: ignore[attr-defined]
+        except OSError as e:
+            logger.warning("Failed to persist transfer manifest to %s: %s", path, e)
 
     @classmethod
     def load(cls, path: Path) -> "TransferManifest":

--- a/src/btrfs_backup_ng/core/doctor.py
+++ b/src/btrfs_backup_ng/core/doctor.py
@@ -1106,11 +1106,11 @@ class Doctor:
         self, lock_file: Path, snapshot_name: str, lock_id: str
     ) -> bool:
         """Remove a stale lock."""
-        from ..__util__ import read_locks, write_locks
+        from btrfs_backup_ng import __util__
 
         try:
             lock_content = lock_file.read_text()
-            locks = read_locks(lock_content)
+            locks = __util__.read_locks(lock_content)
             if snapshot_name in locks:
                 snapshot_locks = locks[snapshot_name].get("locks", [])
                 if lock_id in snapshot_locks:
@@ -1121,7 +1121,12 @@ class Doctor:
                         del locks[snapshot_name]
                     else:
                         locks[snapshot_name]["locks"] = snapshot_locks
-                    lock_file.write_text(write_locks(locks))
+                    # Atomic replace via the shared primitive (R7): a plain write_text
+                    # here could leave a torn lock file on a crash, which read_locks then
+                    # misreads as "no locks" -> retention prunes a still-locked snapshot.
+                    __util__.atomic_write_bytes(  # type: ignore[attr-defined]
+                        lock_file, __util__.write_locks(locks), mode=0o600
+                    )
                     logger.info(
                         "Removed stale lock: %s from %s", lock_id, snapshot_name
                     )

--- a/src/btrfs_backup_ng/core/state.py
+++ b/src/btrfs_backup_ng/core/state.py
@@ -43,6 +43,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Optional
 
+from .. import __util__
+
 logger = logging.getLogger(__name__)
 
 # Default state directory
@@ -292,11 +294,22 @@ class OperationRecord:
         return record
 
     def save(self, path: Path) -> None:
-        """Save operation record to file."""
+        """Save operation record to file.
+
+        Crash-atomic + best-effort (R7): written via the shared atomic-write primitive
+        (temp -> fsync -> os.replace), so a crash mid-write can never leave a torn JSON
+        file that ``load()`` would choke on and thereby kill resume -- a reader always
+        sees the old complete record or the new one. On an I/O failure the previous
+        complete record is left intact and we log + continue: the state file is a resume
+        optimization, never the backup itself, so a save failure must not fail a good
+        operation (the R1/R2 false-negative-safety principle)."""
         self.updated_at = datetime.now().isoformat()
         path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "w") as f:
-            json.dump(self.to_dict(), f, indent=2)
+        payload = json.dumps(self.to_dict(), indent=2)
+        try:
+            __util__.atomic_write_bytes(path, payload)  # type: ignore[attr-defined]
+        except OSError as e:
+            logger.warning("Failed to persist operation state to %s: %s", path, e)
 
     @classmethod
     def load(cls, path: Path) -> "OperationRecord":
@@ -482,6 +495,24 @@ class OperationManager:
 
         if src_path.exists():
             operation.save(dst_path)
+            # save() is best-effort (swallows OSError), so verify the archive copy is
+            # actually written AND loadable before removing the source record. An
+            # unconditional unlink here would destroy a completed operation's record if
+            # the archive write had failed (ENOSPC, archive-dir I/O error) -- the R1
+            # principle: never delete a good record on an inconclusive write.
+            try:
+                archived_ok = (
+                    dst_path.exists() and OperationRecord.load(dst_path) is not None
+                )
+            except Exception:
+                archived_ok = False
+            if not archived_ok:
+                logger.error(
+                    "Archive write for operation %s failed or is unreadable; "
+                    "keeping the source record",
+                    operation_id,
+                )
+                return False
             src_path.unlink()
             logger.info("Archived operation %s", operation_id)
             return True

--- a/src/btrfs_backup_ng/endpoint/common.py
+++ b/src/btrfs_backup_ng/endpoint/common.py
@@ -1087,38 +1087,14 @@ class Endpoint:
     def _write_locks(self, lock_dict: Dict[str, Any]) -> None:
         path = self._get_lock_file_path()
         data = __util__.write_locks(lock_dict)
-        tmp = path.with_name(path.name + ".tmp")
         try:
             logger.debug("Writing lock file: %s", path)
-            # Atomic: write a temp file, fsync it, then os.replace over the target, so a
-            # crash mid-write can never leave a half-written / corrupt lock file (which
-            # would then be misread as "no locks" and let retention prune a locked
-            # snapshot). O_NOFOLLOW|O_EXCL refuse a planted symlink or a stale temp at what
-            # is often a root-owned path; a leftover temp from a prior crash is cleared
-            # first.
-            with contextlib.suppress(OSError):
-                os.unlink(tmp)
-            fd = os.open(
-                str(tmp),
-                os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
-                0o600,
-            )
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(data)
-                f.flush()
-                os.fsync(f.fileno())
-            os.replace(str(tmp), str(path))
-            # fsync the parent directory so the rename itself is durable: the content
-            # fsync above does not guarantee the new directory entry survives a crash, and
-            # a lost rename would silently drop the locks R3 exists to persist.
-            with contextlib.suppress(OSError):
-                dfd = os.open(str(path.parent), os.O_RDONLY)
-                try:
-                    os.fsync(dfd)
-                finally:
-                    os.close(dfd)
+            # Atomic replace via the shared primitive (R7): a crash mid-write can never
+            # leave a half-written / corrupt lock file (which would then be misread as
+            # "no locks" and let retention prune a locked snapshot). The primitive does
+            # the temp -> fsync -> os.replace -> parent-dir fsync dance with
+            # O_EXCL|O_NOFOLLOW at 0600.
+            __util__.atomic_write_bytes(path, data, mode=0o600)
         except OSError as e:
-            with contextlib.suppress(OSError):
-                os.unlink(tmp)
             logger.error("Error on writing lock file %s: %s", path, e)
             raise __util__.AbortError

--- a/src/btrfs_backup_ng/endpoint/raw_metadata.py
+++ b/src/btrfs_backup_ng/endpoint/raw_metadata.py
@@ -15,7 +15,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from btrfs_backup_ng import __version__
+from btrfs_backup_ng import __util__, __version__
 from btrfs_backup_ng.__logger__ import logger
 
 # Compression tool configurations
@@ -340,26 +340,18 @@ class RawSnapshot:
         return json.dumps(self.to_dict(), indent=2).encode("utf-8")
 
     def save_metadata(self) -> None:
-        """Write the sidecar atomically (temp -> fsync -> rename -> dir fsync) at
-        mode 0600, so a crash never leaves a partial/half-written .meta and the
-        metadata dossier is not world-readable.
+        """Write the sidecar atomically at mode 0600 via the shared atomic-write
+        primitive (temp -> fsync -> os.replace -> dir fsync; R7), so a crash never
+        leaves a partial/half-written .meta and the metadata dossier is not
+        world-readable.
 
-        O_NOFOLLOW on the temp open refuses to follow a symlink at the ``.meta.tmp``
-        path: writing while walking an untrusted directory (``raw backfill-metadata``
-        over a target with foreign/legacy content, typically as root) must not let a
-        pre-planted ``<name>.meta.tmp`` symlink redirect the O_CREAT|O_TRUNC write to
-        an arbitrary file."""
-        meta = self.metadata_path
-        tmp = meta.with_name(meta.name + ".tmp")
-        payload = self.serialize()
-        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
-        try:
-            os.write(fd, payload)
-            os.fsync(fd)
-        finally:
-            os.close(fd)
-        os.replace(tmp, meta)
-        _fsync_directory(meta.parent)
+        The primitive opens the temp ``O_EXCL|O_NOFOLLOW``: writing while walking an
+        untrusted directory (``raw backfill-metadata`` over a target with foreign/legacy
+        content, typically as root) must not let a pre-planted ``<name>.meta.tmp``
+        symlink redirect the write to an arbitrary file."""
+        __util__.atomic_write_bytes(  # type: ignore[attr-defined]
+            self.metadata_path, self.serialize(), mode=0o600
+        )
 
     @classmethod
     def from_dict(cls, data: dict[str, Any], stream_path: Path) -> RawSnapshot:

--- a/src/btrfs_backup_ng/snapper/metadata.py
+++ b/src/btrfs_backup_ng/snapper/metadata.py
@@ -261,6 +261,12 @@ def save_backup_metadata(path: Path | str, metadata: BackupMetadata) -> None:
     """
     path = Path(path)
     data = asdict(metadata)
+    # NOTE (R7 scope boundary): this snapper .snapper-meta.json sidecar is written
+    # non-atomically (a crash mid-write can leave a torn JSON). It was deliberately left
+    # out of R7's atomic-persistence pass -- the snapper metadata round-trip is audit
+    # root R11's territory, where the read/write path is being reworked wholesale;
+    # hardening it there (via __util__.atomic_write_bytes, like the raw .meta sidecar)
+    # avoids touching the snapper subsystem twice. Tracked, not forgotten.
     with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
 

--- a/tests/test_r7_atomic_persistence.py
+++ b/tests/test_r7_atomic_persistence.py
@@ -1,0 +1,313 @@
+"""R7 -- atomic state & manifest persistence.
+
+Proves the shared ``__util__.atomic_write_bytes`` primitive is crash-atomic and that the
+three operational-state writers migrated to it -- operation state
+(``OperationRecord.save``), the chunked-transfer manifest (``TransferManifest.save``), and
+the restore-unlock lock write (``restore._execute_unlock``) -- can never leave a torn file
+on a mid-write crash.
+
+The R3 lock suite (``test_r3_lock_persistence.py``) already mutation-guards the primitive's
+stale-temp cleanup, no-residue, and O_NOFOLLOW-symlink behavior *through* the lock path
+(``_write_locks`` now delegates to the primitive); this file exercises the primitive
+directly plus the new callers.
+
+Keystone mutation guard: patch ``os.replace`` to raise mid-save. A caller that still did a
+plain ``open(path, "w") + json.dump`` would truncate the previous good file and leave a
+torn one, so the reload would return the wrong record (or raise). The atomic writer leaves
+the OLD complete file intact and, for best-effort callers, swallows the error.
+"""
+
+import os
+import types
+
+import pytest
+
+from btrfs_backup_ng import __util__
+from btrfs_backup_ng.cli import restore as restore_cli
+from btrfs_backup_ng.core.chunked_transfer import TransferManifest
+from btrfs_backup_ng.core.state import (
+    OperationManager,
+    OperationRecord,
+    OperationState,
+)
+
+
+def _raise_oserror(*_a, **_k):
+    raise OSError("simulated crash before the rename completes")
+
+
+# --------------------------------------------------------------------------- primitive
+
+
+def test_atomic_write_bytes_writes_and_reads_back(tmp_path):
+    p = tmp_path / "f.json"
+    __util__.atomic_write_bytes(p, b'{"a": 1}')
+    assert p.read_bytes() == b'{"a": 1}'
+
+
+def test_atomic_write_bytes_accepts_str(tmp_path):
+    p = tmp_path / "f.txt"
+    __util__.atomic_write_bytes(p, "héllo")
+    assert p.read_text(encoding="utf-8") == "héllo"
+
+
+def test_atomic_write_bytes_mode_0600(tmp_path):
+    p = tmp_path / "secret"
+    __util__.atomic_write_bytes(p, b"x", mode=0o600)
+    assert (p.stat().st_mode & 0o777) == 0o600
+
+
+def test_atomic_write_bytes_leaves_no_temp(tmp_path):
+    p = tmp_path / "f"
+    __util__.atomic_write_bytes(p, b"x")
+    assert not (tmp_path / "f.tmp").exists()
+    assert list(tmp_path.iterdir()) == [p]
+
+
+def test_atomic_write_bytes_replaces_stale_temp(tmp_path):
+    """A leftover ``.tmp`` from a prior crash is reclaimed, not left to accumulate."""
+    p = tmp_path / "f"
+    stale = tmp_path / "f.tmp"
+    stale.write_text("garbage from a prior crash")
+    __util__.atomic_write_bytes(p, b"fresh")
+    assert p.read_bytes() == b"fresh"
+    assert not stale.exists()
+
+
+def test_atomic_write_bytes_overwrites_existing(tmp_path):
+    p = tmp_path / "f"
+    p.write_bytes(b"old")
+    __util__.atomic_write_bytes(p, b"new")
+    assert p.read_bytes() == b"new"
+
+
+def test_atomic_write_bytes_symlinked_temp_does_not_clobber_victim(tmp_path):
+    """A symlink planted at the temp path must not redirect the write to its target.
+
+    Mutation guard: a plain ``open(tmp, "wb")`` with no unlink / no O_NOFOLLOW would
+    follow the symlink and overwrite the victim -> this fails."""
+    victim = tmp_path / "victim"
+    victim.write_text("precious")
+    p = tmp_path / "f"
+    (tmp_path / "f.tmp").symlink_to(victim)
+    __util__.atomic_write_bytes(p, b"payload")
+    assert victim.read_text() == "precious"  # untouched
+    assert p.read_bytes() == b"payload"
+
+
+def test_atomic_write_bytes_fsyncs_file_and_parent_dir(tmp_path, monkeypatch):
+    """The content AND the rename must be made durable (file fsync + parent-dir fsync).
+
+    Mutation guard: dropping either fsync reduces the count below 2."""
+    synced = []
+    real_fsync = os.fsync
+    monkeypatch.setattr(os, "fsync", lambda fd: (synced.append(fd), real_fsync(fd))[1])
+    __util__.atomic_write_bytes(tmp_path / "f", b"x")
+    assert len(synced) >= 2  # file content + parent directory
+
+
+def test_atomic_write_bytes_no_fsync_when_disabled(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(os, "fsync", lambda fd: calls.append(fd))
+    __util__.atomic_write_bytes(tmp_path / "f", b"x", fsync=False)
+    assert calls == []
+    assert (tmp_path / "f").read_bytes() == b"x"
+
+
+def test_atomic_write_bytes_failure_preserves_old_and_cleans_temp(
+    tmp_path, monkeypatch
+):
+    """os.replace failing mid-write leaves the OLD file intact and removes the temp."""
+    p = tmp_path / "f"
+    p.write_bytes(b"old")
+    monkeypatch.setattr(os, "replace", _raise_oserror)
+    with pytest.raises(OSError):
+        __util__.atomic_write_bytes(p, b"new")
+    assert p.read_bytes() == b"old"  # untouched
+    assert not (tmp_path / "f.tmp").exists()  # temp cleaned up
+
+
+# ------------------------------------------------------- G1: operation state (state.py)
+
+
+def _make_record(op_id="op1"):
+    return OperationRecord(
+        operation_id=op_id,
+        state=OperationState.TRANSFERRING,
+        source_volume="/data",
+    )
+
+
+def test_operation_record_save_atomic_roundtrip(tmp_path):
+    p = tmp_path / "op.json"
+    _make_record().save(p)
+    loaded = OperationRecord.load(p)
+    assert loaded.operation_id == "op1"
+    assert loaded.state == OperationState.TRANSFERRING
+    assert not (tmp_path / "op.json.tmp").exists()
+
+
+def test_operation_record_save_torn_write_preserves_old(tmp_path, monkeypatch):
+    """KEYSTONE: a crash mid-save must never leave a torn state file.
+
+    Mutation guard: revert ``save`` to ``open("w") + json.dump`` and the interrupted
+    write truncates the previous record -> the reload returns v2 (clobbered) or raises,
+    either of which fails the ``== "v1"`` assertion below."""
+    p = tmp_path / "op.json"
+    _make_record("v1").save(p)
+    assert OperationRecord.load(p).operation_id == "v1"
+
+    monkeypatch.setattr(os, "replace", _raise_oserror)
+    _make_record("v2").save(p)  # best-effort: swallows the OSError, must NOT raise
+
+    assert OperationRecord.load(p).operation_id == "v1"  # old intact, not torn
+
+
+def test_operation_record_save_best_effort_does_not_raise(tmp_path, monkeypatch):
+    """A state-save I/O failure must never propagate to fail a good operation."""
+    monkeypatch.setattr(os, "replace", _raise_oserror)
+    _make_record().save(tmp_path / "op.json")  # no exception == pass
+
+
+# --------------------------------------------------- G2: transfer manifest (chunked_transfer.py)
+
+
+def _make_manifest(tid="t1"):
+    return TransferManifest(
+        transfer_id=tid,
+        snapshot_name="snap",
+        snapshot_path="/snap",
+        parent_name=None,
+        parent_path=None,
+        destination="ssh://h/p",
+        total_size=None,
+        chunk_size=1024,
+        checksum_algorithm="sha256",
+    )
+
+
+def test_manifest_save_atomic_roundtrip(tmp_path):
+    p = tmp_path / "manifest.json"
+    _make_manifest().save(p)
+    loaded = TransferManifest.load(p)
+    assert loaded.transfer_id == "t1"
+    assert not (tmp_path / "manifest.json.tmp").exists()
+
+
+def test_manifest_save_torn_write_preserves_old(tmp_path, monkeypatch):
+    """A crash mid-save must not leave a torn manifest that forces a full retransmit."""
+    p = tmp_path / "manifest.json"
+    _make_manifest("t1").save(p)
+
+    monkeypatch.setattr(os, "replace", _raise_oserror)
+    _make_manifest("t2").save(p)  # best-effort swallow
+
+    assert TransferManifest.load(p).transfer_id == "t1"  # old intact, not torn
+
+
+# ------------------------------------------------- G3: restore-unlock lock write (restore.py)
+
+
+class _FakeEndpoint:
+    def __init__(self, path):
+        self.config = {"path": path, "lock_file_name": ".btrfs-backup-ng.locks"}
+
+
+def _setup_unlock(tmp_path, monkeypatch, lock_content):
+    lock_path = tmp_path / ".btrfs-backup-ng.locks"
+    lock_path.write_text(lock_content)
+    monkeypatch.setattr(
+        restore_cli,
+        "_prepare_backup_endpoint",
+        lambda args, source: _FakeEndpoint(tmp_path),
+    )
+    args = types.SimpleNamespace(source=str(tmp_path))
+    return lock_path, args
+
+
+def test_unlock_writes_lock_file_atomically(tmp_path, monkeypatch):
+    content = __util__.write_locks({"snap": {"locks": ["restore:abc"]}})
+    lock_path, args = _setup_unlock(tmp_path, monkeypatch, content)
+
+    rc = restore_cli._execute_unlock(args, "all")
+
+    assert rc == 0
+    assert __util__.read_locks(lock_path.read_text()) == {}  # the restore lock is gone
+    assert not (tmp_path / ".btrfs-backup-ng.locks.tmp").exists()
+
+
+def test_unlock_torn_write_preserves_lock_file(tmp_path, monkeypatch):
+    """Mutation guard for G3: revert to plain ``open("w")`` and a crash before the rename
+    truncates the lock file -> retention then misreads it as 'no locks' and can prune a
+    still-locked snapshot. The atomic writer leaves the original lock file intact."""
+    content = __util__.write_locks({"snap": {"locks": ["restore:abc"]}})
+    lock_path, args = _setup_unlock(tmp_path, monkeypatch, content)
+
+    monkeypatch.setattr(os, "replace", _raise_oserror)
+    rc = restore_cli._execute_unlock(args, "all")
+
+    assert rc == 1  # write failed -> non-zero exit
+    assert __util__.read_locks(lock_path.read_text()) == {
+        "snap": {"locks": ["restore:abc"]}
+    }
+
+
+# ---------------------------------- review fix: doctor _fix_stale_lock atomic (was a bypass)
+
+
+def test_doctor_fix_stale_lock_is_atomic(tmp_path):
+    """The doctor's --fix stale-lock action must use the atomic lock writer (it was a
+    plain write_text bypass, the same class as the G3 restore-unlock bypass)."""
+    from btrfs_backup_ng.core.doctor import Doctor
+
+    lock_file = tmp_path / ".btrfs-backup-ng.locks"
+    lock_file.write_text(__util__.write_locks({"snap": {"locks": ["stale:1"]}}))
+
+    ok = Doctor()._fix_stale_lock(lock_file, "snap", "stale:1")
+
+    assert ok is True
+    assert __util__.read_locks(lock_file.read_text()) == {}  # stale lock removed
+    assert not (tmp_path / ".btrfs-backup-ng.locks.tmp").exists()
+
+
+def test_doctor_fix_stale_lock_torn_write_preserves_lock_file(tmp_path, monkeypatch):
+    """Mutation guard: revert to plain ``write_text`` and a crash before the rename
+    truncates the lock file -> retention misreads it as 'no locks'. The atomic writer
+    leaves the original lock file intact."""
+    from btrfs_backup_ng.core.doctor import Doctor
+
+    lock_file = tmp_path / ".btrfs-backup-ng.locks"
+    lock_file.write_text(__util__.write_locks({"snap": {"locks": ["stale:1"]}}))
+
+    monkeypatch.setattr(os, "replace", _raise_oserror)
+    ok = Doctor()._fix_stale_lock(lock_file, "snap", "stale:1")
+
+    assert ok is False  # write failed -> fix reports failure
+    assert __util__.read_locks(lock_file.read_text()) == {
+        "snap": {"locks": ["stale:1"]}
+    }
+
+
+# ---------------------------------- review fix: archive_operation never drops a record
+
+
+def test_archive_operation_keeps_source_when_archive_write_fails(tmp_path, monkeypatch):
+    """Because save() is now best-effort (swallows OSError), archive_operation must NOT
+    unlink the source record unless the archive copy is proven written and loadable --
+    otherwise a failed archive write silently loses a completed operation's record.
+
+    Mutation guard: revert to an unconditional ``src_path.unlink()`` and this fails (the
+    source is gone and the archive was never written)."""
+    mgr = OperationManager(state_dir=tmp_path)
+    op = mgr.create_operation("/data", ["ssh://h/p"])
+    op.state = OperationState.SUCCESS
+    src = mgr._get_operation_path(op.operation_id)
+    op.save(src)  # persist the completed record (os.replace not yet patched)
+    assert src.exists()
+
+    monkeypatch.setattr(os, "replace", _raise_oserror)
+    archived = mgr.archive_operation(op.operation_id)
+
+    assert archived is False  # archive write failed -> reported failure
+    assert src.exists()  # SOURCE RECORD PRESERVED (never destroyed on a failed archive)
+    assert not mgr._get_archive_path(op.operation_id).exists()

--- a/tests/test_r7_atomic_persistence.py
+++ b/tests/test_r7_atomic_persistence.py
@@ -311,3 +311,32 @@ def test_archive_operation_keeps_source_when_archive_write_fails(tmp_path, monke
     assert archived is False  # archive write failed -> reported failure
     assert src.exists()  # SOURCE RECORD PRESERVED (never destroyed on a failed archive)
     assert not mgr._get_archive_path(op.operation_id).exists()
+
+
+def test_archive_operation_keeps_source_when_archive_unreadable(tmp_path, monkeypatch):
+    """Even if the archive copy is written but comes back UNREADABLE (torn/corrupt JSON),
+    the source record is kept -- the load-verification except-branch. Mutation guard:
+    drop the loadability check (existence only) and a corrupt archive would pass, unlinking
+    the source."""
+    mgr = OperationManager(state_dir=tmp_path)
+    op = mgr.create_operation("/data", ["ssh://h/p"])
+    op.state = OperationState.SUCCESS
+    src = mgr._get_operation_path(op.operation_id)
+    op.save(src)
+
+    # The archive copy is written fine, but loading it back raises (simulated corruption).
+    # The source-record load (operations/, not archive/) must still succeed.
+    archive_path = str(mgr._get_archive_path(op.operation_id))
+    real_load = OperationRecord.load
+
+    def flaky_load(path):
+        if str(path) == archive_path:
+            raise ValueError("simulated corrupt archive record")
+        return real_load(path)
+
+    monkeypatch.setattr(OperationRecord, "load", staticmethod(flaky_load))
+
+    archived = mgr.archive_operation(op.operation_id)
+
+    assert archived is False  # unreadable archive -> reported failure
+    assert src.exists()  # SOURCE RECORD PRESERVED

--- a/tests/test_raw_backfill.py
+++ b/tests/test_raw_backfill.py
@@ -229,18 +229,31 @@ def test_native_backup_stays_complete(tmp_path):
 # security: symlink handling (backfill writes while walking an untrusted dir)
 # --------------------------------------------------------------------------- #
 def test_backfill_symlinked_meta_tmp_cannot_truncate_outside_file(tmp_path):
-    """A pre-planted <name>.meta.tmp symlink must NOT let the O_CREAT|O_TRUNC write
-    redirect to an arbitrary file (O_NOFOLLOW in save_metadata). The outside file
-    stays intact and no sidecar is written for the malicious candidate."""
+    """A pre-planted <name>.meta.tmp symlink must NOT let the sidecar write redirect to
+    an arbitrary file. The shared atomic writer (R7 ``atomic_write_bytes``) unlinks the
+    stale/planted temp and re-creates it with O_EXCL|O_NOFOLLOW, so the outside file is
+    never followed or truncated -- the attacker's symlink at our OWN temp path is simply
+    reclaimed (exactly as a stale temp from a crash would be) and the legitimate sidecar
+    is still written to <name>.meta, never to the symlink target. This matches the R3
+    lock-writer's symlink contract (test_write_locks_does_not_clobber_through_symlinked_temp:
+    victim safe AND the file is still written)."""
     outside = tmp_path / "outside.secret"
     outside.write_text("DO-NOT-TRUNCATE")
     stream = tmp_path / "pwn.btrfs"
     stream.write_bytes(b"payload")
     (tmp_path / "pwn.btrfs.meta.tmp").symlink_to(outside)
 
-    _backfill(tmp_path)  # rc may be 1 (write errored); the point is no damage
-    assert outside.read_text() == "DO-NOT-TRUNCATE"  # never truncated
-    assert not (tmp_path / "pwn.btrfs.meta").exists()
+    _backfill(tmp_path)
+
+    # THE security guarantee: the outside file is never truncated or redirected through.
+    assert outside.read_text() == "DO-NOT-TRUNCATE"
+    # The sidecar landed on the REAL meta path as a fresh regular file (not a symlink),
+    # holding valid sidecar JSON for the real stream -- proving the write was not
+    # redirected to/from the victim.
+    meta = tmp_path / "pwn.btrfs.meta"
+    assert meta.exists() and not meta.is_symlink()
+    doc = json.loads(meta.read_text())
+    assert doc["name"] == "pwn"
 
 
 def test_backfill_skips_symlinked_stream(tmp_path):


### PR DESCRIPTION
## R7 — atomic state & manifest persistence

Non-atomic durable writes could leave a **torn file on a crash**: a truncated operation-state or transfer-manifest JSON breaks resume, and a torn lock file is misread as "no locks" → retention prunes a **still-locked snapshot**. R7 consolidates every durable operational-state write onto one crash-atomic primitive.

### The primitive
`__util__.atomic_write_bytes(path, data, *, mode=0o600, fsync=True)` — same-dir sibling temp (so `os.replace` is same-fs, never `EXDEV`), unlink-stale + `O_CREAT|O_EXCL|O_NOFOLLOW`, `fdopen wb` + write + flush + fsync, `os.replace`, then **parent-dir fsync**. Raises `OSError` after removing the temp; the target is untouched.

### Full-DRY migration — four hand-rolled copies + one bypass → one path
| Site | Change |
|------|--------|
| `common.py` `_write_locks` (R3) | delegates; keeps `AbortError`-on-`OSError` |
| `raw_metadata.py` `save_metadata` (raw `.meta`) | delegates; fixes the old `os.write` short-write exposure; `O_EXCL` (was `O_TRUNC`) |
| `state.py` `OperationRecord.save` (**G1**) | delegates, **best-effort** (log+continue) — state is a resume optimization, never the backup |
| `chunked_transfer.py` `TransferManifest.save` (**G2**) | delegates, best-effort |
| `restore.py` `_execute_unlock` (**G3**) | was a plain `open("w")` bypassing the atomic lock writer; now uses the primitive |
| `doctor.py` `_fix_stale_lock` | **found in review** — the same lock-write bypass as G3; fixed |

### Review fixes (adversarial 4-lens pass, before commit)
- **HIGH** — `core/doctor.py _fix_stale_lock` was a second live lock-write bypass (`--fix` action). Migrated + mutation-tested.
- **MEDIUM** — `archive_operation()` now verifies the archive copy is written **and loadable** before unlinking the source record; a best-effort save failure could otherwise silently drop a completed operation's record (R1 never-delete-on-doubt).
- **LOW** — docstring `.meta.<pid>.tmp` → `.meta.tmp`; snapper `.snapper-meta.json` (same class) documented at the write site as deferred to **R11**'s snapper-metadata rework (not silently dropped).

### Scope (documented, not silently dropped)
`transaction.py` (append-only JSONL audit log — different atomicity model) and chunk **data** files (guarded by per-chunk sha256) are out of scope.

### Behavior notes
- state/manifest tighten to mode `0600` (were umask-default) — harmless under per-user `~/.config`, arguably an improvement.
- The raw-sidecar symlink defense now matches the **R3 lock contract**: a symlink planted at our own temp path is reclaimed (not followed), the victim is never truncated/redirected. `test_raw_backfill` security test updated to the stronger, R3-consistent assertion.

### Verification
- **Tier1 2567 passed**, ruff + mypy clean.
- New `tests/test_r7_atomic_persistence.py` (20 tests) — **mutation-verified keystone guards**: revert any writer to plain `open("w")` → the torn-write test fails.
- **Hardware-proven on real btrfs under genuine cross-process `SIGKILL`**: the naive `open("w")` pattern tore **37/50** kills; `atomic_write_bytes` tore **0/50**. (All R7 writes are local even for ssh transfers, so there is no remote-specific path to test.)

No AI/tool attribution.