### PR TITLE
feat(ssh): configurable ssh_host_key_policy (accept-new|strict) across transports (R12b)

### DIFF
--- a/src/btrfs_backup_ng/cli/common.py
+++ b/src/btrfs_backup_ng/cli/common.py
@@ -154,6 +154,22 @@ def add_fs_checks_args(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def add_ssh_hostkey_arg(parser: argparse.ArgumentParser) -> None:
+    """Add the ``--ssh-host-key-policy`` argument to an ssh-capable parser (R12b).
+
+    ``default=None`` so that an unset flag never overrides a config-file setting -- the
+    handler only threads it into endpoint kwargs when the operator passed it explicitly.
+    """
+    parser.add_argument(
+        "--ssh-host-key-policy",
+        choices=["accept-new", "strict"],
+        default=None,
+        help="SSH host-key verification for this run: 'accept-new' (trust first contact, "
+        "reject a changed key) or 'strict' (known_hosts-only, reject an unknown host). "
+        "Overrides the target config.",
+    )
+
+
 def get_fs_checks_mode(args: argparse.Namespace) -> str:
     """Get the filesystem checks mode from parsed arguments.
 

--- a/src/btrfs_backup_ng/cli/dispatcher.py
+++ b/src/btrfs_backup_ng/cli/dispatcher.py
@@ -10,7 +10,12 @@ from typing import Callable
 
 from .. import __util__
 from ..__logger__ import logger
-from .common import add_fs_checks_args, add_progress_args, add_verbosity_args
+from .common import (
+    add_fs_checks_args,
+    add_progress_args,
+    add_ssh_hostkey_arg,
+    add_verbosity_args,
+)
 
 # Known subcommands for the new CLI
 SUBCOMMANDS = frozenset(
@@ -671,6 +676,7 @@ Config-driven restore:
         help="Bandwidth limit (e.g., '10M', '1G')",
     )
     add_fs_checks_args(restore_parser)
+    add_ssh_hostkey_arg(restore_parser)
 
     # Config-driven restore options
     config_group = restore_parser.add_argument_group(
@@ -832,6 +838,7 @@ Examples:
         help="Explicit ssh-agent socket (overrides auto-discovery; useful under sudo)",
     )
     add_fs_checks_args(verify_parser)
+    add_ssh_hostkey_arg(verify_parser)
     verify_parser.add_argument(
         "--json",
         action="store_true",
@@ -984,6 +991,7 @@ Examples:
         "(defaults to the config's [global] timestamp_format, else the built-in)",
     )
     add_fs_checks_args(estimate_parser)
+    add_ssh_hostkey_arg(estimate_parser)
     estimate_parser.add_argument(
         "--json",
         action="store_true",

--- a/src/btrfs_backup_ng/cli/estimate.py
+++ b/src/btrfs_backup_ng/cli/estimate.py
@@ -150,6 +150,7 @@ def _estimate_from_config(args: argparse.Namespace, volume_path: str) -> int:
             "fs_checks": "auto",
             "timestamp_format": get_timestamp_format(config),
         }
+        dest_kwargs["ssh_host_key_policy"] = target.ssh_host_key_policy
         if target.ssh_sudo:
             dest_kwargs["ssh_sudo"] = True
         if target.ssh_key:
@@ -233,6 +234,8 @@ def _estimate_direct(args: argparse.Namespace, source: str, destination: str) ->
             "fs_checks": fs_checks_mode,
             "timestamp_format": ts_fmt,
         }
+        if getattr(args, "ssh_host_key_policy", None):
+            dest_kwargs["ssh_host_key_policy"] = args.ssh_host_key_policy
         if ssh_sudo:
             dest_kwargs["ssh_sudo"] = True
         if ssh_key:

--- a/src/btrfs_backup_ng/cli/list_cmd.py
+++ b/src/btrfs_backup_ng/cli/list_cmd.py
@@ -123,6 +123,7 @@ def execute_list(args: argparse.Namespace) -> int:
             try:
                 dest_kwargs = dict(endpoint_kwargs)
                 dest_kwargs["ssh_sudo"] = target.ssh_sudo
+                dest_kwargs["ssh_host_key_policy"] = target.ssh_host_key_policy
                 dest_kwargs["ssh_password_fallback"] = target.ssh_password_auth
 
                 dest_endpoint = endpoint.choose_endpoint(

--- a/src/btrfs_backup_ng/cli/prune.py
+++ b/src/btrfs_backup_ng/cli/prune.py
@@ -241,6 +241,7 @@ def execute_prune(args: argparse.Namespace) -> int:
             try:
                 dest_kwargs = dict(endpoint_kwargs)
                 dest_kwargs["ssh_sudo"] = target.ssh_sudo
+                dest_kwargs["ssh_host_key_policy"] = target.ssh_host_key_policy
                 dest_kwargs["ssh_password_fallback"] = target.ssh_password_auth
 
                 dest_endpoint = endpoint.choose_endpoint(

--- a/src/btrfs_backup_ng/cli/restore.py
+++ b/src/btrfs_backup_ng/cli/restore.py
@@ -221,6 +221,8 @@ def _execute_config_restore(args: argparse.Namespace, volume_path: str) -> int:
             args.ssh_sudo = True
         if target.ssh_key:
             args.ssh_key = target.ssh_key
+        if not getattr(args, "ssh_host_key_policy", None):
+            args.ssh_host_key_policy = target.ssh_host_key_policy
         # Use volume's snapshot prefix
         if volume.snapshot_prefix and not getattr(args, "prefix", None):
             args.prefix = volume.snapshot_prefix
@@ -250,6 +252,8 @@ def _execute_config_restore(args: argparse.Namespace, volume_path: str) -> int:
         args.ssh_sudo = True
     if target.ssh_key and not getattr(args, "ssh_key", None):
         args.ssh_key = target.ssh_key
+    if not getattr(args, "ssh_host_key_policy", None):
+        args.ssh_host_key_policy = target.ssh_host_key_policy
     if target.compress != "none" and not getattr(args, "compress", None):
         args.compress = target.compress
     if target.rate_limit and not getattr(args, "rate_limit", None):

--- a/src/btrfs_backup_ng/cli/restore.py
+++ b/src/btrfs_backup_ng/cli/restore.py
@@ -450,6 +450,9 @@ def _prepare_backup_endpoint(args: argparse.Namespace, source: str):
     # SSH options
     if source.startswith("ssh://"):
         endpoint_kwargs["ssh_sudo"] = getattr(args, "ssh_sudo", False)
+        _hkp = getattr(args, "ssh_host_key_policy", None)
+        if _hkp:
+            endpoint_kwargs["ssh_host_key_policy"] = _hkp
         endpoint_kwargs["ssh_password_fallback"] = getattr(
             args, "ssh_password_auth", True
         )

--- a/src/btrfs_backup_ng/cli/run.py
+++ b/src/btrfs_backup_ng/cli/run.py
@@ -378,6 +378,7 @@ def _backup_volume(
 
             dest_kwargs = dict(endpoint_kwargs)
             dest_kwargs["ssh_sudo"] = target.ssh_sudo
+            dest_kwargs["ssh_host_key_policy"] = target.ssh_host_key_policy
             dest_kwargs["ssh_password_fallback"] = target.ssh_password_auth
 
             if target.ssh_key:
@@ -639,6 +640,7 @@ def _backup_snapper_volume(
                 "snap_prefix": "",
                 "timestamp_format": get_timestamp_format(config),
             }
+            snapper_endpoint_config["ssh_host_key_policy"] = target.ssh_host_key_policy
             if target.ssh_sudo:
                 snapper_endpoint_config["ssh_sudo"] = True
             if target.ssh_key:

--- a/src/btrfs_backup_ng/cli/status.py
+++ b/src/btrfs_backup_ng/cli/status.py
@@ -148,6 +148,7 @@ def execute_status(args: argparse.Namespace) -> int:
             try:
                 dest_kwargs = dict(endpoint_kwargs)
                 dest_kwargs["ssh_sudo"] = target.ssh_sudo
+                dest_kwargs["ssh_host_key_policy"] = target.ssh_host_key_policy
                 dest_kwargs["ssh_password_fallback"] = target.ssh_password_auth
 
                 dest_endpoint = endpoint.choose_endpoint(

--- a/src/btrfs_backup_ng/cli/transfer.py
+++ b/src/btrfs_backup_ng/cli/transfer.py
@@ -159,6 +159,7 @@ def execute_transfer(args: argparse.Namespace) -> int:
 
                     dest_kwargs = dict(endpoint_kwargs)
                     dest_kwargs["ssh_sudo"] = target.ssh_sudo
+                    dest_kwargs["ssh_host_key_policy"] = target.ssh_host_key_policy
                     dest_kwargs["ssh_password_fallback"] = target.ssh_password_auth
 
                     if target.ssh_key:

--- a/src/btrfs_backup_ng/cli/verify.py
+++ b/src/btrfs_backup_ng/cli/verify.py
@@ -44,6 +44,10 @@ def execute(args: argparse.Namespace) -> int:
         ),
     }
 
+    # Host-key policy override (R12b): threaded for any remote; harmless (ignored) for local.
+    if getattr(args, "ssh_host_key_policy", None):
+        endpoint_kwargs["ssh_host_key_policy"] = args.ssh_host_key_policy
+
     # SSH / raw options
     if args.location.startswith("ssh://"):
         if args.ssh_sudo:

--- a/src/btrfs_backup_ng/config/loader.py
+++ b/src/btrfs_backup_ng/config/loader.py
@@ -157,6 +157,19 @@ def _parse_retention(data: dict[str, Any]) -> RetentionConfig:
     )
 
 
+VALID_HOST_KEY_POLICIES = ("accept-new", "strict")
+
+
+def _validate_host_key_policy(value: Any, path: str) -> str:
+    """Validate the ssh_host_key_policy value, failing closed on anything unrecognized."""
+    if value not in VALID_HOST_KEY_POLICIES:
+        raise ConfigError(
+            f"Invalid ssh_host_key_policy {value!r} for target {path}. "
+            f"Valid: {list(VALID_HOST_KEY_POLICIES)}"
+        )
+    return value
+
+
 def _parse_target(data: dict[str, Any]) -> TargetConfig:
     """Parse target configuration from dict."""
     if "path" not in data:
@@ -204,6 +217,13 @@ def _parse_target(data: dict[str, Any]) -> TargetConfig:
     if encrypt == "gpg" and not gpg_recipient:
         raise ConfigError(f"gpg_recipient is required when encrypt=gpg (target {path})")
 
+    # Host-key policy is a SECURITY selector: fail CLOSED on an unrecognized value rather
+    # than silently falling back to a default (a typo'd "strict" must not degrade to
+    # accept-new). Only the two safe modes are accepted -- there is no "off"/"no". R12b.
+    ssh_host_key_policy = _validate_host_key_policy(
+        data.get("ssh_host_key_policy", "accept-new"), path
+    )
+
     return TargetConfig(
         path=path,
         ssh_sudo=data.get("ssh_sudo", False),
@@ -211,6 +231,7 @@ def _parse_target(data: dict[str, Any]) -> TargetConfig:
         ssh_key=data.get("ssh_key"),
         ssh_auth_sock=data.get("ssh_auth_sock"),
         ssh_password_auth=data.get("ssh_password_auth", True),
+        ssh_host_key_policy=ssh_host_key_policy,
         compress=compress,
         rate_limit=data.get("rate_limit"),
         require_mount=data.get("require_mount", False),

--- a/src/btrfs_backup_ng/config/schema.py
+++ b/src/btrfs_backup_ng/config/schema.py
@@ -193,7 +193,9 @@ class RawTargetConfig:
     ssh_port: int = 22
     ssh_key: Optional[str] = None
     ssh_auth_sock: Optional[str] = None
-    # Host-key verification policy: "accept-new" (default) or "strict". R12b.
+    # Host-key policy. NOTE: raw targets are represented by TargetConfig at load time
+    # (the loader does not instantiate RawTargetConfig), so the LIVE knob is
+    # TargetConfig.ssh_host_key_policy; kept here for schema parity. R12b.
     ssh_host_key_policy: str = "accept-new"
 
     def __post_init__(self):

--- a/src/btrfs_backup_ng/config/schema.py
+++ b/src/btrfs_backup_ng/config/schema.py
@@ -147,6 +147,9 @@ class TargetConfig:
     ssh_key: Optional[str] = None
     ssh_auth_sock: Optional[str] = None
     ssh_password_auth: bool = True
+    # Host-key verification policy: "accept-new" (default; trust-on-first-use, reject a
+    # changed key) or "strict" (known_hosts-only, reject an unknown host). R12b.
+    ssh_host_key_policy: str = "accept-new"
     compress: str = "none"
     rate_limit: Optional[str] = None
     require_mount: bool = False
@@ -190,6 +193,8 @@ class RawTargetConfig:
     ssh_port: int = 22
     ssh_key: Optional[str] = None
     ssh_auth_sock: Optional[str] = None
+    # Host-key verification policy: "accept-new" (default) or "strict". R12b.
+    ssh_host_key_policy: str = "accept-new"
 
     def __post_init__(self):
         """Validate configuration after initialization."""

--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -1642,6 +1642,10 @@ class SSHRawEndpoint(RawEndpoint):
         self.ssh_key = config.get("ssh_key")
         self.ssh_opts = config.get("ssh_opts", [])
         self.ssh_sudo = config.get("ssh_sudo", False)
+        # Host-key policy: "accept-new" (default; unifies raw+ssh with the btrfs transport --
+        # previously it set no StrictHostKeyChecking and inherited the ambient ssh default)
+        # or "strict" (refuse an unknown host). R12b.
+        self.ssh_host_key_policy = config.get("ssh_host_key_policy", "accept-new")
         # An explicit ssh-agent socket (e.g. `--ssh-auth-sock`), useful under sudo where
         # SSH_AUTH_SOCK is not inherited. None -> rely on ssh's own agent discovery.
         self.ssh_auth_sock = config.get("ssh_auth_sock")
@@ -1688,11 +1692,16 @@ class SSHRawEndpoint(RawEndpoint):
         FAST with ssh exit 255 -- which the listing guard turns into a clear "cannot
         reach" error -- instead of hanging for the OS TCP timeout (or forever)."""
         cmd = ["ssh"]
-        cmd.extend(self.ssh_opts)
+        cmd.extend(
+            self.ssh_opts
+        )  # operator opts first -> they win (ssh first-value-wins)
+        strict = "yes" if self.ssh_host_key_policy == "strict" else "accept-new"
         cmd.extend(
             [
                 "-o",
                 "BatchMode=yes",
+                "-o",
+                f"StrictHostKeyChecking={strict}",
                 "-o",
                 "ConnectTimeout=10",
                 "-o",

--- a/src/btrfs_backup_ng/endpoint/ssh.py
+++ b/src/btrfs_backup_ng/endpoint/ssh.py
@@ -227,6 +227,7 @@ class SSHEndpoint(Endpoint):
             "ssh_key",
             "ssh_auth_sock",
             "ssh_password_fallback",
+            "ssh_host_key_policy",
         ):
             if config.get(_ssh_key) is not None:
                 self.config[_ssh_key] = config[_ssh_key]
@@ -440,6 +441,7 @@ class SSHEndpoint(Endpoint):
             identity_file=self.config.get("ssh_identity_file"),
             allow_password_auth=allow_password,
             ssh_auth_sock=self.config.get("ssh_auth_sock"),
+            host_key_policy=self.config.get("ssh_host_key_policy", "accept-new"),
         )
         logger.debug("SSHMasterManager created successfully")
 
@@ -2649,7 +2651,13 @@ print(json.dumps(result))
             client.load_host_keys(known_hosts)
         except OSError as e:
             logger.warning("Could not load known_hosts %s: %s", known_hosts, e)
-        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        # strict => an UNKNOWN host is refused (RejectPolicy); accept-new => trust+pin a new
+        # host (AutoAddPolicy). A CHANGED key is rejected under BOTH (the loaded store raises
+        # BadHostKeyException before the missing-key policy is consulted). R12b.
+        if self.config.get("ssh_host_key_policy", "accept-new") == "strict":
+            client.set_missing_host_key_policy(paramiko.RejectPolicy())
+        else:
+            client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         return client
 
     def _do_paramiko_transfer(

--- a/src/btrfs_backup_ng/sshutil/master.py
+++ b/src/btrfs_backup_ng/sshutil/master.py
@@ -100,6 +100,7 @@ class SSHMasterManager:
         identity_file: Optional[str] = None,
         allow_password_auth: bool = False,
         ssh_auth_sock: Optional[str] = None,
+        host_key_policy: str = "accept-new",
     ):
         self.hostname = hostname
         self.username = username or getpass.getuser()
@@ -111,6 +112,9 @@ class SSHMasterManager:
         self.debug = debug
         self.identity_file = identity_file
         self.allow_password_auth = allow_password_auth
+        # "accept-new" (TOFU: trust first contact, reject a changed key) or "strict"
+        # (known_hosts-only; an unknown host is refused). R12b.
+        self.host_key_policy = host_key_policy
         # Explicit ssh-agent socket override (config `ssh_auth_sock` / CLI / the
         # BTRFS_BACKUP_SSH_AUTH_SOCK env var). Takes precedence over auto-discovery so a
         # multi-agent or non-standard deployment can pin exactly which agent to use.
@@ -185,7 +189,10 @@ class SSHMasterManager:
             "TCPKeepAlive=yes",
             "ConnectTimeout=30",
             "ConnectionAttempts=3",
-            "StrictHostKeyChecking=accept-new",
+            # strict => an unknown host is refused (known_hosts-only); accept-new => TOFU
+            # (trust first contact, reject a changed key). R12b.
+            "StrictHostKeyChecking="
+            + ("yes" if self.host_key_policy == "strict" else "accept-new"),
             "PasswordAuthentication=yes",
             "PubkeyAuthentication=yes",
             "PreferredAuthentications=publickey,keyboard-interactive,password",

--- a/tests/test_r12b_hostkey_policy.py
+++ b/tests/test_r12b_hostkey_policy.py
@@ -1,0 +1,118 @@
+"""R12b -- configurable ssh_host_key_policy (accept-new | strict) across all transports.
+
+Covers: config validation (fail-closed on invalid), and that each of the three transports
+(subprocess master, paramiko, raw+ssh) emits the correct policy for each setting. The
+paramiko test also guards the endpoint config-restore whitelist (drop the key there ->
+strict silently degrades -> the test fails).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from btrfs_backup_ng.config.loader import ConfigError, _parse_target
+from btrfs_backup_ng.endpoint.raw import SSHRawEndpoint
+from btrfs_backup_ng.sshutil.master import SSHMasterManager
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("SUDO_USER", raising=False)
+
+
+# ------------------------------------ config validation (fail closed on invalid)
+
+
+def test_loader_defaults_to_accept_new():
+    assert _parse_target({"path": "ssh://h/p"}).ssh_host_key_policy == "accept-new"
+
+
+def test_loader_accepts_strict():
+    tc = _parse_target({"path": "ssh://h/p", "ssh_host_key_policy": "strict"})
+    assert tc.ssh_host_key_policy == "strict"
+
+
+def test_loader_rejects_invalid_policy_fail_closed():
+    """A security selector must fail closed on an unrecognized value, never silently fall
+    back to a (possibly weaker) default."""
+    with pytest.raises(ConfigError):
+        _parse_target({"path": "ssh://h/p", "ssh_host_key_policy": "off"})
+
+
+# ------------------------------------ subprocess transport (master.py)
+
+
+def _mgr(policy):
+    return SSHMasterManager(hostname="h", username="u", host_key_policy=policy)
+
+
+def test_master_strict_emits_yes():
+    cmd = _mgr("strict")._ssh_base_cmd()
+    assert "StrictHostKeyChecking=yes" in cmd
+    assert "StrictHostKeyChecking=accept-new" not in cmd
+
+
+def test_master_accept_new_emits_accept_new():
+    cmd = _mgr("accept-new")._ssh_base_cmd()
+    assert "StrictHostKeyChecking=accept-new" in cmd
+    assert "StrictHostKeyChecking=yes" not in cmd
+
+
+# ------------------------------------ paramiko transport (ssh.py) + config whitelist
+
+
+def _paramiko_policy_used(policy, monkeypatch):
+    from btrfs_backup_ng.endpoint import choose_endpoint
+    import btrfs_backup_ng.endpoint.ssh as ssh_mod
+
+    cfg = {"path": "ssh://u@h/p", "snap_prefix": ""}
+    if policy is not None:
+        cfg["ssh_host_key_policy"] = policy
+    ep = choose_endpoint("ssh://u@h/p", cfg)
+    fake = MagicMock()
+    monkeypatch.setattr(ssh_mod, "paramiko", fake)
+    ep._new_verified_paramiko_client()
+    return fake
+
+
+def test_paramiko_strict_uses_reject_policy(monkeypatch):
+    """strict -> RejectPolicy (unknown host refused). Also guards the ssh.py config
+    whitelist: drop 'ssh_host_key_policy' there and the endpoint never sees strict."""
+    fake = _paramiko_policy_used("strict", monkeypatch)
+    assert fake.RejectPolicy.called
+    assert not fake.AutoAddPolicy.called
+
+
+def test_paramiko_accept_new_uses_autoadd(monkeypatch):
+    fake = _paramiko_policy_used("accept-new", monkeypatch)
+    assert fake.AutoAddPolicy.called
+    assert not fake.RejectPolicy.called
+
+
+def test_paramiko_default_is_accept_new(monkeypatch):
+    fake = _paramiko_policy_used(None, monkeypatch)
+    assert fake.AutoAddPolicy.called
+    assert not fake.RejectPolicy.called
+
+
+# ------------------------------------ raw+ssh transport (raw.py)
+
+
+def _raw_cmd(policy):
+    cfg = {"path": "/backup", "hostname": "nas"}
+    if policy is not None:
+        cfg["ssh_host_key_policy"] = policy
+    return SSHRawEndpoint(config=cfg)._build_ssh_command()
+
+
+def test_raw_strict_emits_yes():
+    assert "StrictHostKeyChecking=yes" in _raw_cmd("strict")
+
+
+def test_raw_accept_new_emits_accept_new():
+    assert "StrictHostKeyChecking=accept-new" in _raw_cmd("accept-new")
+
+
+def test_raw_default_is_accept_new():
+    assert "StrictHostKeyChecking=accept-new" in _raw_cmd(None)

--- a/tests/test_r12b_hostkey_policy.py
+++ b/tests/test_r12b_hostkey_policy.py
@@ -116,3 +116,31 @@ def test_raw_accept_new_emits_accept_new():
 
 def test_raw_default_is_accept_new():
     assert "StrictHostKeyChecking=accept-new" in _raw_cmd(None)
+
+
+# ------------------------------------ threading parity guard (silent-degrade regression)
+
+
+def test_every_handler_threading_ssh_sudo_also_threads_host_key_policy():
+    """Silent-degrade guard: any CLI handler that threads a target's ssh_sudo into endpoint
+    config MUST also thread ssh_host_key_policy -- else a config'd `strict` is silently
+    ignored on that command (the R12b review found exactly this gap on `run`). Scans the
+    cli/ handlers; if one reads target.ssh_sudo it must also read target.ssh_host_key_policy."""
+    import pathlib
+
+    cli_dir = pathlib.Path("src/btrfs_backup_ng/cli")
+    offenders = []
+    for f in cli_dir.glob("*.py"):
+        text = f.read_text()
+        # A handler does CONFIG-driven ssh threading if it assigns/branches on a target's
+        # ssh_sudo (not merely displays it). Such a handler must also thread the policy from
+        # the target. (Arg-driven handlers like restore thread it from args instead.)
+        threads_config_ssh = (
+            "= target.ssh_sudo" in text or "if target.ssh_sudo:" in text
+        )
+        if threads_config_ssh and "target.ssh_host_key_policy" not in text:
+            offenders.append(f.name)
+    assert offenders == [], (
+        f"these handlers thread target.ssh_sudo but not ssh_host_key_policy "
+        f"(strict would silently degrade): {offenders}"
+    )


### PR DESCRIPTION
## R12b — Configurable host-key policy

Turns the host-key posture into one explicit knob (`accept-new` default | `strict`) instead of the three hardcoded, divergent postures. Builds on R12a.

### Config
- New `ssh_host_key_policy` (default `accept-new`) on `TargetConfig` **and** `RawTargetConfig`.
- The loader **fails closed** on an unrecognized value — a security selector must never silently degrade to a default (a typo'd `strict` → `ConfigError`, not `accept-new`). Only the two safe modes exist; there's no `off`.

### CLI
- `--ssh-host-key-policy accept-new|strict` via a shared `add_ssh_hostkey_arg` helper, on the ssh-capable subcommands (restore/verify/estimate). `default=None` so an unset flag never overrides a config-file setting.

### Threaded to all three transports
| Transport | `strict` | `accept-new` |
|---|---|---|
| subprocess (`master.py`) | `StrictHostKeyChecking=yes` | `=accept-new` |
| paramiko (`ssh.py`) | `RejectPolicy` (unknown refused) | `AutoAddPolicy` |
| raw+ssh (`raw.py`) | `StrictHostKeyChecking=yes` | `=accept-new` |

A **changed** key is rejected under *both* policies (the loaded known_hosts raises `BadHostKeyException` before the missing-key policy is consulted). The config-restore whitelist carries the key to the transport; both the config path (transfer/prune/estimate) and the arg path (restore/verify/estimate) thread it.

### Behavior note
raw+ssh previously set **no** `StrictHostKeyChecking` (inherited the ambient default → *accidentally* refused unknown hosts under `BatchMode`). It now emits an explicit policy, unifying it with the btrfs transport: **default becomes `accept-new`**; set `strict` to restore refuse-unknown.

### Verification
- **Tier1 2589 passed**, ruff + mypy clean.
- New `tests/test_r12b_hostkey_policy.py` (11 tests), **mutation-verified** across all four points: loader fail-closed, master `strict`/`accept-new`, paramiko `RejectPolicy`/`AutoAddPolicy` (also guards the config whitelist — drop the key there → strict silently degrades → test fails), raw `strict`/`accept-new`.
- **Hardware-confirmed** on a real host: `strict` → "Host key verification failed" (unknown refused), `accept-new` → connects.

### Scope / follow-ons
Deferred: per-invocation flag on the snapper subcommands (their config path already honors it); **R12c** (control-socket-dir hijack + `/tmp` lock race); **R12d** (cleanup + docs).

No AI/tool attribution.