### PR TITLE
fix(ssh): harden control-socket dir + command lock against predictable-path races (R12c)

### DIFF
--- a/src/btrfs_backup_ng/endpoint/common.py
+++ b/src/btrfs_backup_ng/endpoint/common.py
@@ -3,10 +3,11 @@ Common functionality among modules.
 """
 
 import contextlib
-import getpass
 import logging
 import os
+import stat
 import subprocess
+import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -17,6 +18,53 @@ from btrfs_backup_ng.__logger__ import logger
 from btrfs_backup_ng.core.space import SpaceInfo
 from btrfs_backup_ng.core.space import get_space_info as _get_space_info
 from btrfs_backup_ng.endpoint.raw_metadata import StructureVerdict
+
+
+def _secure_lock_dir(base: Path, euid: int) -> Optional[Path]:
+    """Return a euid-owned 0700 ``btrfs-backup-ng-<euid>`` subdir of ``base`` for lock files,
+    or None if it cannot be secured (a pre-planted symlink or foreign-owned dir at that
+    predictable name). Placing the lock INSIDE a private 0700 dir means no untrusted symlink
+    can be planted at the lock path itself -- this closes the check-then-open TOCTOU that a
+    bare /tmp lock has (the filelock library opens O_TRUNC without O_NOFOLLOW). R12c/P5."""
+    d = base / f"btrfs-backup-ng-{euid}"
+    try:
+        d.mkdir(mode=0o700, exist_ok=True)
+        st = os.lstat(d)  # lstat: a symlink is seen AS a symlink, not its target
+    except OSError:
+        return None
+    if (
+        not stat.S_ISDIR(st.st_mode)
+        or st.st_uid != euid
+        or stat.S_IMODE(st.st_mode) != 0o700
+    ):
+        return None
+    return d
+
+
+def _command_lock_path() -> Path:
+    """Stable per-euid path for the btrfs-command serialization lock, placed INSIDE a
+    euid-owned 0700 directory so it is immune to a symlink race in world-writable /tmp
+    (R12c/P5). Prefer ``$XDG_RUNTIME_DIR`` (euid-owned); else a verified
+    ``/tmp/btrfs-backup-ng-<euid>``. Fails CLOSED if neither can be secured -- never follows
+    an attacker-controlled path to truncate a victim file."""
+    euid = os.geteuid()
+    xdg = os.environ.get("XDG_RUNTIME_DIR")
+    if xdg and os.path.isdir(xdg) and not os.path.islink(xdg):
+        try:
+            if os.stat(xdg).st_uid == euid:
+                d = _secure_lock_dir(Path(xdg), euid)
+                if d is not None:
+                    return d / "command.lock"
+        except OSError:
+            pass
+    d = _secure_lock_dir(Path(tempfile.gettempdir()), euid)
+    if d is None:
+        raise __util__.AbortError(
+            f"Refusing to proceed: cannot secure a lock directory "
+            f"(a symlink or foreign-owned btrfs-backup-ng-{euid} is present in the temp "
+            f"dir -- remove it)"
+        )
+    return d / "command.lock"
 
 
 def require_source(method):
@@ -938,7 +986,7 @@ class Endpoint:
         # Convert all command arguments to strings for subprocess
         command = [str(arg) for arg in command]
         logger.debug("Executing command: %s", command)
-        lock_path = Path("/tmp") / f".btrfs-backup-ng.{getpass.getuser()}.lock"
+        lock_path = _command_lock_path()
 
         try:
             with FileLock(lock_path):

--- a/src/btrfs_backup_ng/sshutil/master.py
+++ b/src/btrfs_backup_ng/sshutil/master.py
@@ -1,13 +1,34 @@
+import atexit
 import getpass
 import os
 import pwd
 import shutil
 import subprocess
+import tempfile
 import threading
 from pathlib import Path
 from typing import List, Optional
 
 from btrfs_backup_ng.__logger__ import logger
+
+
+def _control_dir_base() -> Optional[str]:
+    """Base dir for the (mkdtemp) ControlMaster socket dir.
+
+    Prefer ``$XDG_RUNTIME_DIR`` (tmpfs, auto-cleaned on logout) BUT only when it is owned by
+    the current euid -- so under sudo we never place root's control socket inside the
+    invoking user's runtime dir (where they could tamper with or DoS it). Otherwise return
+    None so tempfile falls back to its default ($TMPDIR / /tmp); the unpredictable 0700
+    mkdtemp name is hijack-safe there regardless."""
+    xdg = os.environ.get("XDG_RUNTIME_DIR")
+    if xdg:
+        try:
+            st = os.stat(xdg)
+            if st.st_uid == os.geteuid() and os.path.isdir(xdg):
+                return xdg
+        except OSError:
+            pass
+    return None
 
 
 def operator_ssh_dir() -> Path:
@@ -143,15 +164,23 @@ class SSHMasterManager:
 
         if control_dir:
             self.control_dir = Path(control_dir)
+            self.control_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+            self._own_control_dir = False
         else:
-            if self.running_as_sudo:
-                self.control_dir = Path(f"/tmp/ssh-controlmasters-{self.sudo_user}")
-            else:
-                self.control_dir = self.ssh_config_dir / "controlmasters"
+            # Create the ControlMaster socket dir with tempfile.mkdtemp: an UNPREDICTABLE,
+            # 0700, euid-owned directory. The old predictable /tmp/ssh-controlmasters-<user>
+            # + mkdir(exist_ok=True) let a local attacker pre-create the dir and capture the
+            # control socket -- which carries root's authenticated ssh to the backup host
+            # (socket hijack -> command execution as root@remote). An unguessable name that
+            # only euid owns closes it by design; the socket name already embeds pid+tid, so
+            # nothing relied on a stable path. R12c/P2.
+            self.control_dir = Path(
+                tempfile.mkdtemp(prefix="btrfs-backup-ng-cm-", dir=_control_dir_base())
+            )
+            self._own_control_dir = True
+            # Backstop cleanup if stop_master()/cleanup_socket() is never reached.
+            atexit.register(shutil.rmtree, str(self.control_dir), ignore_errors=True)
 
-        # parents=True so a missing ~/.ssh (fresh account, CI, container) does not
-        # break endpoint construction with FileNotFoundError.
-        self.control_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
         self._instance_id = f"{os.getpid()}_{threading.get_ident()}"
         self.control_path = (
             self.control_dir
@@ -689,6 +718,7 @@ class SSHMasterManager:
             try:
                 subprocess.run(cmd, check=True, capture_output=True)
                 self._master_started = False
+                self._cleanup_control_dir()  # deterministic teardown (R12c/P2)
                 return True
             except Exception as e:
                 logger.error(f"Failed to stop SSH master: {e}")
@@ -719,12 +749,20 @@ class SSHMasterManager:
             return False
 
     def cleanup_socket(self) -> None:
-        """Clean up the control socket file."""
+        """Clean up the control socket file (and our private mkdtemp dir, if we own it)."""
         try:
             if self.control_path.exists():
                 self.control_path.unlink()
         except Exception as e:
             logger.error(f"Failed to cleanup socket: {e}")
+        self._cleanup_control_dir()
+
+    def _cleanup_control_dir(self) -> None:
+        """Remove the unpredictable per-manager control dir we created (R12c/P2), so it does
+        not linger in $XDG_RUNTIME_DIR / /tmp. Idempotent + best-effort; an explicit
+        control_dir override (``_own_control_dir`` False) is never removed."""
+        if getattr(self, "_own_control_dir", False):
+            shutil.rmtree(self.control_dir, ignore_errors=True)
 
     def get_ssh_base_cmd(self, force_tty: bool = False) -> List[str]:
         """Get the base SSH command with all necessary options.

