### PR TITLE
docs: document ssh_host_key_policy across README + per-command manpages

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ incremental transfers, and time-based retention.
 
 Actively developed, pre-1.0, with a strong emphasis on data integrity. Backup and restore
 across local, SSH, and raw targets are working and have been adversarially tested and
-verified byte-identical on real hardware. A reliability-hardening roadmap (lock
-persistence, retention edge cases, deeper verification, SSH hardening) is tracked in
-[#20](https://github.com/berrym/btrfs-backup-ng/issues/20). As with any backup tool, test
+verified byte-identical on real hardware. Much of the reliability-and-security hardening
+roadmap has now shipped — retention correctness and the incremental-backup engine in 0.9.0,
+and deeper verification, crash-atomic state/lock persistence, and SSH security (host-key
+verification / MITM mitigation) in 0.9.1 (tracked in
+[#20](https://github.com/berrym/btrfs-backup-ng/issues/20)). As with any backup tool, test
 your restores.
 
 ## Heritage
@@ -74,7 +76,7 @@ See the [LICENSE](LICENSE) file for full copyright attribution.
 - **Parallel Execution**: Concurrent volume and target transfers
 - **Stream Compression**: zstd, gzip, lz4, pigz, lzop support
 - **Bandwidth Throttling**: Rate limiting for remote transfers
-- **Robust SSH**: Password fallback, sudo support, Paramiko integration
+- **Robust SSH**: Host-key verification (accept-new/strict, MITM-safe), password fallback, sudo support
 
 ### Raw Targets (Non-btrfs Destinations)
 - **Write to Files**: Store btrfs send streams as files on any filesystem (NFS, SMB, cloud storage)
@@ -586,6 +588,7 @@ path = "ssh://user@host:/backups"      # SSH remote path
 ssh_sudo = true                        # Use sudo on remote
 ssh_port = 22                          # SSH port
 ssh_key = "~/.ssh/backup_key"          # SSH private key
+ssh_host_key_policy = "accept-new"     # Host-key policy: accept-new (default) | strict
 ssh_password_auth = true               # Allow password fallback
 compress = "zstd"                      # Compression (none|gzip|zstd|lz4|pigz|lzop)
 rate_limit = "10M"                     # Bandwidth limit (K|M|G suffix)
@@ -1080,6 +1083,13 @@ path = "ssh://backup@remote-server:/mnt/backups/home"
 ssh_sudo = true                           # Required for btrfs receive
 ssh_key = "~/.ssh/btrfs-backup-key"       # Path to private key
 ```
+
+> **Host-key verification:** on first connection btrfs-backup-ng trusts and pins the server's
+> SSH key (`accept-new`), then refuses to connect if that key later changes. Add
+> `ssh_host_key_policy = "strict"` to require the host already be present in `known_hosts`.
+> Under `sudo`, keys are checked against the *invoking* user's `~/.ssh/known_hosts`, so running
+> `ssh-keyscan remote-server >> ~/.ssh/known_hosts` (as your normal user) before the first
+> automated run avoids any first-contact prompt.
 
 ### Step 6: Running Backups with sudo Locally
 

--- a/man/man1/btrfs-backup-ng-estimate.1
+++ b/man/man1/btrfs-backup-ng-estimate.1
@@ -53,6 +53,9 @@ Use sudo for btrfs commands on the remote host.
 .TP
 .BI \-\-ssh-key " FILE"
 Path to SSH private key file.
+.TP
+.BI \-\-ssh-host-key-policy " POLICY"
+Host-key verification for this run: \fBaccept-new\fR (default) or \fBstrict\fR.
 .SS Space Checking Options
 .TP
 .B \-\-check-space

--- a/man/man1/btrfs-backup-ng-restore.1
+++ b/man/man1/btrfs-backup-ng-restore.1
@@ -89,6 +89,9 @@ Use sudo for btrfs commands on the remote host.
 .TP
 .BI \-\-ssh-key " FILE"
 Path to SSH private key file.
+.TP
+.BI \-\-ssh-host-key-policy " POLICY"
+Host-key verification for this run: \fBaccept-new\fR (default) or \fBstrict\fR.
 .SS Other Options
 .TP
 .BI \-\-prefix " PREFIX"

--- a/man/man1/btrfs-backup-ng-snapper.1
+++ b/man/man1/btrfs-backup-ng-snapper.1
@@ -101,6 +101,15 @@ Default: zstd for SSH targets, none for local.
 .BI \-\-rate-limit " RATE"
 Bandwidth limit for transfers. Examples: 10M, 1G, 500K.
 .TP
+.B \-\-ssh-sudo
+Use sudo for btrfs commands on the remote host (SSH / raw+ssh targets).
+.TP
+.BI \-\-ssh-key " FILE"
+Path to SSH private key file.
+.TP
+.BI \-\-ssh-host-key-policy " POLICY"
+Host-key verification: \fBaccept-new\fR (default) or \fBstrict\fR.
+.TP
 .B \-\-dry-run
 Show what would be backed up without making changes.
 .TP
@@ -130,6 +139,15 @@ Restore specific snapshot number. Can be specified multiple times.
 .TP
 .BR \-a ", " \-\-all
 Restore all available backups.
+.TP
+.B \-\-ssh-sudo
+Use sudo for btrfs commands on the remote host (SSH / raw+ssh targets).
+.TP
+.BI \-\-ssh-key " FILE"
+Path to SSH private key file.
+.TP
+.BI \-\-ssh-host-key-policy " POLICY"
+Host-key verification: \fBaccept-new\fR (default) or \fBstrict\fR.
 .TP
 .B \-\-dry-run
 Show what would be restored without making changes.

--- a/man/man1/btrfs-backup-ng-verify.1
+++ b/man/man1/btrfs-backup-ng-verify.1
@@ -87,6 +87,9 @@ Use sudo for btrfs commands on remote host.
 .BI \-\-ssh-key " " \fIFILE\fR
 SSH private key file for authentication.
 .TP
+.BI \-\-ssh-host-key-policy " " \fIPOLICY\fR
+Host-key verification for this run: \fBaccept-new\fR (default) or \fBstrict\fR.
+.TP
 .BI \-\-fs-checks " " \fIMODE\fR
 Filesystem verification mode. Valid values:
 .RS


### PR DESCRIPTION
Fills the documentation gaps left after the 0.9.1 SSH-security work — `ssh_host_key_policy` was only in the main manpage + CLI-REFERENCE.

- **README**: added `ssh_host_key_policy` to the SSH target config example; host-key verification in the features list; a host-key note (accept-new/strict + sudo `known_hosts`/`ssh-keyscan` tip) in the SSH Remote Backup Setup walkthrough; and corrected the intro that still listed verification/persistence/SSH-hardening as *tracked/future* (they shipped in 0.9.0/0.9.1).
- **Manpages**: `--ssh-host-key-policy` added to restore/verify/estimate; and the SSH options block (incl. the new flag) added to `snapper backup`/`restore`, which documented **none** of their ssh flags before.

Docs only. All manpages render clean under `groff -mandoc`. MIGRATING/SNAPPER config examples left as-is (the option is optional, defaults to accept-new).

No AI/tool attribution.