### PR TITLE
chore: bump version to 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Targeted for **0.9.1** — the verification and SSH-security hardening release.
+## [0.9.1] - 2026-07-27
+
+The verification and SSH-security hardening release.
 
 ### Security
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ where = ["src"]
 
 [project]
 name = "btrfs-backup-ng"
-version = "0.9.0"
+version = "0.9.1"
 description = "Complete btrfs backup solution with automated snapshots, incremental transfers, restore functionality, snapper integration, and systemd scheduling"
 authors = [{ name = "Michael Berry", email = "trismegustis@gmail.com" }]
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Release prep — 0.9.1

Bumps `pyproject.toml` `version` 0.9.0 → **0.9.1** and finalizes the CHANGELOG `[0.9.1]` entry. `__version__` is metadata-derived, so this is the only version string to change.

**0.9.1 bundles** (all merged since 0.9.0):
- **R8** — verification that actually verifies (structure, sealed checksums, standalone full-restore; honest output + `verdict`).
- **R7** — crash-atomic state/manifest/lock persistence.
- **R12 (a–d)** — the SSH-security overhaul: host-key **MITM** fix, configurable `ssh_host_key_policy`, control-socket/lock/remote-sidecar predictable-path hardening, dead-file cleanup + docs.

**Verified locally:** `python -m build` (wheel + sdist) + `twine check` PASSED; fresh-venv install resolves `__version__ = 0.9.1`.

### Release order (after this merges) — deliberately staged
1. GitHub Release **`v0.9.1`** → `release.yml` trusted-publishing → PyPI.
2. **Verify PyPI serves 0.9.1** (wheel + sdist, fresh-venv `__version__`).
3. **Then** publish the GHSA for the R12a host-key MITM (CWE-295, Moderate) — *not before an installable fix is on PyPI*.

No AI/tool attribution.