--- a/tests/integration/test_endpoints.py
+++ b/tests/integration/test_endpoints.py
@@ -546,7 +546,15 @@ class TestEndpointCommandExecution:
         )
 
         cmd = [("btrfs", False), ("subvolume", False), ("list", False)]
-        endpoint._exec_command({"command": cmd})
+        # This test mocks os.geteuid()->0 to exercise the root/no-sudo path; the R12c
+        # per-euid lock dir verifies ownership against that (mocked) euid, which would
+        # mismatch the real-uid-owned dir. The lock is not under test here (FileLock is
+        # already mocked), so stub the path computation.
+        with patch(
+            "btrfs_backup_ng.endpoint.common._command_lock_path",
+            return_value=tmp_path / "cmd.lock",
+        ):
+            endpoint._exec_command({"command": cmd})
 
         # Verify sudo was NOT prepended
         called_cmd = mock_exec.call_args[0][0]

--- a/tests/integration/test_endpoints.py
+++ b/tests/integration/test_endpoints.py
@@ -519,7 +519,14 @@ class TestEndpointCommandExecution:
         )
 
         cmd = [("btrfs", False), ("subvolume", False), ("list", False)]
-        endpoint._exec_command({"command": cmd})
+        # os.geteuid() is mocked here; the R12c per-euid lock dir verifies ownership against
+        # that mocked euid, which mismatches the real-uid-owned dir on a CI runner. The lock
+        # is not under test (FileLock is mocked), so stub the path computation.
+        with patch(
+            "btrfs_backup_ng.endpoint.common._command_lock_path",
+            return_value=tmp_path / "cmd.lock",
+        ):
+            endpoint._exec_command({"command": cmd})
 
         # Verify sudo was prepended
         called_cmd = mock_exec.call_args[0][0]

