### PR TITLE
fix(ssh): verify host keys on the paramiko path + honor ssh_opts/known_hosts (R12a)

### DIFF
--- a/src/btrfs_backup_ng/endpoint/ssh.py
+++ b/src/btrfs_backup_ng/endpoint/ssh.py
@@ -2626,6 +2626,32 @@ print(json.dumps(result))
             show_progress=show_progress,
         )
 
+    def _new_verified_paramiko_client(self) -> Any:
+        """Create a Paramiko SSHClient that verifies the host key against the operator's
+        known_hosts (R12/P1).
+
+        Loading the store is what closes the fail-open: with it, a CHANGED key raises
+        ``BadHostKeyException`` on connect (the MITM signal), while a genuinely new host is
+        trusted AND persisted -- accept-new parity with the subprocess transport. The old
+        code loaded NOTHING, so every key looked "missing" and ``AutoAddPolicy`` blindly
+        accepted any key, including a changed one, on the path that carries the SSH and
+        sudo passwords."""
+        assert paramiko is not None
+        client = paramiko.SSHClient()
+        try:
+            client.load_system_host_keys()
+        except OSError:
+            pass  # a missing/unreadable system known_hosts must not block the transfer
+        known_hosts = str(self.ssh_manager.known_hosts_path)
+        try:
+            # load_host_keys also sets the write-back file, so AutoAddPolicy persists a
+            # newly accepted host to the operator's known_hosts (accept-new pinning).
+            client.load_host_keys(known_hosts)
+        except OSError as e:
+            logger.warning("Could not load known_hosts %s: %s", known_hosts, e)
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        return client
+
     def _do_paramiko_transfer(
         self,
         source_path: str,
@@ -2729,8 +2755,9 @@ print(json.dumps(result))
             # 1. Get username (from CLI/URL - already in ssh_user)
             # 2. Get password (via getpass - in ssh_password)
             # 3. Connect with those credentials
-            client = _paramiko.SSHClient()  # type: ignore[union-attr]
-            client.set_missing_host_key_policy(_paramiko.AutoAddPolicy())  # type: ignore[union-attr]
+            # Host-key-verified client (loads the operator's known_hosts -> accept-new
+            # parity: a changed key is refused, a new host is trusted+pinned). R12/P1.
+            client = self._new_verified_paramiko_client()
 
             connect_kwargs: Dict[str, Any] = {
                 "hostname": self.hostname,
@@ -2899,6 +2926,18 @@ print(json.dumps(result))
         except Exception as e:
             # Handle paramiko-specific exceptions
             if paramiko is not None:
+                # A changed host key -> refuse LOUDLY (this is the MITM signal the R12/P1
+                # fix exists to raise). Must precede the SSHException check (subclass).
+                if isinstance(e, paramiko.BadHostKeyException):
+                    logger.error(
+                        "SSH host key for %s does NOT match the pinned key in %s -- "
+                        "refusing to transfer (possible man-in-the-middle). If the host was "
+                        "legitimately rekeyed, remove its stale entry from that known_hosts "
+                        "file and retry.",
+                        self.hostname,
+                        self.ssh_manager.known_hosts_path,
+                    )
+                    return False
                 if isinstance(e, paramiko.AuthenticationException):
                     logger.error(f"SSH authentication failed: {e}")
                     return False

--- a/src/btrfs_backup_ng/sshutil/master.py
+++ b/src/btrfs_backup_ng/sshutil/master.py
@@ -10,6 +10,69 @@ from typing import List, Optional
 from btrfs_backup_ng.__logger__ import logger
 
 
+def operator_ssh_dir() -> Path:
+    """The ``.ssh`` directory of the INVOKING operator, even under sudo.
+
+    Under ``sudo`` (SUDO_USER set, euid 0) this resolves to the sudo user's ``~/.ssh``,
+    NOT root's -- so host-key trust (``known_hosts``) matches the keys the operator
+    curated interactively, instead of pinning into root's (usually empty) store where the
+    operator can neither see nor manage it (R12/P4)."""
+    sudo_user = os.environ.get("SUDO_USER")
+    if sudo_user and os.geteuid() == 0:
+        return Path(pwd.getpwnam(sudo_user).pw_dir) / ".ssh"
+    return Path.home() / ".ssh"
+
+
+def operator_known_hosts() -> Path:
+    """Path to the operator's ``known_hosts`` (see :func:`operator_ssh_dir`)."""
+    return operator_ssh_dir() / "known_hosts"
+
+
+def ensure_operator_known_hosts() -> Path:
+    """Return the operator's ``known_hosts`` path, creating an empty 0600 file owned by the
+    operator if it is missing.
+
+    Under sudo this runs AS ROOT inside the (untrusted) operator's home, so it must NEVER
+    follow a symlink there: a sudo user who pre-plants ``~/.ssh`` or ``~/.ssh/known_hosts``
+    as a symlink to a root-owned target could otherwise trick root into creating/chowning a
+    file OUTSIDE the home -- a privilege escalation beyond their sudo scope (own /etc/shadow).
+    So, under sudo: (1) bail if either path element is a symlink; (2) create the file with
+    ``O_CREAT|O_EXCL|O_NOFOLLOW`` (a fresh regular file, never through a symlink); (3) chown
+    via the resulting fd, so we only ever take ownership of a file we just created -- an
+    existing file (operator- or root-owned) is left exactly as-is."""
+    ssh_dir = operator_ssh_dir()
+    kh = ssh_dir / "known_hosts"
+    sudo_user = os.environ.get("SUDO_USER")
+    running_as_sudo = bool(sudo_user) and os.geteuid() == 0
+    try:
+        if running_as_sudo and (os.path.islink(ssh_dir) or os.path.islink(kh)):
+            logger.warning(
+                "Refusing to initialise %s as root: a symlink is present in the operator's "
+                ".ssh path (possible privilege-escalation attempt); using it as-is",
+                kh,
+            )
+            return kh
+        ssh_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        if not os.path.lexists(kh):  # lexists: a dangling symlink counts as present
+            # O_NOFOLLOW|O_EXCL: create a FRESH regular file; a symlink racing in at kh makes
+            # the open fail (ELOOP) rather than be written through.
+            fd = os.open(
+                kh, os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_NOFOLLOW, 0o600
+            )
+            try:
+                if running_as_sudo:
+                    assert (
+                        sudo_user is not None
+                    )  # narrowing: implied by running_as_sudo
+                    pw = pwd.getpwnam(sudo_user)
+                    os.fchown(fd, pw.pw_uid, pw.pw_gid)  # fd-based -> symlink-safe
+            finally:
+                os.close(fd)
+    except OSError as e:
+        logger.warning("Could not ensure operator known_hosts at %s: %s", kh, e)
+    return kh
+
+
 class SSHMasterManager:
     """Manages SSH master connections with password fallback support.
 
@@ -41,6 +104,8 @@ class SSHMasterManager:
         self.hostname = hostname
         self.username = username or getpass.getuser()
         self.port = port
+        # Each entry is a BARE ``key=value`` ssh option (e.g. "StrictHostKeyChecking=yes"),
+        # emitted as ``-o key=value`` by _ssh_base_cmd -- NOT a pre-formatted "-o ..." token.
         self.ssh_opts = ssh_opts or []
         self.persist = persist
         self.debug = debug
@@ -66,10 +131,11 @@ class SSHMasterManager:
         )
         self.sudo_user = os.environ.get("SUDO_USER")
 
-        if self.running_as_sudo and self.sudo_user:
-            self.ssh_config_dir = Path(pwd.getpwnam(self.sudo_user).pw_dir) / ".ssh"
-        else:
-            self.ssh_config_dir = Path.home() / ".ssh"
+        self.ssh_config_dir = operator_ssh_dir()
+        # The operator's known_hosts, ensured to exist and be operator-owned. Passed as
+        # UserKnownHostsFile so accept-new/strict verify against the operator's curated
+        # trust even under sudo (was silently using root's store) -- R12/P4.
+        self.known_hosts_path = ensure_operator_known_hosts()
 
         if control_dir:
             self.control_dir = Path(control_dir)
@@ -103,8 +169,14 @@ class SSHMasterManager:
         if force_tty:
             cmd.append("-tt")
 
+        # Operator-supplied ssh_opts come FIRST so they WIN: ssh uses the first obtained
+        # value for each option, so an operator who hardens e.g. StrictHostKeyChecking=yes
+        # via config `ssh_opts` overrides the default below (was silently DROPPED here --
+        # R12/P3; it is still honored in raw+ssh, so this restores parity).
+        opts = list(self.ssh_opts)
+
         # SSH options for better reliability
-        opts = [
+        opts += [
             f"ControlPath={self.control_path}",
             "ControlMaster=auto",
             f"ControlPersist={self.persist}",
@@ -118,6 +190,14 @@ class SSHMasterManager:
             "PubkeyAuthentication=yes",
             "PreferredAuthentications=publickey,keyboard-interactive,password",
         ]
+
+        # Under sudo, ssh runs as root and would otherwise pin/verify against ROOT's
+        # known_hosts, ignoring the operator's curated trust (and defeating any TOFU the
+        # operator did as themselves). Bind it to the operator's file so accept-new lands
+        # where the operator can see and manage it -- R12/P4. Non-sudo ssh already uses the
+        # operator's ~/.ssh/known_hosts and respects their ssh_config, so it is left alone.
+        if self.running_as_sudo:
+            opts.append(f"UserKnownHostsFile={self.known_hosts_path}")
 
         # Only use BatchMode if password authentication is not needed
         if not self.allow_password_auth:

--- a/tests/test_r12a_ssh_hostkey.py
+++ b/tests/test_r12a_ssh_hostkey.py
@@ -1,0 +1,226 @@
+"""R12a -- SSH host-key hardening.
+
+- P1: the Paramiko password-sudo transport now loads the operator's known_hosts BEFORE
+  connecting, so a changed key is refused (BadHostKeyException) and a genuinely new host is
+  trust-on-first-use pinned -- accept-new parity. The old code loaded nothing, so
+  AutoAddPolicy blindly accepted ANY key (including a changed one) -- a fail-open MITM on the
+  path that carries the SSH + sudo passwords.
+- P3: operator-supplied ssh_opts are applied on the primary subprocess transport, and FIRST
+  (ssh uses the first value -> operator hardening wins). They were silently dropped.
+- P4: UserKnownHostsFile points at the OPERATOR's known_hosts (even under sudo), so accept-new
+  verifies/pins against the operator's curated trust, not root's empty store.
+
+The changed-key -> refused behaviour itself is paramiko's guarantee once the store is loaded,
+and is validated end-to-end on real hardware; here the enforcement guard is that the store IS
+loaded (revert the load -> fail-open returns -> the wiring test fails).
+"""
+
+import os
+import pwd
+import stat
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from btrfs_backup_ng.sshutil import master as master_mod
+from btrfs_backup_ng.sshutil.master import (
+    SSHMasterManager,
+    ensure_operator_known_hosts,
+    operator_ssh_dir,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    # Constructing the manager touches ~/.ssh; point HOME at a temp dir and clear SUDO_USER
+    # so tests never touch the real home and run on a fresh account/CI runner.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("SUDO_USER", raising=False)
+
+
+# ------------------------------------ operator known_hosts resolution (P4 foundation)
+
+
+def test_operator_ssh_dir_non_sudo_uses_home(tmp_path):
+    assert operator_ssh_dir() == tmp_path / ".ssh"
+
+
+def test_operator_ssh_dir_under_sudo_uses_sudo_user(monkeypatch):
+    """Under sudo the operator's (SUDO_USER's) ~/.ssh is used, NOT root's -- so host-key
+    trust matches what the operator curated. Mutation guard: ignore SUDO_USER -> returns
+    Path.home()/.ssh (the temp HOME) and this fails."""
+    user = pwd.getpwuid(os.getuid()).pw_name
+    monkeypatch.setenv("SUDO_USER", user)
+    monkeypatch.setattr(master_mod.os, "geteuid", lambda: 0)
+    assert operator_ssh_dir() == Path(pwd.getpwnam(user).pw_dir) / ".ssh"
+
+
+def test_ensure_operator_known_hosts_creates_0600_file(tmp_path):
+    kh = ensure_operator_known_hosts()
+    assert kh == tmp_path / ".ssh" / "known_hosts"
+    assert kh.exists()
+    assert stat.S_IMODE(kh.stat().st_mode) == 0o600
+
+
+def test_ensure_known_hosts_refuses_to_chown_through_symlink_under_sudo(
+    tmp_path, monkeypatch
+):
+    """CRITICAL guard: under sudo (as root), a symlink planted at the operator's known_hosts
+    must NOT be followed/chowned -- else a sudo user escalates by symlinking it to a
+    root-owned file. Mutation guard: revert to stat()+os.chown() (follow symlinks) -> with
+    the target faked root-owned, os.chown fires -> this fails."""
+    user = pwd.getpwuid(os.getuid()).pw_name
+    monkeypatch.setenv("SUDO_USER", user)
+    monkeypatch.setattr(master_mod.os, "geteuid", lambda: 0)
+    monkeypatch.setattr(master_mod, "operator_ssh_dir", lambda: tmp_path / ".ssh")
+    (tmp_path / ".ssh").mkdir()
+    victim = tmp_path / "victim"
+    victim.write_text("root-owned-secret")
+    kh = tmp_path / ".ssh" / "known_hosts"
+    kh.symlink_to(victim)
+
+    # Simulate the symlink TARGET being root-owned (the escalation precondition) so a naive
+    # stat()+chown() would fire. Only the follow-symlinks stat() (what the old buggy code
+    # used) is faked; follow_symlinks=False (pathlib lstat / islink) delegates to the real
+    # stat so os.path.islink still works.
+    real_stat = os.stat
+
+    def fake_stat(p, *a, follow_symlinks=True, **k):
+        if str(p) == str(kh) and follow_symlinks:
+            return type("S", (), {"st_uid": 0})()
+        return real_stat(p, *a, follow_symlinks=follow_symlinks, **k)
+
+    monkeypatch.setattr(master_mod.os, "stat", fake_stat)
+    chowns = []
+    monkeypatch.setattr(master_mod.os, "chown", lambda *a, **k: chowns.append(a))
+    monkeypatch.setattr(master_mod.os, "fchown", lambda *a, **k: chowns.append(a))
+
+    ensure_operator_known_hosts()
+
+    assert chowns == []  # never chowned through the symlink
+    assert os.path.islink(kh)  # the planted symlink was not replaced
+    assert victim.read_text() == "root-owned-secret"  # victim untouched
+
+
+def test_ensure_known_hosts_fchowns_only_the_fresh_file_under_sudo(
+    tmp_path, monkeypatch
+):
+    """The legit path: under sudo a freshly-created known_hosts is chowned to the OPERATOR
+    via its fd (symlink-safe). Mutation guard: drop the fchown -> not recorded."""
+    user = pwd.getpwuid(os.getuid()).pw_name
+    pw = pwd.getpwnam(user)
+    monkeypatch.setenv("SUDO_USER", user)
+    monkeypatch.setattr(master_mod.os, "geteuid", lambda: 0)
+    monkeypatch.setattr(master_mod, "operator_ssh_dir", lambda: tmp_path / ".ssh")
+    fchowns = []
+    monkeypatch.setattr(
+        master_mod.os, "fchown", lambda fd, uid, gid: fchowns.append((uid, gid))
+    )
+
+    kh = ensure_operator_known_hosts()
+
+    assert kh.exists() and not kh.is_symlink()
+    assert fchowns == [(pw.pw_uid, pw.pw_gid)]
+
+
+# ------------------------------------ P4: UserKnownHostsFile on the primary transport
+
+
+def _mgr(**kw):
+    return SSHMasterManager(hostname="h", username="u", **kw)
+
+
+def test_ssh_base_cmd_sets_user_known_hosts_file_under_sudo(monkeypatch):
+    """Under sudo the subprocess transport pins to the OPERATOR's known_hosts (was unset ->
+    ssh, as root, used root's store). Mutation guard: drop the sudo-branch append -> absent."""
+    user = pwd.getpwuid(os.getuid()).pw_name
+    monkeypatch.setenv("SUDO_USER", user)
+    monkeypatch.setattr(master_mod.os, "geteuid", lambda: 0)
+    operator_kh = Path(pwd.getpwnam(user).pw_dir) / ".ssh" / "known_hosts"
+    cmd = _mgr()._ssh_base_cmd()
+    assert f"UserKnownHostsFile={operator_kh}" in cmd
+
+
+def test_ssh_base_cmd_leaves_known_hosts_alone_non_sudo(tmp_path):
+    """Non-sudo, ssh already uses the operator's ~/.ssh/known_hosts and respects ssh_config,
+    so we do NOT force UserKnownHostsFile (avoids overriding a power-user's ssh_config)."""
+    cmd = _mgr()._ssh_base_cmd()
+    assert not any(c.startswith("UserKnownHostsFile=") for c in cmd)
+
+
+# ------------------------------------ P3: operator ssh_opts applied, and FIRST (they win)
+
+
+def test_ssh_base_cmd_applies_operator_ssh_opts_first():
+    """Operator ssh_opts are honored on the primary transport (were silently dropped) and
+    precede the tool default so ssh's first-value-wins gives the operator override effect.
+    Mutation guard: drop `list(self.ssh_opts)` -> the operator opt is absent."""
+    cmd = _mgr(ssh_opts=["StrictHostKeyChecking=yes"])._ssh_base_cmd()
+    assert "StrictHostKeyChecking=yes" in cmd
+    assert cmd.index("StrictHostKeyChecking=yes") < cmd.index(
+        "StrictHostKeyChecking=accept-new"
+    )
+
+
+# ------------------------------------ P1: Paramiko loads the operator known_hosts (no fail-open)
+
+
+def test_paramiko_client_loads_operator_known_hosts(monkeypatch):
+    """THE P1 enforcement guard: the verified-client factory loads system + the operator's
+    known_hosts before returning, so paramiko rejects a changed key. Mutation guard: remove
+    the load_host_keys call -> AutoAddPolicy runs on an empty store (fail-open) and this
+    fails."""
+    from btrfs_backup_ng.endpoint import choose_endpoint
+    import btrfs_backup_ng.endpoint.ssh as ssh_mod
+
+    ep = choose_endpoint(
+        "ssh://u@host/p", {"path": "ssh://u@host/p", "snap_prefix": ""}
+    )
+
+    fake_paramiko = MagicMock()
+    fake_client = fake_paramiko.SSHClient.return_value
+    monkeypatch.setattr(ssh_mod, "paramiko", fake_paramiko)
+
+    client = ep._new_verified_paramiko_client()
+
+    assert client is fake_client
+    fake_client.load_system_host_keys.assert_called_once()
+    fake_client.load_host_keys.assert_called_once_with(
+        str(ep.ssh_manager.known_hosts_path)
+    )
+    fake_client.set_missing_host_key_policy.assert_called_once()
+    assert fake_paramiko.AutoAddPolicy.called
+
+
+# ------------------------------------ P1: the BadHostKeyException handler refuses loudly
+
+
+def test_paramiko_transfer_refuses_changed_host_key(monkeypatch):
+    """The BadHostKeyException handler (R12/P1) returns False AND logs a loud MITM message
+    -- the changed-key outcome. Driven through the real method's error path: the client
+    factory raises the exception inside the transfer's try. Mutation guard: move the
+    BadHostKeyException branch below its SSHException superclass -> the MITM message is lost
+    and this fails."""
+    import paramiko
+
+    from btrfs_backup_ng.endpoint import choose_endpoint
+    import btrfs_backup_ng.endpoint.ssh as ssh_mod
+
+    ep = choose_endpoint(
+        "ssh://u@host/p", {"path": "ssh://u@host/p", "snap_prefix": ""}
+    )
+    monkeypatch.setattr(ep, "_estimate_snapshot_size", lambda *a, **k: 0)
+
+    def _raise(*_a, **_k):
+        raise paramiko.BadHostKeyException("host", MagicMock(), MagicMock())
+
+    monkeypatch.setattr(ep, "_new_verified_paramiko_client", _raise)
+
+    errors = []
+    monkeypatch.setattr(ssh_mod.logger, "error", lambda *a, **k: errors.append(a))
+
+    ok = ep._do_paramiko_transfer("/src", "/dst", "snap", None, "sudopw", False)
+
+    assert ok is False
+    assert any("man-in-the-middle" in str(a[0]) for a in errors)


### PR DESCRIPTION
## R12a — SSH host-key verification (the urgent-security slice of R12)

First of the R12 SSH-security series, pulled forward as a focused fix. Closes three host-key gaps; the default policy is unchanged (`accept-new`) so **no existing unattended backup breaks**.

### The gaps (verified against the code)
| | Severity | Fix |
|---|---|---|
| **P1** | 🔴 fail-open MITM | The paramiko password-sudo path set `AutoAddPolicy` with **no `known_hosts` loaded** → every key looked "missing" → **any** key, incl. a *changed* one, blindly accepted — on the path carrying the SSH + sudo passwords. New `_new_verified_paramiko_client()` loads system + the operator's known_hosts first → **accept-new parity**: changed key → `BadHostKeyException` (loud MITM refusal), new host → trusted + pinned. |
| **P3** | 🟠 dropped hardening | `_ssh_base_cmd` never referenced `self.ssh_opts` → an operator's `StrictHostKeyChecking=yes` was silently ignored on the primary transport (honored only in raw+ssh). Now prepended **first** (ssh first-value-wins → operator override). |
| **P4** | 🟠 wrong store under sudo | `UserKnownHostsFile` unset → ssh-as-root pinned to **root's** store, ignoring the operator's curated trust. Now bound (sudo-only) to the operator's known_hosts; non-sudo untouched (don't override a power-user's ssh_config). |

New helpers `operator_ssh_dir()` / `operator_known_hosts()` / `ensure_operator_known_hosts()` resolve + create the operator's file.

### Adversarial review caught a 🔴 CRITICAL (fixed)
`ensure_operator_known_hosts` runs **as root** inside the untrusted operator's home. A naive `stat()+chown()` **follows a symlink** — a sudo user could plant `~/.ssh/known_hosts → /etc/shadow` and have root hand them ownership (**privilege escalation** beyond their sudo scope). Fixed: bail on any symlink in the path, create with `O_CREAT|O_EXCL|O_NOFOLLOW`, chown via the **fd** — so it only ever owns a file it just created; an existing file is never chowned.

### Verification
- **Tier1 2578 passed**, ruff + mypy clean. New `tests/test_r12a_ssh_hostkey.py` (10 tests), **all guards mutation-verified** — including the symlink escalation (reverting to `stat()+chown()` chowns the victim → test fails) and the `BadHostKeyException` MITM handler.
- **Hardware-proven with real paramiko vs a real host**: correct key **ACCEPTED**, wrong pinned key **REJECTED (`BadHostKeyException`)**, old empty-store+`AutoAdd` **ACCEPTED** (the fail-open). Real ssh confirmed operator `ssh_opts` (`StrictHostKeyChecking=yes` first) wins and `UserKnownHostsFile` pins to the operator's file.

### Scope / follow-ons
Configurable `strict` mode + `--ssh-host-key-policy` CLI (R12b), control-socket-dir hijack + `/tmp` lock race (R12c), cleanup + docs (R12d). Given P1 is a real (scoped) MITM, this may warrant a **GHSA + point release** — your call at merge.

No AI/tool attribution.