### PR TITLE
fix(raw+ssh): symlink-safe remote sidecar write + snapper host-key flag (R12d pt1)

### DIFF
--- a/src/btrfs_backup_ng/cli/dispatcher.py
+++ b/src/btrfs_backup_ng/cli/dispatcher.py
@@ -1336,6 +1336,7 @@ Examples:
         metavar="PATH",
         help="Explicit ssh-agent socket (overrides auto-discovery; useful under sudo)",
     )
+    add_ssh_hostkey_arg(snapper_backup)
     snapper_backup.add_argument(
         "--compress",
         metavar="METHOD",
@@ -1459,6 +1460,7 @@ Examples:
         metavar="PATH",
         help="Explicit ssh-agent socket (overrides auto-discovery; useful under sudo)",
     )
+    add_ssh_hostkey_arg(snapper_restore)
     snapper_restore.add_argument(
         "-l",
         "--list",

--- a/src/btrfs_backup_ng/cli/snapper_cmd.py
+++ b/src/btrfs_backup_ng/cli/snapper_cmd.py
@@ -239,6 +239,8 @@ def _handle_backup(args: argparse.Namespace) -> int:
         endpoint_config["ssh_key"] = args.ssh_key
     if getattr(args, "ssh_auth_sock", None):
         endpoint_config["ssh_auth_sock"] = args.ssh_auth_sock
+    if getattr(args, "ssh_host_key_policy", None):
+        endpoint_config["ssh_host_key_policy"] = args.ssh_host_key_policy
     # Encryption for raw targets. Threaded from the CLI flags; fail closed below so
     # this path can never silently write plaintext when encryption was requested.
     encrypt = getattr(args, "encrypt", None) or "none"

--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -1782,8 +1782,8 @@ class SSHRawEndpoint(RawEndpoint):
         # mtime only stat can give, so the preflight must promise what enumeration
         # actually depends on.
         check = (
-            'for t in cat mv chmod stat; do command -v "$t" >/dev/null 2>&1 '
-            "|| exit 1; done; echo RAWSSHOK"
+            'for t in cat mv chmod stat mktemp dirname; do command -v "$t" '
+            ">/dev/null 2>&1 || exit 1; done; echo RAWSSHOK"
         )
         res = self._exec_remote_command(["sh", "-c", check], check=False)
         out = res.stdout
@@ -2100,11 +2100,18 @@ class SSHRawEndpoint(RawEndpoint):
         return so a maintenance command can tell whether the write succeeded; the
         engine's commit path wraps this to stay best-effort."""
         meta = str(snapshot.metadata_path)
-        tmp = f"{meta}.tmp"
+        meta_q = shlex.quote(meta)
+        # Write the sidecar to an UNPREDICTABLE remote temp (mktemp), then mv it atomically
+        # into place. The old predictable ``<meta>.tmp`` let a local user ON THE REMOTE plant
+        # a symlink at that guessable path so ``cat >`` followed it and truncated an arbitrary
+        # file the remote (sudo) user can write -- an unguessable mktemp name closes that by
+        # design (R12d/P6). A ``trap`` removes the temp on any failure; the name avoids
+        # ``.btrfs``/``.meta`` so a leaked temp is never mis-enumerated as a stream/sidecar.
         script = (
-            f"cat > {shlex.quote(tmp)} && sync && "
-            f"mv -f {shlex.quote(tmp)} {shlex.quote(meta)} && "
-            f"chmod 600 {shlex.quote(meta)}"
+            f"set -e; d=$(dirname -- {meta_q}); "
+            'tmp=$(mktemp "$d/.sidecar-tmp.XXXXXX"); '
+            "trap 'rm -f -- \"$tmp\"' EXIT; "
+            f'cat > "$tmp"; chmod 600 "$tmp"; sync; mv -f -- "$tmp" {meta_q}'
         )
         result = self._exec_remote_command(
             ["sh", "-c", script], input=snapshot.serialize(), check=False

--- a/tests/test_r12b_hostkey_policy.py
+++ b/tests/test_r12b_hostkey_policy.py
@@ -144,3 +144,20 @@ def test_every_handler_threading_ssh_sudo_also_threads_host_key_policy():
         f"these handlers thread target.ssh_sudo but not ssh_host_key_policy "
         f"(strict would silently degrade): {offenders}"
     )
+
+
+# ------------------------------------ R12d: snapper subcommands get the flag (R12b deferral)
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["snapper", "backup", "--ssh-host-key-policy", "strict", "src", "ssh://h/p"],
+        ["snapper", "restore", "--ssh-host-key-policy", "strict", "ssh://h/p", "/dest"],
+    ],
+)
+def test_snapper_subcommands_accept_ssh_host_key_policy(argv):
+    from btrfs_backup_ng.cli.dispatcher import create_subcommand_parser
+
+    ns = create_subcommand_parser().parse_args(argv)
+    assert ns.ssh_host_key_policy == "strict"