--- a/tests/test_r12c_control_lock_hardening.py
+++ b/tests/test_r12c_control_lock_hardening.py
@@ -1,0 +1,133 @@
+"""R12c -- control-socket dir + command-lock path hardening.
+
+P2: the ControlMaster socket dir is now an UNPREDICTABLE, 0700, euid-owned mkdtemp dir
+(prefer $XDG_RUNTIME_DIR base), removed on cleanup -- the old predictable
+/tmp/ssh-controlmasters-<user> + mkdir(exist_ok=True) was a socket-hijack vector.
+
+P5: the per-user btrfs-command lock lives in a euid-owned dir when possible, and FAILS
+CLOSED (never follows) a symlink planted at the /tmp fallback path.
+"""
+
+import os
+import stat
+
+import pytest
+
+from btrfs_backup_ng import __util__
+from btrfs_backup_ng.endpoint import common as common_mod
+from btrfs_backup_ng.endpoint.common import _command_lock_path
+from btrfs_backup_ng.sshutil import master as master_mod
+from btrfs_backup_ng.sshutil.master import SSHMasterManager, _control_dir_base
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("SUDO_USER", raising=False)
+
+
+# ------------------------------------ P2: control-socket dir
+
+
+def _mgr():
+    return SSHMasterManager(hostname="h", username="u")
+
+
+def test_control_dir_is_unpredictable_and_0700():
+    """mkdtemp -> random name + 0700 + euid-owned. Mutation guard: revert to the predictable
+    /tmp/ssh-controlmasters-<user> and the random-suffix assertion fails."""
+    m = _mgr()
+    try:
+        assert m._own_control_dir is True
+        assert "btrfs-backup-ng-cm-" in m.control_dir.name
+        st = m.control_dir.stat()
+        assert stat.S_IMODE(st.st_mode) == 0o700
+        assert st.st_uid == os.geteuid()
+    finally:
+        m.cleanup_socket()
+
+
+def test_two_managers_get_distinct_control_dirs():
+    a, b = _mgr(), _mgr()
+    try:
+        assert a.control_dir != b.control_dir  # unpredictable -> no collision/hijack
+    finally:
+        a.cleanup_socket()
+        b.cleanup_socket()
+
+
+def test_cleanup_removes_owned_control_dir():
+    m = _mgr()
+    d = m.control_dir
+    assert d.exists()
+    m.cleanup_socket()
+    assert not d.exists()  # our private dir is torn down
+
+
+def test_explicit_control_dir_is_respected_and_not_removed(tmp_path):
+    """An explicit control_dir override is used as-is and NEVER removed by cleanup."""
+    d = tmp_path / "explicit"
+    m = SSHMasterManager(hostname="h", username="u", control_dir=str(d))
+    assert m._own_control_dir is False
+    assert m.control_dir == d
+    m.cleanup_socket()
+    assert d.exists()  # not ours to remove
+
+
+def test_control_dir_base_requires_euid_ownership(tmp_path, monkeypatch):
+    """$XDG_RUNTIME_DIR is used as the mkdtemp base only when euid-owns it -- so under sudo
+    we never place root's socket inside a non-root user's runtime dir."""
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    assert _control_dir_base() == str(tmp_path)  # owned by us -> used
+    monkeypatch.setattr(master_mod.os, "geteuid", lambda: 999999)
+    assert _control_dir_base() is None  # not euid-owned -> refused
+
+
+# ------------------------------------ P5: command-lock path
+
+
+def test_command_lock_path_prefers_owned_xdg(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    p = _command_lock_path()
+    assert p == tmp_path / f"btrfs-backup-ng-{os.geteuid()}" / "command.lock"
+    assert p.parent.exists() and stat.S_IMODE(p.parent.stat().st_mode) == 0o700
+
+
+def test_command_lock_path_falls_back_to_secure_tmp_dir(tmp_path, monkeypatch):
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    monkeypatch.setattr(common_mod.tempfile, "gettempdir", lambda: str(tmp_path))
+    p = _command_lock_path()
+    # lock lives INSIDE a euid-owned 0700 dir (not bare in /tmp) -> no plantable symlink path
+    assert p == tmp_path / f"btrfs-backup-ng-{os.geteuid()}" / "command.lock"
+    assert stat.S_IMODE(p.parent.stat().st_mode) == 0o700
+
+
+def test_command_lock_path_refuses_symlinked_dir_fail_closed(tmp_path, monkeypatch):
+    """THE P5 guard: if the per-euid lock DIR is a symlink (or foreign-owned), refuse --
+    never place the lock through an attacker path. Mutation guard: drop the lstat S_ISDIR/
+    ownership check and this raises nothing."""
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    monkeypatch.setattr(common_mod.tempfile, "gettempdir", lambda: str(tmp_path))
+    victim = tmp_path / "victim_dir"
+    victim.mkdir()
+    (tmp_path / f"btrfs-backup-ng-{os.geteuid()}").symlink_to(victim)
+    with pytest.raises(__util__.AbortError):
+        _command_lock_path()
+
+
+# ------------------------------------ P2: deterministic cleanup on stop_master
+
+
+def test_stop_master_removes_owned_control_dir(monkeypatch):
+    """stop_master() tears the mkdtemp control dir down deterministically (not only via the
+    atexit backstop). Mutation guard: drop the _cleanup_control_dir() call in stop_master."""
+    import subprocess as sp
+
+    m = _mgr()
+    d = m.control_dir
+    m._master_started = True  # pretend a master is running
+    monkeypatch.setattr(
+        master_mod.subprocess, "run", lambda *a, **k: sp.CompletedProcess(a, 0)
+    )
+    assert m.stop_master() is True
+    assert not d.exists()


### PR DESCRIPTION
## R12c — Control-socket & lock-path hardening

Closes the two predictable-`/tmp` path vulnerabilities from the R12 scout.

### P2 — ControlMaster socket-dir hijack (sudo) 🔴→✅
The socket dir was the predictable `/tmp/ssh-controlmasters-<sudo_user>`, `mkdir(exist_ok=True)` with **no ownership check** — a local attacker pre-creating it captured root's authenticated ControlMaster socket (**→ command execution as root@remote**). Now `tempfile.mkdtemp()` → an **unpredictable, 0700, euid-owned** dir (prefers `$XDG_RUNTIME_DIR` when euid-owned, else `/tmp`), closing the hijack **by design**. The socket name already embeds pid+tid, so nothing relied on a stable path. Removed deterministically on `stop_master()`/`cleanup_socket()` (only our own dir; an explicit `control_dir` override is untouched), atexit backstop.

### P5 — command-lock symlink race ✅
The per-user lock was `/tmp/.btrfs-backup-ng.<user>.lock`, opened by `filelock` with `O_TRUNC` and **no `O_NOFOLLOW`** → a planted symlink (as root) could truncate an arbitrary file. The lock now lives **inside a euid-owned 0700 dir** (`btrfs-backup-ng-<euid>`), so no untrusted symlink can be planted at the lock path at all — eliminating the check-then-open TOCTOU. **Fails closed** if that dir can't be secured.

### Adversarial review (no critical/high) drove two hardenings
The 2-lens review confirmed the core sound and pushed two improvements over the first cut: (1) the P5 lock moved from a bare `/tmp` path + point-in-time `islink()` into a **verified euid-owned dir** (closing the residual `filelock`-`O_TRUNC` TOCTOU it flagged); (2) control-dir cleanup **wired into `stop_master()`** rather than relying only on the atexit backstop.

### Verification
- **Tier1 2599 passed**, ruff + mypy clean.
- New `tests/test_r12c_control_lock_hardening.py` (9 tests), **mutation-verified**: mkdtemp unpredictability/0700/ownership, cleanup on `cleanup_socket` + `stop_master`, explicit-dir respected, XDG-base-requires-euid-ownership, lock in a secure euid-owned dir, and the fail-closed symlinked-dir refusal.
- **Hardware-proven**: a real ssh ControlMaster in the mkdtemp dir multiplexes a command end-to-end (`connected:fedora`) and tears down; the lock resolves to a euid-owned `$XDG_RUNTIME_DIR` dir.

### Remaining R12
**R12d**: dead-file cleanup (`master.py.new`, `ssh_transfer.py`), raw+ssh remote `.meta.tmp` symlink-follow, snapper per-invocation `--ssh-host-key-policy`, docs/manpage + SSH security section — then cut 0.9.1 bundling R12a's GHSA.

No AI/tool attribution.