--- a/tests/test_raw_sidecar_writer.py
+++ b/tests/test_raw_sidecar_writer.py
@@ -78,8 +78,10 @@ def test_local_and_remote_sidecar_bytes_are_identical(tmp_path):
 
 
 def test_ssh_write_sidecar_builds_atomic_script_at_meta_path():
-    """The remote write is atomic (temp -> sync -> mv -> chmod 600) and targets
-    exactly ``<stream>.meta``."""
+    """The remote write is atomic and targets exactly ``<stream>.meta``, via an
+    UNPREDICTABLE mktemp temp (R12d/P6) -- NOT the old predictable ``<meta>.tmp`` a
+    remote user could pre-symlink. Mutation guard: revert to ``cat > <meta>.tmp`` and the
+    'no predictable temp' assertion fails."""
     ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
     ep._exec_remote_command = MagicMock(
         return_value=MagicMock(returncode=0, stderr=b"", stdout=b"")
@@ -89,10 +91,12 @@ def test_ssh_write_sidecar_builds_atomic_script_at_meta_path():
 
     script = ep._exec_remote_command.call_args[0][0][2]
     assert str(snap.metadata_path) == "/backup/snap.btrfs.meta"
-    assert "/backup/snap.btrfs.meta.tmp" in script
-    assert "sync &&" in script
-    assert "mv -f" in script
+    # unpredictable temp + atomic mv into the real meta path; no guessable temp path
+    assert "mktemp" in script
+    assert "/backup/snap.btrfs.meta.tmp" not in script
+    assert 'mv -f -- "$tmp" /backup/snap.btrfs.meta' in script
     assert "chmod 600" in script
+    assert "trap" in script  # temp cleaned up on failure
 
 
 def test_ssh_write_sidecar_raises_on_remote_failure():


### PR DESCRIPTION
## R12d Part 1 — remote sidecar symlink fix (P6) + snapper host-key flag

The **code** half of the R12 closeout (Part 2 = dead-file cleanup + docs).

### P6 🟡→✅ — raw+ssh remote sidecar symlink-follow
`SSHRawEndpoint.write_sidecar` wrote to a **predictable** remote temp `<meta>.tmp` via `cat >`, which **follows a symlink**. A local user *on the remote target* could plant a symlink at that guessable path and redirect/truncate a file the remote (sudo) user can write. The write now goes to an **unpredictable** remote temp (`mktemp` in the target dir — name avoids `.btrfs`/`.meta` so a leaked temp is never mis-enumerated), then `mv -f` atomically into place at 0600, with a `trap` that removes the temp on any failure. `mktemp`/`dirname` added to the raw+ssh POSIX-tools preflight.

### Snapper `--ssh-host-key-policy` (the R12b deferral)
The flag is now on `snapper backup`/`snapper restore` and threaded into the destination endpoint config, so snapper `ssh://` / `raw+ssh://` targets honor `strict`/`accept-new` per invocation.

### Verification
- **Tier1 2601 passed**, ruff + mypy clean.
- `write_sidecar` test asserts the mktemp/atomic-mv script and the **absence** of the predictable `<meta>.tmp` (**mutation-verified**: reverting to `cat > <meta>.tmp` fails it); snapper backup+restore flag parsing tested.
- **Hardware-proven on a real remote (`.70`)**: the sidecar lands atomically at 0600, and a symlink planted at the old predictable `<meta>.tmp` is **bypassed entirely** — the victim file is left intact and the trap cleans the temp.

### Remaining
**R12d Part 2**: delete dead files (`master.py.new`, `ssh_transfer.py`), docs/manpage + SSH security section — then cut **0.9.1** bundling R12a's GHSA.

No AI/tool attribution.