### PR TITLE
R11: Restore snapper backups from raw:// / raw+ssh:// targets

### DIFF
--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -908,7 +908,24 @@ btrfs-backup-ng snapper restore /mnt/backup/root --config root --all
 
 # Dry run
 btrfs-backup-ng snapper restore /mnt/backup/root --config root --all --dry-run
+
+# Restore a root-owned raw+ssh:// backup (written with --ssh-sudo): pass it again
+btrfs-backup-ng snapper restore raw+ssh://user@host/backups/root --config root --snapshot 559 --ssh-sudo
 ```
+
+> **Note — snapper daemon cache.** A restored snapshot is written directly into
+> `.snapshots/{N}/` (not via `snapper create`), so `snapperd` does not see it until it
+> rescans. Run `snapper -c <config> list` (or reboot) after a restore before using
+> `snapper diff`, `snapper undochange`, or a rollback against the restored snapshot; the
+> restore command prints a reminder. The on-disk snapshot is complete and correct — this
+> only affects the daemon's in-memory view. Restored slots use snapper's native `0755`
+> permissions on `.snapshots/{N}/`.
+
+> **Note — duplicate snapper numbers.** Snapper reuses snapshot numbers after a prune, so a
+> `raw://` / `raw+ssh://` target can accumulate two retained backups with the same number
+> (they differ by the date in the backup name). `--snapshot N` restores the **newest** of
+> them by date and warns; addressing an older same-number copy by name/date is a planned
+> enhancement.
 
 #### snapper generate-config
 

--- a/docs/SNAPPER-INTEGRATION.md
+++ b/docs/SNAPPER-INTEGRATION.md
@@ -101,6 +101,13 @@ btrfs-backup-ng snapper restore /mnt/backup/root --config root --list
 btrfs-backup-ng snapper restore /mnt/backup/root --config root --snapshot 559
 ```
 
+A restored snapshot lands in the config's `.snapshots/{N}/` and integrates with snapper —
+but the snapper **daemon** caches its snapshot list, so run `snapper -c root list` (or
+reboot) after a restore before `snapper diff`/`undochange`/rollback against it (the restore
+command reminds you). To roll back, prefer snapper's own flow: boot the read-only
+grub-btrfs entry, then `snapper rollback`. For a root-owned `raw+ssh://` backup written with
+`--ssh-sudo`, pass `--ssh-sudo` to `restore` too.
+
 ## Configuration
 
 ### Using Config Files

--- a/man/man1/btrfs-backup-ng-snapper.1
+++ b/man/man1/btrfs-backup-ng-snapper.1
@@ -154,6 +154,19 @@ Show what would be restored without making changes.
 .TP
 .B \-\-json
 Output in JSON format (with \fB\-\-list\fR).
+.PP
+A restored snapshot is written directly into \fI.snapshots/{N}/\fR (not via
+\fBsnapper create\fR), so the Snapper daemon does not see it until it rescans. Run
+\fBsnapper \-c \fICONFIG\fB list\fR (or reboot) after a restore before using
+\fBsnapper diff\fR, \fBsnapper undochange\fR, or a rollback against it; the command
+prints a reminder. The on\-disk snapshot is complete and correct \(em only the daemon's
+in\-memory view lags. Restored slots use Snapper's native \fB0755\fR directory mode.
+.PP
+For a \fBraw+ssh://\fR source written with \fB\-\-ssh-sudo\fR (root\-owned remote
+directory), pass \fB\-\-ssh-sudo\fR to \fBrestore\fR as well, or it will report a
+permission error instead of the backups. When Snapper has reused a number after a prune,
+a raw target can hold two backups with the same number; \fB\-\-snapshot \fINUM\fR restores
+the newest by date and warns.
 .SS status
 Show backup status for Snapper configurations.
 .PP

--- a/src/btrfs_backup_ng/cli/snapper_cmd.py
+++ b/src/btrfs_backup_ng/cli/snapper_cmd.py
@@ -519,10 +519,25 @@ def _handle_restore(args: argparse.Namespace) -> int:
 
     source_path = args.source
 
+    # Thread SSH options so a raw+ssh:// source written with --ssh-sudo (root-owned
+    # remote dir/streams) is READ BACK with the same options -- else the remote
+    # ls/cat run without sudo and the backups enumerate as empty (mirrors how the
+    # backup path builds its endpoint config).
+    endpoint_options: dict[str, Any] = {}
+    if getattr(args, "ssh_sudo", False):
+        endpoint_options["ssh_sudo"] = True
+    if getattr(args, "ssh_key", None):
+        endpoint_options["ssh_identity_file"] = args.ssh_key
+        endpoint_options["ssh_key"] = args.ssh_key
+    if getattr(args, "ssh_auth_sock", None):
+        endpoint_options["ssh_auth_sock"] = args.ssh_auth_sock
+    if getattr(args, "ssh_host_key_policy", None):
+        endpoint_options["ssh_host_key_policy"] = args.ssh_host_key_policy
+
     # List mode - show available backups
     if args.list:
         try:
-            backups = list_snapper_backups(source_path)
+            backups = list_snapper_backups(source_path, endpoint_options)
         except Exception as e:
             if args.json:
                 print(json.dumps({"error": str(e)}))
@@ -589,7 +604,7 @@ def _handle_restore(args: argparse.Namespace) -> int:
 
     # Get available backups
     try:
-        backups = list_snapper_backups(source_path)
+        backups = list_snapper_backups(source_path, endpoint_options)
     except Exception as e:
         logger.error("Failed to list backups: %s", e)
         return 1
@@ -652,6 +667,7 @@ def _handle_restore(args: argparse.Namespace) -> int:
                 parent_backup_number=parent_num,
                 options=options,
                 dry_run=args.dry_run,
+                endpoint_options=endpoint_options,
             )
 
             if not args.dry_run:

--- a/src/btrfs_backup_ng/cli/snapper_cmd.py
+++ b/src/btrfs_backup_ng/cli/snapper_cmd.py
@@ -686,6 +686,17 @@ def _handle_restore(args: argparse.Namespace) -> int:
     logger.info("  Restored: %d", restored_count)
     logger.info("  Failed: %d", failed_count)
 
+    # snapperd caches its snapshot list, so a slot created out-of-band (here, not via
+    # `snapper create`) is not visible to `snapper diff`/`undochange`/etc. until the
+    # daemon rescans. Nudge the user -- `snapper list` (or a reboot) triggers the rescan.
+    if restored_count > 0 and not args.dry_run:
+        logger.info("")
+        logger.info(
+            "Note: run 'snapper -c %s list' (or reboot) so snapper's daemon picks up "
+            "the restored snapshot(s) before 'snapper diff'/'undochange'/rollback.",
+            args.config,
+        )
+
     return 1 if failed_count > 0 else 0
 
 

--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -2312,17 +2312,37 @@ def _list_snapper_backups_at_destination(endpoint) -> set[str]:
     if is_remote:
         # List remote directory
         if hasattr(endpoint, "_exec_remote_command"):
-            try:
-                result = endpoint._exec_remote_command(
-                    ["ls", "-1", str(dest_path)],
-                    check=False,
-                )
-                if result.returncode == 0:
-                    for name in result.stdout.decode().strip().split("\n"):
-                        if name.endswith(".snapper-meta.json"):
-                            backup_names.add(name[:-18])  # Remove suffix
-            except Exception as e:
-                logger.warning("Could not list remote backups: %s", e)
+            result = endpoint._exec_remote_command(
+                ["ls", "-1", str(dest_path)],
+                check=False,
+            )
+            if result.returncode == 0:
+                for name in result.stdout.decode().strip().split("\n"):
+                    if name.endswith(".snapper-meta.json"):
+                        backup_names.add(name[:-18])  # Remove suffix
+            else:
+                # A genuinely absent target dir is "no backups yet", not an error --
+                # return an empty set. But an unreachable host, an auth failure, or a
+                # permission-denied (e.g. a --ssh-sudo root-owned target listed without
+                # sudo) must NOT masquerade as an empty target: that reads as "no
+                # backups"/"not found" during restore -- exactly when it is most
+                # dangerous. Surface it as an error so callers (list/restore/status)
+                # report the real cause.
+                stderr = (result.stderr or b"").decode(errors="replace").strip()
+                if "No such file or directory" in stderr:
+                    logger.debug(
+                        "Remote snapper target %s does not exist yet: %s",
+                        dest_path,
+                        stderr,
+                    )
+                else:
+                    host = getattr(endpoint, "hostname", None) or "remote host"
+                    detail = stderr or f"ls exited {result.returncode}"
+                    raise RuntimeError(
+                        f"Cannot list snapper backups on {host}: {detail}. If the "
+                        "target was written with --ssh-sudo (root-owned), retry the "
+                        "command with --ssh-sudo."
+                    )
     else:
         # List local directory
         try:

--- a/src/btrfs_backup_ng/core/restore.py
+++ b/src/btrfs_backup_ng/core/restore.py
@@ -691,6 +691,7 @@ def find_parent_by_correspondence(
 
 def list_snapper_backups(
     backup_path: str,
+    endpoint_options: dict | None = None,
 ) -> list[dict]:
     """List snapper backups at a backup location.
 
@@ -718,7 +719,7 @@ def list_snapper_backups(
     # to scan. Dispatch those to a sidecar-based enumeration so they can be listed AND
     # restored (Part 2), instead of silently returning [] as the .snapshots scan did.
     if str(backup_path).startswith(("raw://", "raw+ssh://")):
-        return _list_raw_snapper_backups(backup_path)
+        return _list_raw_snapper_backups(backup_path, endpoint_options)
 
     from ..snapper.metadata import parse_info_xml
 
@@ -785,7 +786,23 @@ def _load_snapper_sidecar(endpoint: Any, name: str) -> Any:
     return load_backup_metadata(dest_path / filename)
 
 
-def _list_raw_snapper_backups(backup_path: str) -> list[dict]:
+def _raw_endpoint_config(backup_path: str, endpoint_options: dict | None) -> dict:
+    """Build the common_config for a raw:// / raw+ssh:// restore-side endpoint.
+
+    ``endpoint_options`` carries the CLI's ssh options (ssh_sudo / ssh_key /
+    ssh_auth_sock / ssh_host_key_policy) so a raw+ssh target WRITTEN with --ssh-sudo
+    (root-owned remote dir/streams) is READ BACK with the same options -- otherwise
+    the remote ls/cat run without sudo and the backups enumerate as empty.
+    """
+    config: dict[str, Any] = {"path": backup_path, "snap_prefix": ""}
+    if endpoint_options:
+        config.update(endpoint_options)
+    return config
+
+
+def _list_raw_snapper_backups(
+    backup_path: str, endpoint_options: dict | None = None
+) -> list[dict]:
     """Enumerate snapper backups at a ``raw://`` / ``raw+ssh://`` target.
 
     Raw snapper backups have no ``.snapshots/{num}/info.xml`` layout, so the
@@ -797,7 +814,9 @@ def _list_raw_snapper_backups(backup_path: str) -> list[dict]:
     """
     from ..endpoint import choose_endpoint
 
-    endpoint = choose_endpoint(backup_path, {"path": backup_path, "snap_prefix": ""})
+    endpoint = choose_endpoint(
+        backup_path, _raw_endpoint_config(backup_path, endpoint_options)
+    )
 
     backups: list[dict[str, Any]] = []
     for name in _list_snapper_backups_at_destination(endpoint):
@@ -821,12 +840,15 @@ def _list_raw_snapper_backups(backup_path: str) -> list[dict]:
             }
         )
 
-    backups.sort(key=lambda b: int(str(b["number"])))
+    # Sort by number, then by backup_name (which embeds the date) so that duplicate
+    # snapper numbers -- which snapper reuses after a prune -- have a STABLE, visible
+    # order rather than the arbitrary order of the underlying set.
+    backups.sort(key=lambda b: (int(str(b["number"])), str(b["backup_name"])))
     return backups
 
 
 def _resolve_raw_snapper_backup(
-    backup_path: str, backup_number: int
+    backup_path: str, backup_number: int, endpoint_options: dict | None = None
 ) -> tuple[Any, Any, Any]:
     """Resolve a raw snapper backup number to (endpoint, RawSnapshot, BackupMetadata).
 
@@ -840,11 +862,20 @@ def _resolve_raw_snapper_backup(
     """
     from ..endpoint import choose_endpoint
 
-    endpoint = choose_endpoint(backup_path, {"path": backup_path, "snap_prefix": ""})
+    endpoint = choose_endpoint(
+        backup_path, _raw_endpoint_config(backup_path, endpoint_options)
+    )
 
-    match_name = None
-    match_meta = None
-    for name in _list_snapper_backups_at_destination(endpoint):
+    # Collect ALL sidecars matching this snapper number, not just the first. Snapper
+    # reuses numbers after a prune (see operations.py: "the snapper number, which
+    # snapper reuses after a prune"), and raw targets accumulate streams over time, so
+    # two RETAINED sidecars can share a number, differing only by the date in their
+    # backup_name. Iterating the UNORDERED set and breaking on the first match would
+    # pick nondeterministically (Python's salted set order) -- a wrong-snapshot restore.
+    # Iterate a sorted list and, on a collision, pick the NEWEST by snapper_date and warn
+    # loudly so the ambiguity is visible (name/date-based addressing is a follow-up).
+    matches: list[tuple[str, Any]] = []
+    for name in sorted(_list_snapper_backups_at_destination(endpoint)):
         try:
             backup_meta = _load_snapper_sidecar(endpoint, name)
         except Exception as e:
@@ -853,14 +884,27 @@ def _resolve_raw_snapper_backup(
             )
             continue
         if backup_meta.snapper_number == backup_number:
-            match_name = name
-            match_meta = backup_meta
-            break
+            matches.append((name, backup_meta))
 
-    if match_name is None:
+    if not matches:
         raise RestoreError(
             f"Snapper backup number {backup_number} not found at {backup_path}"
         )
+
+    if len(matches) > 1:
+        # Deterministic: newest snapper_date wins (name breaks a date tie).
+        matches.sort(key=lambda nm: (nm[1].snapper_date, nm[0]), reverse=True)
+        logger.warning(
+            "Multiple raw snapper backups share number %d at %s: %s. Restoring the "
+            "newest (%s, %s); the older copies are not reachable by number alone.",
+            backup_number,
+            backup_path,
+            ", ".join(f"{n} ({m.snapper_date})" for n, m in matches),
+            matches[0][0],
+            matches[0][1].snapper_date,
+        )
+
+    match_name, match_meta = matches[0]
 
     raw_snapshot = next(
         (s for s in endpoint.list_snapshots() if s.name == match_name), None
@@ -881,6 +925,7 @@ def restore_snapper_snapshot(
     parent_backup_number: int | None = None,
     options: dict | None = None,
     dry_run: bool = False,
+    endpoint_options: dict | None = None,
 ) -> tuple[int, Path]:
     """Restore a snapper backup to local snapper format.
 
@@ -913,7 +958,7 @@ def restore_snapper_snapshot(
         SnapperMetadata,
         generate_info_xml,
         parse_info_xml,
-        parse_info_xml_string,
+        renumber_info_xml,
     )
 
     if options is None:
@@ -941,7 +986,7 @@ def restore_snapper_snapshot(
 
     if is_raw:
         raw_endpoint, raw_snapshot, raw_backup_meta = _resolve_raw_snapper_backup(
-            backup_path, backup_number
+            backup_path, backup_number, endpoint_options
         )
         source_desc = raw_snapshot.name
     else:
@@ -1109,29 +1154,32 @@ def restore_snapper_snapshot(
         # Copy or generate info.xml
         dest_info_xml = dest_snapshot_dir / "info.xml"
         if is_raw:
-            # Seam 4: regenerate info.xml from the sidecar (renumbered to the fresh
-            # local slot), preserving the snapper type/description/cleanup/userdata
-            # that snapper restore would otherwise lose -- raw targets have no
-            # .snapshots/{n}/info.xml to copy. Prefer the sidecar's original_info_xml
-            # (snapper's OWN xml) through the fixed parser, so multi-entry userdata and
-            # older sidecars (which stored a mis-parsed userdata dict) both restore
-            # faithfully; fall back to the parsed fields only when no original exists.
+            # Seam 4: build info.xml for the fresh slot. Raw targets have no
+            # .snapshots/{n}/info.xml to copy, so prefer RENUMBERING the sidecar's
+            # stored original_info_xml (snapper's OWN xml) in place -- only <num>
+            # changes; userdata (incl. multi-entry), <uid>, and any element we do not
+            # model are preserved VERBATIM. Fall back to regenerating from the parsed
+            # fields only when no original was stored or it will not parse (older
+            # sidecars that also stored a mis-parsed userdata dict still round-trip
+            # correctly this way, since the original xml is snapper's authoritative copy).
             assert raw_backup_meta is not None
-            metadata = None
+            xml_content = None
             if raw_backup_meta.original_info_xml:
                 try:
-                    metadata = parse_info_xml_string(raw_backup_meta.original_info_xml)
+                    xml_content = renumber_info_xml(
+                        raw_backup_meta.original_info_xml, next_num
+                    )
                 except Exception as e:
                     logger.warning(
-                        "Could not parse stored info.xml for backup %d (%s); "
+                        "Could not renumber stored info.xml for backup %d (%s); "
                         "regenerating from sidecar fields",
                         backup_number,
                         e,
                     )
-            if metadata is None:
+            if xml_content is None:
                 metadata = raw_backup_meta.to_snapper_metadata()
-            metadata.num = next_num
-            xml_content = generate_info_xml(metadata)
+                metadata.num = next_num
+                xml_content = generate_info_xml(metadata)
         elif backup_info_xml is not None and backup_info_xml.exists():
             # Copy original info.xml but update the number
             try:
@@ -1164,6 +1212,12 @@ def restore_snapper_snapshot(
             xml_content = generate_info_xml(metadata)
 
         # Write info.xml
+        #
+        # Slot dir is 0755 to match what snapper NATIVELY creates for .snapshots/{N}
+        # (verified against snapper 0.13: native slot dirs are 0755, only the parent
+        # .snapshots is 0750). 0750 here would be stricter than snapper and can block
+        # non-root snapper access under ALLOW_USERS/ALLOW_GROUPS/SYNC_ACL; the parent
+        # .snapshots (0750, root+group) still gates who can reach the slot at all.
         if os.geteuid() != 0:
             subprocess.run(
                 ["sudo", "tee", str(dest_info_xml)],
@@ -1172,13 +1226,13 @@ def restore_snapper_snapshot(
                 capture_output=True,
             )
             subprocess.run(
-                ["sudo", "chmod", "750", str(dest_snapshot_dir)],
+                ["sudo", "chmod", "755", str(dest_snapshot_dir)],
                 check=True,
                 capture_output=True,
             )
         else:
             dest_info_xml.write_text(xml_content)
-            dest_snapshot_dir.chmod(0o750)
+            dest_snapshot_dir.chmod(0o755)
 
         duration = time.monotonic() - transfer_start
 

--- a/src/btrfs_backup_ng/core/restore.py
+++ b/src/btrfs_backup_ng/core/restore.py
@@ -4,6 +4,7 @@ Enables pulling snapshots from backup storage (SSH or local) back to local syste
 for disaster recovery, migration, or backup verification.
 """
 
+import json
 import logging
 import subprocess
 import time
@@ -15,7 +16,7 @@ from .. import __util__
 from ..__util__ import Snapshot
 from ..transaction import log_transaction
 from . import progress as progress_utils
-from .operations import send_snapshot
+from .operations import _list_snapper_backups_at_destination, send_snapshot
 
 logger = logging.getLogger(__name__)
 
@@ -712,6 +713,13 @@ def list_snapper_backups(
             ...
         ]
     """
+    # R11: raw:// and raw+ssh:// snapper backups are flat btrfs-send streams plus a
+    # {name}.snapper-meta.json sidecar -- there is no .snapshots/{num}/info.xml layout
+    # to scan. Dispatch those to a sidecar-based enumeration so they can be listed AND
+    # restored (Part 2), instead of silently returning [] as the .snapshots scan did.
+    if str(backup_path).startswith(("raw://", "raw+ssh://")):
+        return _list_raw_snapper_backups(backup_path)
+
     from ..snapper.metadata import parse_info_xml
 
     backup_base = Path(backup_path)
@@ -749,6 +757,70 @@ def list_snapper_backups(
                 backups.append(backup_info)
 
     # Sort by number
+    backups.sort(key=lambda b: int(str(b["number"])))
+    return backups
+
+
+def _load_snapper_sidecar(endpoint: Any, name: str) -> Any:
+    """Load a ``{name}.snapper-meta.json`` sidecar into a BackupMetadata.
+
+    Local ``raw://`` reads the file directly; ``raw+ssh://`` cat's it back over
+    ssh (the argv is shlex-quoted inside ``_exec_remote_command``, so the name is
+    injection-safe). Both funnel through ``BackupMetadata.from_dict`` so the file
+    and stream paths cannot drift.
+    """
+    from ..snapper.metadata import BackupMetadata, load_backup_metadata
+
+    filename = f"{name}.snapper-meta.json"
+    dest_path = Path(endpoint.config["path"])
+
+    if getattr(endpoint, "_is_remote", False):
+        remote_path = str(dest_path / filename)
+        result = endpoint._exec_remote_command(["cat", remote_path], check=True)
+        raw = result.stdout
+        if isinstance(raw, (bytes, bytearray)):
+            raw = raw.decode("utf-8")
+        return BackupMetadata.from_dict(json.loads(raw))
+
+    return load_backup_metadata(dest_path / filename)
+
+
+def _list_raw_snapper_backups(backup_path: str) -> list[dict]:
+    """Enumerate snapper backups at a ``raw://`` / ``raw+ssh://`` target.
+
+    Raw snapper backups have no ``.snapshots/{num}/info.xml`` layout, so the
+    snapper number and metadata are recovered from each ``{name}.snapper-meta.json``
+    sidecar (reusing the proven ``_list_snapper_backups_at_destination`` name scan,
+    local and remote). Returns the same dict shape the btrfs path returns
+    (``number``/``metadata``/``snapshot_path``/``info_xml_path``) plus ``raw`` and
+    ``backup_name`` so Part 2 (materialization) can resolve the stream by name.
+    """
+    from ..endpoint import choose_endpoint
+
+    endpoint = choose_endpoint(backup_path, {"path": backup_path, "snap_prefix": ""})
+
+    backups: list[dict[str, Any]] = []
+    for name in _list_snapper_backups_at_destination(endpoint):
+        try:
+            backup_meta = _load_snapper_sidecar(endpoint, name)
+            metadata = backup_meta.to_snapper_metadata()
+        except Exception as e:
+            logger.warning(
+                "Skipping raw snapper backup %r (unreadable sidecar): %s", name, e
+            )
+            continue
+
+        backups.append(
+            {
+                "number": backup_meta.snapper_number,
+                "snapshot_path": None,
+                "info_xml_path": None,
+                "metadata": metadata,
+                "raw": True,
+                "backup_name": name,
+            }
+        )
+
     backups.sort(key=lambda b: int(str(b["number"])))
     return backups
 

--- a/src/btrfs_backup_ng/core/restore.py
+++ b/src/btrfs_backup_ng/core/restore.py
@@ -825,6 +825,55 @@ def _list_raw_snapper_backups(backup_path: str) -> list[dict]:
     return backups
 
 
+def _resolve_raw_snapper_backup(
+    backup_path: str, backup_number: int
+) -> tuple[Any, Any, Any]:
+    """Resolve a raw snapper backup number to (endpoint, RawSnapshot, BackupMetadata).
+
+    Maps a snapper number -> backup_name (via the ``.snapper-meta.json`` sidecars)
+    -> the matching RawSnapshot (by ``.name``, the shared cross-type backup identity
+    set when the stream and sidecar were written from one ``get_backup_name()``). One
+    endpoint is built and reused for both the lookup and the later ``send()``. The
+    returned BackupMetadata carries the snapper fields used to regenerate info.xml.
+
+    Raises RestoreError if the number has no sidecar or its stream file is missing.
+    """
+    from ..endpoint import choose_endpoint
+
+    endpoint = choose_endpoint(backup_path, {"path": backup_path, "snap_prefix": ""})
+
+    match_name = None
+    match_meta = None
+    for name in _list_snapper_backups_at_destination(endpoint):
+        try:
+            backup_meta = _load_snapper_sidecar(endpoint, name)
+        except Exception as e:
+            logger.warning(
+                "Skipping raw snapper backup %r (unreadable sidecar): %s", name, e
+            )
+            continue
+        if backup_meta.snapper_number == backup_number:
+            match_name = name
+            match_meta = backup_meta
+            break
+
+    if match_name is None:
+        raise RestoreError(
+            f"Snapper backup number {backup_number} not found at {backup_path}"
+        )
+
+    raw_snapshot = next(
+        (s for s in endpoint.list_snapshots() if s.name == match_name), None
+    )
+    if raw_snapshot is None:
+        raise RestoreError(
+            f"Raw stream for snapper backup {match_name!r} not found at {backup_path} "
+            "(its .snapper-meta.json sidecar exists but the btrfs-send stream is missing)"
+        )
+
+    return endpoint, raw_snapshot, match_meta
+
+
 def restore_snapper_snapshot(
     backup_path: str,
     backup_number: int,
@@ -873,14 +922,30 @@ def restore_snapper_snapshot(
     if local_config is None:
         raise RestoreError(f"Local snapper config not found: {snapper_config_name}")
 
-    # Backup paths
+    # Backup paths / source resolution. Raw targets have no .snapshots/{n}/snapshot
+    # subvolume -- the source is a stored btrfs-send stream resolved via the sidecars
+    # (Seam 1). btrfs targets keep the existing subvolume-path check.
     backup_base = Path(backup_path)
-    backup_snapshot_dir = backup_base / ".snapshots" / str(backup_number)
-    backup_snapshot_path = backup_snapshot_dir / "snapshot"
-    backup_info_xml = backup_snapshot_dir / "info.xml"
+    is_raw = str(backup_path).startswith(("raw://", "raw+ssh://"))
 
-    if not backup_snapshot_path.exists():
-        raise RestoreError(f"Backup snapshot not found: {backup_snapshot_path}")
+    raw_endpoint = None
+    raw_snapshot = None
+    raw_backup_meta = None
+    backup_snapshot_path: Path | None = None
+    backup_info_xml: Path | None = None
+
+    if is_raw:
+        raw_endpoint, raw_snapshot, raw_backup_meta = _resolve_raw_snapper_backup(
+            backup_path, backup_number
+        )
+        source_desc = raw_snapshot.name
+    else:
+        backup_snapshot_dir = backup_base / ".snapshots" / str(backup_number)
+        backup_snapshot_path = backup_snapshot_dir / "snapshot"
+        backup_info_xml = backup_snapshot_dir / "info.xml"
+        if not backup_snapshot_path.exists():
+            raise RestoreError(f"Backup snapshot not found: {backup_snapshot_path}")
+        source_desc = str(backup_snapshot_path)
 
     # Get next available snapshot number for restore
     next_num = scanner.get_next_snapshot_number(local_config)
@@ -889,9 +954,12 @@ def restore_snapper_snapshot(
     dest_snapshot_dir = local_config.snapshots_dir / str(next_num)
     dest_snapshot_path = dest_snapshot_dir / "snapshot"
 
-    # Parent path for incremental
+    # Parent path for incremental. Not applicable to raw: the stored stream already
+    # encodes whatever it encodes (full, or incremental against a parent matched by
+    # received_uuid, which the oldest-first restore loop lands just before this one) --
+    # RawEndpoint.send replays it verbatim, there is no btrfs-send `-p` to add here.
     parent_path = None
-    if parent_backup_number:
+    if not is_raw and parent_backup_number:
         parent_path = (
             backup_base / ".snapshots" / str(parent_backup_number) / "snapshot"
         )
@@ -901,6 +969,11 @@ def restore_snapper_snapshot(
                 parent_backup_number,
             )
             parent_path = None
+    elif is_raw and parent_backup_number:
+        logger.debug(
+            "Raw source: ignoring parent %d (stream is self-contained)",
+            parent_backup_number,
+        )
 
     if parent_path:
         logger.info(
@@ -921,11 +994,14 @@ def restore_snapper_snapshot(
     log_transaction(
         action="snapper_restore",
         status="started",
-        source=str(backup_snapshot_path),
+        source=source_desc,
         destination=str(dest_snapshot_path),
         snapshot=str(backup_number),
         parent=str(parent_backup_number) if parent_backup_number else None,
     )
+
+    # Label for send-side failures: a raw stream's decode pipeline is not `btrfs send`.
+    send_label = "raw stream decode" if is_raw else "btrfs send"
 
     try:
         # Create destination directory
@@ -938,36 +1014,43 @@ def restore_snapper_snapshot(
         else:
             dest_snapshot_dir.mkdir(parents=True, exist_ok=True)
 
-        # Build btrfs send command
-        send_cmd = ["btrfs", "send"]
-        if parent_path:
-            send_cmd.extend(["-p", str(parent_path)])
-        send_cmd.append(str(backup_snapshot_path))
-
-        # Build btrfs receive command
+        # Build btrfs receive command (shared: the raw stream's embedded subvolume is
+        # named "snapshot" -- the backup source was .snapshots/{n}/snapshot -- so
+        # receive lands dest_snapshot_dir/snapshot exactly like the btrfs path).
         receive_cmd = ["btrfs", "receive", str(dest_snapshot_dir)]
-
-        # Add sudo if needed
         if os.geteuid() != 0:
-            send_cmd = ["sudo"] + send_cmd
             receive_cmd = ["sudo"] + receive_cmd
-
-        logger.debug("Send command: %s", " ".join(send_cmd))
         logger.debug("Receive command: %s", " ".join(receive_cmd))
 
-        # Estimate size for progress bar (only for full transfers)
+        # Seam 2 (send side) + Seam 3 (progress estimate).
         estimated_size = None
-        if show_progress and not parent_path:
-            estimated_size = progress_utils.estimate_snapshot_size(
-                str(backup_snapshot_path), str(parent_path) if parent_path else None
+        if is_raw:
+            # RawEndpoint.send returns a Popen whose stdout is the verified,
+            # decrypted/decompressed btrfs-send stream -- a drop-in for the send
+            # Popen below. Its integrity check fires INSIDE send() before any bytes
+            # are received, so a corrupt stream aborts before touching the slot. No
+            # size estimate: raw .size is the on-disk (compressed) size, not the
+            # decoded stream size, so a progress total would mislead (spinner only).
+            assert raw_endpoint is not None and raw_snapshot is not None
+            send_process = raw_endpoint.send(raw_snapshot)
+        else:
+            send_cmd = ["btrfs", "send"]
+            if parent_path:
+                send_cmd.extend(["-p", str(parent_path)])
+            send_cmd.append(str(backup_snapshot_path))
+            if os.geteuid() != 0:
+                send_cmd = ["sudo"] + send_cmd
+            logger.debug("Send command: %s", " ".join(send_cmd))
+            if show_progress and not parent_path:
+                estimated_size = progress_utils.estimate_snapshot_size(
+                    str(backup_snapshot_path),
+                    str(parent_path) if parent_path else None,
+                )
+            send_process = subprocess.Popen(
+                send_cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
             )
-
-        # Start send process
-        send_process = subprocess.Popen(
-            send_cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
 
         # Use Rich progress for local transfers
         use_rich_progress = show_progress and progress_utils.is_interactive()
@@ -988,7 +1071,7 @@ def restore_snapper_snapshot(
             )
 
             if send_rc != 0:
-                raise RestoreError(f"btrfs send failed with code {send_rc}")
+                raise RestoreError(f"{send_label} failed with code {send_rc}")
             if receive_rc != 0:
                 raise RestoreError(f"btrfs receive failed with code {receive_rc}")
         else:
@@ -1008,7 +1091,7 @@ def restore_snapper_snapshot(
 
             if send_process.returncode != 0:
                 raise RestoreError(
-                    f"btrfs send failed with code {send_process.returncode}"
+                    f"{send_label} failed with code {send_process.returncode}"
                 )
             if receive_process.returncode != 0:
                 raise RestoreError(
@@ -1020,7 +1103,16 @@ def restore_snapper_snapshot(
 
         # Copy or generate info.xml
         dest_info_xml = dest_snapshot_dir / "info.xml"
-        if backup_info_xml.exists():
+        if is_raw:
+            # Seam 4: regenerate info.xml from the authoritative .snapper-meta.json
+            # sidecar (renumbered to the fresh local slot), preserving the snapper
+            # type/description/cleanup/userdata that snapper restore would otherwise
+            # lose -- raw targets have no .snapshots/{n}/info.xml to copy.
+            assert raw_backup_meta is not None
+            metadata = raw_backup_meta.to_snapper_metadata()
+            metadata.num = next_num
+            xml_content = generate_info_xml(metadata)
+        elif backup_info_xml is not None and backup_info_xml.exists():
             # Copy original info.xml but update the number
             try:
                 metadata = parse_info_xml(backup_info_xml)
@@ -1073,7 +1165,7 @@ def restore_snapper_snapshot(
         log_transaction(
             action="snapper_restore",
             status="completed",
-            source=str(backup_snapshot_path),
+            source=source_desc,
             destination=str(dest_snapshot_path),
             snapshot=str(backup_number),
             parent=str(parent_backup_number) if parent_backup_number else None,
@@ -1093,7 +1185,7 @@ def restore_snapper_snapshot(
         log_transaction(
             action="snapper_restore",
             status="failed",
-            source=str(backup_snapshot_path),
+            source=source_desc,
             destination=str(dest_snapshot_path),
             snapshot=str(backup_number),
             parent=str(parent_backup_number) if parent_backup_number else None,

--- a/src/btrfs_backup_ng/core/restore.py
+++ b/src/btrfs_backup_ng/core/restore.py
@@ -909,7 +909,12 @@ def restore_snapper_snapshot(
     import shutil
 
     from ..snapper import SnapperScanner
-    from ..snapper.metadata import SnapperMetadata, generate_info_xml, parse_info_xml
+    from ..snapper.metadata import (
+        SnapperMetadata,
+        generate_info_xml,
+        parse_info_xml,
+        parse_info_xml_string,
+    )
 
     if options is None:
         options = {}
@@ -1104,12 +1109,27 @@ def restore_snapper_snapshot(
         # Copy or generate info.xml
         dest_info_xml = dest_snapshot_dir / "info.xml"
         if is_raw:
-            # Seam 4: regenerate info.xml from the authoritative .snapper-meta.json
-            # sidecar (renumbered to the fresh local slot), preserving the snapper
-            # type/description/cleanup/userdata that snapper restore would otherwise
-            # lose -- raw targets have no .snapshots/{n}/info.xml to copy.
+            # Seam 4: regenerate info.xml from the sidecar (renumbered to the fresh
+            # local slot), preserving the snapper type/description/cleanup/userdata
+            # that snapper restore would otherwise lose -- raw targets have no
+            # .snapshots/{n}/info.xml to copy. Prefer the sidecar's original_info_xml
+            # (snapper's OWN xml) through the fixed parser, so multi-entry userdata and
+            # older sidecars (which stored a mis-parsed userdata dict) both restore
+            # faithfully; fall back to the parsed fields only when no original exists.
             assert raw_backup_meta is not None
-            metadata = raw_backup_meta.to_snapper_metadata()
+            metadata = None
+            if raw_backup_meta.original_info_xml:
+                try:
+                    metadata = parse_info_xml_string(raw_backup_meta.original_info_xml)
+                except Exception as e:
+                    logger.warning(
+                        "Could not parse stored info.xml for backup %d (%s); "
+                        "regenerating from sidecar fields",
+                        backup_number,
+                        e,
+                    )
+            if metadata is None:
+                metadata = raw_backup_meta.to_snapper_metadata()
             metadata.num = next_num
             xml_content = generate_info_xml(metadata)
         elif backup_info_xml is not None and backup_info_xml.exists():

--- a/src/btrfs_backup_ng/snapper/metadata.py
+++ b/src/btrfs_backup_ng/snapper/metadata.py
@@ -16,6 +16,7 @@ __all__ = [
     "parse_info_xml",
     "parse_info_xml_string",
     "generate_info_xml",
+    "renumber_info_xml",
     "load_backup_metadata",
     "save_backup_metadata",
 ]
@@ -255,6 +256,30 @@ def generate_info_xml(metadata: SnapperMetadata) -> str:
 
     lines.append("</snapshot>")
     return "\n".join(lines)
+
+
+def renumber_info_xml(original_xml: str, new_num: int) -> str:
+    """Return snapper info.xml with ONLY <num> changed to new_num.
+
+    Every other element is preserved VERBATIM -- including ones this module does not
+    model (e.g. <uid>, which snapper emits on manual snapshots). Used on restore to
+    renumber a sidecar's stored original_info_xml into a fresh local slot without the
+    fidelity loss of a parse -> SnapperMetadata -> generate round-trip (that path
+    only preserves the modeled fields).
+
+    Raises:
+        ValueError: If the XML is malformed or has no <num> element.
+    """
+    try:
+        root = ET.fromstring(original_xml)
+    except ET.ParseError as e:
+        raise ValueError(f"Failed to parse info.xml: {e}") from e
+    num_elem = root.find("num")
+    if num_elem is None:
+        raise ValueError("info.xml has no <num> element to renumber")
+    num_elem.text = str(new_num)
+    body = ET.tostring(root, encoding="unicode")
+    return f'<?xml version="1.0"?>\n{body}'
 
 
 @dataclass

--- a/src/btrfs_backup_ng/snapper/metadata.py
+++ b/src/btrfs_backup_ng/snapper/metadata.py
@@ -14,6 +14,7 @@ from typing import Any, Optional
 __all__ = [
     "SnapperMetadata",
     "parse_info_xml",
+    "parse_info_xml_string",
     "generate_info_xml",
     "load_backup_metadata",
     "save_backup_metadata",
@@ -74,29 +75,42 @@ class SnapperMetadata:
         )
 
 
-def parse_info_xml(path: Path | str) -> SnapperMetadata:
-    """Parse a snapper info.xml file.
+def _parse_userdata(userdata_elems: list[ET.Element]) -> dict[str, str]:
+    """Parse snapper's <userdata> element(s) into a {name: value} dict.
 
-    Args:
-        path: Path to the info.xml file
+    Snapper (verified on 0.13.0) writes ONE ``<userdata>`` element PER entry, each
+    holding a ``<key>NAME</key><value>VALUE</value>`` pair -- so a two-entry snapshot
+    has two sibling ``<userdata>`` blocks. Iterate every block (not just the first)
+    and pair key/value within it, so multiple entries all survive. The old code used
+    ``root.find("userdata")`` (first block only) AND the child tag as the dict key,
+    silently dropping every entry after the first -- multi-entry userdata data loss.
 
-    Returns:
-        SnapperMetadata object with parsed information
-
-    Raises:
-        FileNotFoundError: If the file doesn't exist
-        ValueError: If the XML is malformed or missing required fields
+    Also handles a single block containing several key/value pairs, and a legacy
+    ``<name>value</name>`` child, for robustness.
     """
-    path = Path(path)
-    if not path.exists():
-        raise FileNotFoundError(f"info.xml not found: {path}")
+    userdata: dict[str, str] = {}
+    for userdata_elem in userdata_elems:
+        pending_key: Optional[str] = None
+        for item in userdata_elem:
+            if item.tag == "key":
+                pending_key = item.text or ""
+            elif item.tag == "value":
+                if pending_key is not None:
+                    userdata[pending_key] = item.text or ""
+                    pending_key = None
+                # A <value> with no preceding <key> is malformed; ignore it.
+            elif item.tag and item.text:
+                # Legacy / alternative <name>value</name> form.
+                userdata[item.tag] = item.text
+    return userdata
 
-    try:
-        tree = ET.parse(path)
-        root = tree.getroot()
-    except ET.ParseError as e:
-        raise ValueError(f"Failed to parse info.xml: {e}") from e
 
+def _snapper_metadata_from_root(root: ET.Element) -> SnapperMetadata:
+    """Build a SnapperMetadata from a parsed <snapshot> element.
+
+    Shared by ``parse_info_xml`` (file) and ``parse_info_xml_string`` (a sidecar's
+    stored ``original_info_xml``) so both read snapper's format identically.
+    """
     if root.tag != "snapshot":
         raise ValueError(f"Expected <snapshot> root element, got <{root.tag}>")
 
@@ -143,14 +157,6 @@ def parse_info_xml(path: Path | str) -> SnapperMetadata:
         except ValueError:
             pass  # Ignore invalid pre_num
 
-    # Extract userdata
-    userdata = {}
-    userdata_elem = root.find("userdata")
-    if userdata_elem is not None:
-        for item in userdata_elem:
-            if item.tag and item.text:
-                userdata[item.tag] = item.text
-
     return SnapperMetadata(
         type=type_elem.text,
         num=num,
@@ -158,8 +164,52 @@ def parse_info_xml(path: Path | str) -> SnapperMetadata:
         description=description,
         cleanup=cleanup,
         pre_num=pre_num,
-        userdata=userdata,
+        userdata=_parse_userdata(root.findall("userdata")),
     )
+
+
+def parse_info_xml(path: Path | str) -> SnapperMetadata:
+    """Parse a snapper info.xml file.
+
+    Args:
+        path: Path to the info.xml file
+
+    Returns:
+        SnapperMetadata object with parsed information
+
+    Raises:
+        FileNotFoundError: If the file doesn't exist
+        ValueError: If the XML is malformed or missing required fields
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"info.xml not found: {path}")
+
+    try:
+        tree = ET.parse(path)
+        root = tree.getroot()
+    except ET.ParseError as e:
+        raise ValueError(f"Failed to parse info.xml: {e}") from e
+
+    return _snapper_metadata_from_root(root)
+
+
+def parse_info_xml_string(xml_content: str) -> SnapperMetadata:
+    """Parse snapper info.xml from a string.
+
+    Used to reconstruct metadata from a sidecar's stored ``original_info_xml`` --
+    snapper's own XML, the authoritative source on restore (independent of the
+    parsed-dict field, which older sidecars may have stored mis-parsed).
+
+    Raises:
+        ValueError: If the XML is malformed or missing required fields
+    """
+    try:
+        root = ET.fromstring(xml_content)
+    except ET.ParseError as e:
+        raise ValueError(f"Failed to parse info.xml: {e}") from e
+
+    return _snapper_metadata_from_root(root)
 
 
 def generate_info_xml(metadata: SnapperMetadata) -> str:
@@ -192,13 +242,16 @@ def generate_info_xml(metadata: SnapperMetadata) -> str:
         lines.append(f"  <pre_num>{metadata.pre_num}</pre_num>")
 
     if metadata.userdata:
-        lines.append("  <userdata>")
+
+        def _esc(s: str) -> str:
+            return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+        # Snapper writes one <userdata> block PER entry, each a <key>/<value> pair.
         for key, value in metadata.userdata.items():
-            value = value.replace("&", "&amp;")
-            value = value.replace("<", "&lt;")
-            value = value.replace(">", "&gt;")
-            lines.append(f"    <{key}>{value}</{key}>")
-        lines.append("  </userdata>")
+            lines.append("  <userdata>")
+            lines.append(f"    <key>{_esc(key)}</key>")
+            lines.append(f"    <value>{_esc(value)}</value>")
+            lines.append("  </userdata>")
 
     lines.append("</snapshot>")
     return "\n".join(lines)

--- a/src/btrfs_backup_ng/snapper/metadata.py
+++ b/src/btrfs_backup_ng/snapper/metadata.py
@@ -251,6 +251,26 @@ class BackupMetadata:
             userdata=self.snapper_userdata,
         )
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "BackupMetadata":
+        """Create from a JSON-decoded dict.
+
+        Single construction site shared by ``load_backup_metadata`` (local file)
+        and the raw+ssh enumeration path (a ``.snapper-meta.json`` cat'd back over
+        ssh), so the two never drift.
+        """
+        return cls(
+            snapper_config=data.get("snapper_config", ""),
+            snapper_number=data.get("snapper_number", 0),
+            snapper_type=data.get("snapper_type", "single"),
+            snapper_description=data.get("snapper_description", ""),
+            snapper_cleanup=data.get("snapper_cleanup", ""),
+            snapper_pre_num=data.get("snapper_pre_num"),
+            snapper_userdata=data.get("snapper_userdata", {}),
+            snapper_date=data.get("snapper_date", ""),
+            original_info_xml=data.get("original_info_xml", ""),
+        )
+
 
 def save_backup_metadata(path: Path | str, metadata: BackupMetadata) -> None:
     """Save backup metadata to a JSON file.
@@ -294,14 +314,4 @@ def load_backup_metadata(path: Path | str) -> BackupMetadata:
     except json.JSONDecodeError as e:
         raise ValueError(f"Invalid metadata JSON: {e}") from e
 
-    return BackupMetadata(
-        snapper_config=data.get("snapper_config", ""),
-        snapper_number=data.get("snapper_number", 0),
-        snapper_type=data.get("snapper_type", "single"),
-        snapper_description=data.get("snapper_description", ""),
-        snapper_cleanup=data.get("snapper_cleanup", ""),
-        snapper_pre_num=data.get("snapper_pre_num"),
-        snapper_userdata=data.get("snapper_userdata", {}),
-        snapper_date=data.get("snapper_date", ""),
-        original_info_xml=data.get("original_info_xml", ""),
-    )
+    return BackupMetadata.from_dict(data)

--- a/src/btrfs_backup_ng/snapper/metadata.py
+++ b/src/btrfs_backup_ng/snapper/metadata.py
@@ -259,16 +259,16 @@ def save_backup_metadata(path: Path | str, metadata: BackupMetadata) -> None:
         path: Path to the .snapper-meta.json file
         metadata: BackupMetadata object to save
     """
+    from btrfs_backup_ng import __util__
+
     path = Path(path)
     data = asdict(metadata)
-    # NOTE (R7 scope boundary): this snapper .snapper-meta.json sidecar is written
-    # non-atomically (a crash mid-write can leave a torn JSON). It was deliberately left
-    # out of R7's atomic-persistence pass -- the snapper metadata round-trip is audit
-    # root R11's territory, where the read/write path is being reworked wholesale;
-    # hardening it there (via __util__.atomic_write_bytes, like the raw .meta sidecar)
-    # avoids touching the snapper subsystem twice. Tracked, not forgotten.
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2)
+    # Write atomically (temp -> fsync -> os.replace) so a crash mid-write can never leave a
+    # torn .snapper-meta.json that load_backup_metadata would reject -- fulfilling the R7
+    # deferral for this sidecar, now that R11 reads it back on restore. R11/R7.
+    __util__.atomic_write_bytes(  # type: ignore[attr-defined]
+        path, json.dumps(data, indent=2), mode=0o600
+    )
 
 
 def load_backup_metadata(path: Path | str) -> BackupMetadata:

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -3952,6 +3952,11 @@ class TestRestoreRawSnapperSnapshot:
         assert next_num == 42
         dest_dir = config.snapshots_dir / "42"
         assert path == dest_dir / "snapshot"
+        # #P: slot dir is 0755 to match snapper's native .snapshots/{N} (not 0750,
+        # which would block non-root snapper access under ALLOW_USERS/SYNC_ACL).
+        import os as _os
+
+        assert oct(_os.stat(dest_dir).st_mode & 0o777) == oct(0o755)
         # info.xml regenerated from the sidecar, renumbered, metadata preserved.
         info_xml = (dest_dir / "info.xml").read_text()
         assert "<type>pre</type>" in info_xml
@@ -4131,3 +4136,198 @@ class TestRawRestoreUserdataFidelity:
         assert "fallback case" in info_xml
         assert "<key>reason</key>" in info_xml and "<value>manual</value>" in info_xml
         assert "<num>42</num>" in info_xml
+
+    def test_uid_preserved_through_restore(self, tmp_path):
+        """#4: renumbering original_info_xml keeps unmodeled elements (<uid>)."""
+        from btrfs_backup_ng.snapper.metadata import BackupMetadata
+
+        original = (
+            "<?xml version='1.0'?><snapshot>"
+            "<type>single</type><num>1</num><date>2025-10-01 12:00:00</date>"
+            "<uid>1000</uid>"
+            "<userdata><key>reason</key><value>manual</value></userdata>"
+            "</snapshot>"
+        )
+        meta = BackupMetadata(
+            snapper_config="root",
+            snapper_number=1,
+            snapper_type="single",
+            snapper_description="",
+            snapper_cleanup="",
+            snapper_pre_num=None,
+            snapper_userdata={"reason": "manual"},
+            snapper_date="2025-10-01 12:00:00",
+            original_info_xml=original,
+        )
+        info_xml = self._restore(tmp_path, meta)
+        assert "<uid>1000</uid>" in info_xml  # would be dropped by parse->generate
+        assert "<num>42</num>" in info_xml and "<num>1</num>" not in info_xml
+        assert "<key>reason</key>" in info_xml and "<value>manual</value>" in info_xml
+
+
+def _write_named_sidecar(tmp_path, name, number, date, *, desc="d"):
+    """Write a {name}.snapper-meta.json with an explicit snapper_number + date."""
+    from btrfs_backup_ng.snapper.metadata import BackupMetadata, save_backup_metadata
+
+    meta = BackupMetadata(
+        snapper_config="root",
+        snapper_number=number,
+        snapper_type="single",
+        snapper_description=desc,
+        snapper_cleanup="number",
+        snapper_pre_num=None,
+        snapper_userdata={},
+        snapper_date=date,
+        original_info_xml="",
+    )
+    save_backup_metadata(tmp_path / f"{name}.snapper-meta.json", meta)
+
+
+class TestRawSnapperResolutionFixes:
+    """R11 #1 (duplicate snapper_number determinism) and #2 (ssh option threading)."""
+
+    def _fake_local_ep(self, tmp_path, stream_names):
+        streams = []
+        for nm in stream_names:
+            s = MagicMock()
+            s.name = nm
+            streams.append(s)
+
+        class _Ep:  # local: no _is_remote -> enumerator reads tmp_path via iterdir
+            def __init__(self):
+                self.config = {"path": tmp_path}
+
+            def list_snapshots(self, flush_cache=False):
+                return streams
+
+        return _Ep()
+
+    def test_duplicate_number_picks_newest_and_warns(self, tmp_path, caplog):
+        """Two sidecars share number 100; resolve picks the newest date + warns."""
+        from btrfs_backup_ng.core.restore import _resolve_raw_snapper_backup
+
+        _write_named_sidecar(tmp_path, "root-100-old", 100, "2024-01-01 00:00:00")
+        _write_named_sidecar(tmp_path, "root-100-new", 100, "2024-06-01 00:00:00")
+        fake = self._fake_local_ep(tmp_path, ["root-100-old", "root-100-new"])
+        with patch("btrfs_backup_ng.endpoint.choose_endpoint", return_value=fake):
+            with caplog.at_level("WARNING"):
+                _ep, snap, meta = _resolve_raw_snapper_backup(f"raw://{tmp_path}", 100)
+        assert snap.name == "root-100-new"  # newest by snapper_date
+        assert meta.snapper_date == "2024-06-01 00:00:00"
+        assert "share number 100" in caplog.text
+        assert "root-100-old" in caplog.text and "root-100-new" in caplog.text
+
+    def test_duplicate_number_resolution_is_deterministic(self, tmp_path):
+        """Repeated resolves always pick the same (newest) backup, not set-order."""
+        from btrfs_backup_ng.core.restore import _resolve_raw_snapper_backup
+
+        _write_named_sidecar(tmp_path, "root-5-a", 5, "2024-01-01 00:00:00")
+        _write_named_sidecar(tmp_path, "root-5-b", 5, "2024-02-01 00:00:00")
+        _write_named_sidecar(tmp_path, "root-5-c", 5, "2024-03-01 00:00:00")
+        names = ["root-5-a", "root-5-b", "root-5-c"]
+        picks = set()
+        for _ in range(5):
+            fake = self._fake_local_ep(tmp_path, names)
+            with patch("btrfs_backup_ng.endpoint.choose_endpoint", return_value=fake):
+                _e, snap, _m = _resolve_raw_snapper_backup(f"raw://{tmp_path}", 5)
+            picks.add(snap.name)
+        assert picks == {"root-5-c"}  # always the newest, every time
+
+    def test_list_duplicate_numbers_stable_order(self, tmp_path):
+        """list surfaces both same-number rows in a stable (number, name) order."""
+        from btrfs_backup_ng.core.restore import _list_raw_snapper_backups
+
+        _write_named_sidecar(tmp_path, "root-100-new", 100, "2024-06-01 00:00:00")
+        _write_named_sidecar(tmp_path, "root-100-old", 100, "2024-01-01 00:00:00")
+        _write_named_sidecar(tmp_path, "root-3-x", 3, "2024-01-01 00:00:00")
+        result = _list_raw_snapper_backups(f"raw://{tmp_path}")
+        assert [(b["number"], b["backup_name"]) for b in result] == [
+            (3, "root-3-x"),
+            (100, "root-100-new"),
+            (100, "root-100-old"),
+        ]
+
+    def test_endpoint_options_threaded_into_choose_endpoint(self, tmp_path):
+        """#2: ssh_sudo/ssh_key flow into choose_endpoint's common_config."""
+        from btrfs_backup_ng.core.restore import (
+            RestoreError,
+            _list_raw_snapper_backups,
+            _resolve_raw_snapper_backup,
+        )
+
+        fake = self._fake_local_ep(tmp_path, [])
+        with patch("btrfs_backup_ng.endpoint.choose_endpoint", return_value=fake) as ce:
+            _list_raw_snapper_backups(
+                "raw+ssh://h/p", {"ssh_sudo": True, "ssh_key": "/k"}
+            )
+        cfg = ce.call_args.args[1]
+        assert cfg["ssh_sudo"] is True and cfg["ssh_key"] == "/k"
+        assert cfg["path"] == "raw+ssh://h/p" and cfg["snap_prefix"] == ""
+
+        with patch("btrfs_backup_ng.endpoint.choose_endpoint", return_value=fake) as ce:
+            with pytest.raises(RestoreError):
+                _resolve_raw_snapper_backup("raw+ssh://h/p", 1, {"ssh_sudo": True})
+        assert ce.call_args.args[1]["ssh_sudo"] is True
+
+
+class TestRemoteSnapperEnumerationErrors:
+    """R11 #3: remote enumeration surfaces unreachable/denied, not a silent empty."""
+
+    def _remote_ep(self, path, rc, stdout=b"", stderr=b""):
+        class _Ep:
+            _is_remote = True
+            hostname = "host.example"
+
+            def __init__(self):
+                self.config = {"path": path}
+
+            def _exec_remote_command(self, cmd, check=False, **kw):
+                cp = MagicMock()
+                cp.returncode = rc
+                cp.stdout = stdout
+                cp.stderr = stderr
+                return cp
+
+        return _Ep()
+
+    def test_success_parses_names(self):
+        from btrfs_backup_ng.core.operations import (
+            _list_snapper_backups_at_destination,
+        )
+
+        ep = self._remote_ep(
+            "/b", 0, stdout=b"root-1.snapper-meta.json\nroot-1\nnote.txt\n"
+        )
+        assert _list_snapper_backups_at_destination(ep) == {"root-1"}
+
+    def test_missing_dir_returns_empty(self):
+        from btrfs_backup_ng.core.operations import (
+            _list_snapper_backups_at_destination,
+        )
+
+        ep = self._remote_ep(
+            "/b", 2, stderr=b"ls: cannot access '/b': No such file or directory"
+        )
+        assert _list_snapper_backups_at_destination(ep) == set()
+
+    def test_permission_denied_raises_actionable(self):
+        from btrfs_backup_ng.core.operations import (
+            _list_snapper_backups_at_destination,
+        )
+
+        ep = self._remote_ep(
+            "/b", 2, stderr=b"ls: cannot open directory '/b': Permission denied"
+        )
+        with pytest.raises(RuntimeError, match="ssh-sudo"):
+            _list_snapper_backups_at_destination(ep)
+
+    def test_unreachable_host_raises(self):
+        from btrfs_backup_ng.core.operations import (
+            _list_snapper_backups_at_destination,
+        )
+
+        ep = self._remote_ep(
+            "/b", 255, stderr=b"ssh: connect to host X port 22: No route to host"
+        )
+        with pytest.raises(RuntimeError, match="host.example"):
+            _list_snapper_backups_at_destination(ep)

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -3816,3 +3816,196 @@ class TestListRawSnapperBackups:
         assert [b["number"] for b in result] == [2, 8]
         assert all(b["raw"] for b in result)
         assert {b["backup_name"] for b in result} == {"root-2", "root-8"}
+
+
+class TestResolveRawSnapperBackup:
+    """R11 Part 2: snapper number -> backup_name -> RawSnapshot resolution."""
+
+    def _write_sidecars(self, tmp_path, numbers):
+        for n in numbers:
+            save_backup_metadata(
+                tmp_path / f"root-{n}.snapper-meta.json", _make_backup_meta(n)
+            )
+
+    def _fake_endpoint(self, tmp_path, stream_names):
+        streams = []
+        for nm in stream_names:
+            s = MagicMock()
+            s.name = nm
+            streams.append(s)
+
+        class _Ep:
+            def __init__(self):
+                self.config = {"path": tmp_path}
+
+            def list_snapshots(self, flush_cache=False):
+                return streams
+
+        return _Ep()
+
+    def test_resolves_number_to_stream(self, tmp_path):
+        from btrfs_backup_ng.core.restore import _resolve_raw_snapper_backup
+
+        self._write_sidecars(tmp_path, [7, 12])
+        fake = self._fake_endpoint(tmp_path, ["root-7", "root-12"])
+        with patch("btrfs_backup_ng.endpoint.choose_endpoint", return_value=fake):
+            ep, snap, meta = _resolve_raw_snapper_backup(f"raw://{tmp_path}", 12)
+        assert ep is fake
+        assert snap.name == "root-12"
+        assert meta.snapper_number == 12
+
+    def test_missing_number_raises(self, tmp_path):
+        from btrfs_backup_ng.core.restore import (
+            RestoreError,
+            _resolve_raw_snapper_backup,
+        )
+
+        self._write_sidecars(tmp_path, [7])
+        fake = self._fake_endpoint(tmp_path, ["root-7"])
+        with patch("btrfs_backup_ng.endpoint.choose_endpoint", return_value=fake):
+            with pytest.raises(RestoreError, match="number 99 not found"):
+                _resolve_raw_snapper_backup(f"raw://{tmp_path}", 99)
+
+    def test_missing_stream_raises(self, tmp_path):
+        from btrfs_backup_ng.core.restore import (
+            RestoreError,
+            _resolve_raw_snapper_backup,
+        )
+
+        self._write_sidecars(tmp_path, [7])
+        fake = self._fake_endpoint(tmp_path, [])  # sidecar present, stream gone
+        with patch("btrfs_backup_ng.endpoint.choose_endpoint", return_value=fake):
+            with pytest.raises(RestoreError, match="stream for snapper backup"):
+                _resolve_raw_snapper_backup(f"raw://{tmp_path}", 7)
+
+
+class TestRestoreRawSnapperSnapshot:
+    """R11 Part 2: materialize a raw snapper stream into a fresh snapper slot."""
+
+    def _setup(self, tmp_path, *, send_rc=0):
+        from btrfs_backup_ng.snapper import SnapperConfig
+
+        config = SnapperConfig(name="root", subvolume=tmp_path / "local")
+        raw_ep = MagicMock()
+        send_proc = MagicMock()
+        send_proc.stdout = MagicMock()
+        send_proc.returncode = send_rc
+        raw_ep.send.return_value = send_proc
+        raw_snap = MagicMock()
+        raw_snap.name = "root-558"
+        recv_proc = MagicMock()
+        recv_proc.communicate.return_value = (b"", b"")
+        recv_proc.returncode = 0
+        return config, raw_ep, raw_snap, recv_proc
+
+    def test_materializes_and_regenerates_info_xml(self, tmp_path):
+        from btrfs_backup_ng.core.restore import restore_snapper_snapshot
+
+        meta = _make_backup_meta(
+            558, desc="before upgrade", snap_type="pre", userdata={"reason": "manual"}
+        )
+        config, raw_ep, raw_snap, recv_proc = self._setup(tmp_path)
+
+        with (
+            patch("btrfs_backup_ng.snapper.SnapperScanner") as scanner,
+            patch(
+                "btrfs_backup_ng.core.restore._resolve_raw_snapper_backup",
+                return_value=(raw_ep, raw_snap, meta),
+            ),
+            patch(
+                "btrfs_backup_ng.core.restore.subprocess.Popen", return_value=recv_proc
+            ),
+            patch(
+                "btrfs_backup_ng.core.restore.progress_utils.is_interactive",
+                return_value=False,
+            ),
+            patch("os.geteuid", return_value=0),
+        ):
+            scanner.return_value.get_config.return_value = config
+            scanner.return_value.get_next_snapshot_number.return_value = 42
+
+            next_num, path = restore_snapper_snapshot(
+                backup_path="raw:///backups/root",
+                backup_number=558,
+                snapper_config_name="root",
+                options={"show_progress": False},
+            )
+
+        # The raw stream was materialized via RawEndpoint.send (not btrfs send).
+        raw_ep.send.assert_called_once_with(raw_snap)
+        assert next_num == 42
+        dest_dir = config.snapshots_dir / "42"
+        assert path == dest_dir / "snapshot"
+        # info.xml regenerated from the sidecar, renumbered, metadata preserved.
+        info_xml = (dest_dir / "info.xml").read_text()
+        assert "<type>pre</type>" in info_xml
+        assert "<num>42</num>" in info_xml
+        assert "before upgrade" in info_xml
+        assert "<reason>manual</reason>" in info_xml
+
+    def test_send_failure_cleans_up_and_raises(self, tmp_path):
+        from btrfs_backup_ng.core.restore import (
+            RestoreError,
+            restore_snapper_snapshot,
+        )
+
+        meta = _make_backup_meta(558)
+        config, raw_ep, raw_snap, recv_proc = self._setup(tmp_path, send_rc=1)
+
+        with (
+            patch("btrfs_backup_ng.snapper.SnapperScanner") as scanner,
+            patch(
+                "btrfs_backup_ng.core.restore._resolve_raw_snapper_backup",
+                return_value=(raw_ep, raw_snap, meta),
+            ),
+            patch(
+                "btrfs_backup_ng.core.restore.subprocess.Popen", return_value=recv_proc
+            ),
+            patch(
+                "btrfs_backup_ng.core.restore.progress_utils.is_interactive",
+                return_value=False,
+            ),
+            patch("os.geteuid", return_value=0),
+        ):
+            scanner.return_value.get_config.return_value = config
+            scanner.return_value.get_next_snapshot_number.return_value = 42
+
+            with pytest.raises(RestoreError, match="raw stream decode failed"):
+                restore_snapper_snapshot(
+                    backup_path="raw:///backups/root",
+                    backup_number=558,
+                    snapper_config_name="root",
+                    options={"show_progress": False},
+                )
+
+        # The freshly-allocated slot is cleaned up -- no partial backup left behind.
+        assert not (config.snapshots_dir / "42").exists()
+
+    def test_dry_run_resolves_then_returns_early(self, tmp_path):
+        from btrfs_backup_ng.core.restore import restore_snapper_snapshot
+
+        meta = _make_backup_meta(558)
+        config, raw_ep, raw_snap, _ = self._setup(tmp_path)
+
+        with (
+            patch("btrfs_backup_ng.snapper.SnapperScanner") as scanner,
+            patch(
+                "btrfs_backup_ng.core.restore._resolve_raw_snapper_backup",
+                return_value=(raw_ep, raw_snap, meta),
+            ) as resolve,
+            patch("os.geteuid", return_value=0),
+        ):
+            scanner.return_value.get_config.return_value = config
+            scanner.return_value.get_next_snapshot_number.return_value = 42
+
+            next_num, path = restore_snapper_snapshot(
+                backup_path="raw:///backups/root",
+                backup_number=558,
+                snapper_config_name="root",
+                dry_run=True,
+            )
+
+        resolve.assert_called_once()  # existence validated even in dry-run
+        raw_ep.send.assert_not_called()  # but no transfer happens
+        assert next_num == 42
+        assert path == Path("/dev/null")

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -1,7 +1,9 @@
 """Tests for restore functionality."""
 
 import argparse
+import json
 import time
+from dataclasses import asdict
 from pathlib import Path
 from unittest.mock import ANY, MagicMock, patch
 
@@ -15,8 +17,10 @@ from btrfs_backup_ng.core.restore import (
     find_snapshot_by_name,
     get_restore_chain,
     list_remote_snapshots,
+    list_snapper_backups,
     validate_restore_destination,
 )
+from btrfs_backup_ng.snapper.metadata import BackupMetadata, save_backup_metadata
 
 
 class MockSnapshot:
@@ -3680,3 +3684,135 @@ class TestRestoreSnapperSnapshot:
 
             # Check warning was logged
             assert "falling back to full restore" in caplog.text.lower()
+
+
+def _make_backup_meta(number, *, desc="timeline", snap_type="single", userdata=None):
+    """Build a BackupMetadata for a raw snapper sidecar (R11 Part 1 tests)."""
+    return BackupMetadata(
+        snapper_config="root",
+        snapper_number=number,
+        snapper_type=snap_type,
+        snapper_description=desc,
+        snapper_cleanup="timeline",
+        snapper_pre_num=None,
+        snapper_userdata=userdata or {},
+        snapper_date="2025-10-01 12:00:00",
+        original_info_xml=f"<?xml version='1.0'?><snapshot><num>{number}</num></snapshot>",
+    )
+
+
+class _FakeRemoteEndpoint:
+    """Minimal stand-in for SSHRawEndpoint used by the raw+ssh enumeration test.
+
+    A bare MagicMock is unusable here: _list_snapper_backups_at_destination and
+    _load_snapper_sidecar branch on hasattr(_is_remote)/getattr(_is_remote), and a
+    MagicMock answers truthy for every attribute -- so we model only what the code
+    actually reads.
+    """
+
+    _is_remote = True
+
+    def __init__(self, path, exec_fn):
+        self.config = {"path": path}
+        self._exec_remote_command = exec_fn
+
+
+class TestListRawSnapperBackups:
+    """R11 Part 1: enumerate raw:// / raw+ssh:// snapper backups via sidecars."""
+
+    def test_backup_metadata_from_dict_round_trips(self):
+        """BackupMetadata.from_dict reverses asdict() with no drift."""
+        meta = _make_backup_meta(7, desc="pre-update", userdata={"k": "v"})
+        rebuilt = BackupMetadata.from_dict(asdict(meta))
+        assert rebuilt == meta
+
+    def test_local_raw_enumeration_sorted(self, tmp_path):
+        """A raw:// dir of sidecars enumerates as number-sorted backup dicts."""
+        for num in (12, 3, 7):
+            save_backup_metadata(
+                tmp_path / f"root-{num}.snapper-meta.json", _make_backup_meta(num)
+            )
+
+        result = list_snapper_backups(f"raw://{tmp_path}")
+
+        assert [b["number"] for b in result] == [3, 7, 12]
+        for b in result:
+            assert b["raw"] is True
+            assert b["backup_name"] == f"root-{b['number']}"
+            assert b["snapshot_path"] is None
+            assert b["info_xml_path"] is None
+
+    def test_local_raw_metadata_fields_preserved(self, tmp_path):
+        """The display metadata (type/date/description/userdata) survives the sidecar."""
+        save_backup_metadata(
+            tmp_path / "root-5.snapper-meta.json",
+            _make_backup_meta(
+                5, desc="before upgrade", snap_type="pre", userdata={"reason": "test"}
+            ),
+        )
+
+        (backup,) = list_snapper_backups(f"raw://{tmp_path}")
+        meta = backup["metadata"]
+
+        assert meta.type == "pre"
+        assert meta.num == 5
+        assert meta.description == "before upgrade"
+        assert meta.userdata == {"reason": "test"}
+        assert str(meta.date).startswith("2025-10-01 12:00:00")
+
+    def test_ignores_non_snapper_sidecars(self, tmp_path):
+        """Raw stream files and .meta sidecars are not mistaken for snapper backups."""
+        save_backup_metadata(
+            tmp_path / "root-9.snapper-meta.json", _make_backup_meta(9)
+        )
+        (tmp_path / "root-9").write_bytes(b"btrfs-send-stream")
+        (tmp_path / "root-9.meta").write_text("{}")
+
+        result = list_snapper_backups(f"raw://{tmp_path}")
+
+        assert [b["number"] for b in result] == [9]
+
+    def test_bad_sidecar_is_skipped(self, tmp_path, caplog):
+        """A corrupt sidecar is warned-and-skipped; good ones still enumerate."""
+        save_backup_metadata(
+            tmp_path / "root-4.snapper-meta.json", _make_backup_meta(4)
+        )
+        (tmp_path / "root-bad.snapper-meta.json").write_text("{not valid json")
+
+        with caplog.at_level("WARNING"):
+            result = list_snapper_backups(f"raw://{tmp_path}")
+
+        assert [b["number"] for b in result] == [4]
+        assert "root-bad" in caplog.text
+
+    def test_missing_dir_returns_empty(self, tmp_path):
+        """A raw:// path with no sidecars yields no backups (no crash)."""
+        assert list_snapper_backups(f"raw://{tmp_path}/does-not-exist") == []
+
+    def test_remote_raw_ssh_enumeration(self):
+        """raw+ssh:// enumerates by ls'ing names then cat'ing each sidecar over ssh."""
+        metas = {n: _make_backup_meta(n) for n in (2, 8)}
+        sidecar_json = {
+            f"root-{n}.snapper-meta.json": json.dumps(asdict(m))
+            for n, m in metas.items()
+        }
+
+        def fake_exec(command, **kwargs):
+            cp = MagicMock()
+            cp.returncode = 0
+            if command[0] == "ls":
+                cp.stdout = ("\n".join(sidecar_json) + "\n").encode()
+            elif command[0] == "cat":
+                cp.stdout = sidecar_json[Path(command[1]).name].encode()
+            else:  # pragma: no cover - defensive
+                raise AssertionError(f"unexpected remote command: {command}")
+            return cp
+
+        fake_ep = _FakeRemoteEndpoint("/remote/backups", fake_exec)
+
+        with patch("btrfs_backup_ng.endpoint.choose_endpoint", return_value=fake_ep):
+            result = list_snapper_backups("raw+ssh://host/remote/backups")
+
+        assert [b["number"] for b in result] == [2, 8]
+        assert all(b["raw"] for b in result)
+        assert {b["backup_name"] for b in result} == {"root-2", "root-8"}

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -3687,7 +3687,23 @@ class TestRestoreSnapperSnapshot:
 
 
 def _make_backup_meta(number, *, desc="timeline", snap_type="single", userdata=None):
-    """Build a BackupMetadata for a raw snapper sidecar (R11 Part 1 tests)."""
+    """Build a BackupMetadata for a raw snapper sidecar (R11 tests).
+
+    original_info_xml is a valid snapper info.xml (real <key>/<value> userdata
+    format) so restore's primary path (parse the stored xml) is exercised.
+    """
+    ud = userdata or {}
+    # Snapper's real format: one <userdata> block per entry (sibling blocks).
+    ud_xml = "".join(
+        f"<userdata><key>{k}</key><value>{v}</value></userdata>" for k, v in ud.items()
+    )
+    original = (
+        "<?xml version='1.0'?><snapshot>"
+        f"<type>{snap_type}</type><num>{number}</num>"
+        "<date>2025-10-01 12:00:00</date>"
+        f"<description>{desc}</description><cleanup>timeline</cleanup>"
+        f"{ud_xml}</snapshot>"
+    )
     return BackupMetadata(
         snapper_config="root",
         snapper_number=number,
@@ -3695,9 +3711,9 @@ def _make_backup_meta(number, *, desc="timeline", snap_type="single", userdata=N
         snapper_description=desc,
         snapper_cleanup="timeline",
         snapper_pre_num=None,
-        snapper_userdata=userdata or {},
+        snapper_userdata=ud,
         snapper_date="2025-10-01 12:00:00",
-        original_info_xml=f"<?xml version='1.0'?><snapshot><num>{number}</num></snapshot>",
+        original_info_xml=original,
     )
 
 
@@ -3941,7 +3957,9 @@ class TestRestoreRawSnapperSnapshot:
         assert "<type>pre</type>" in info_xml
         assert "<num>42</num>" in info_xml
         assert "before upgrade" in info_xml
-        assert "<reason>manual</reason>" in info_xml
+        # snapper's real userdata format: <key>/<value> pairs
+        assert "<key>reason</key>" in info_xml
+        assert "<value>manual</value>" in info_xml
 
     def test_send_failure_cleans_up_and_raises(self, tmp_path):
         from btrfs_backup_ng.core.restore import (
@@ -4009,3 +4027,107 @@ class TestRestoreRawSnapperSnapshot:
         raw_ep.send.assert_not_called()  # but no transfer happens
         assert next_num == 42
         assert path == Path("/dev/null")
+
+
+class TestRawRestoreUserdataFidelity:
+    """R11: restore sources info.xml from original_info_xml so userdata survives."""
+
+    def _setup(self, tmp_path):
+        from btrfs_backup_ng.snapper import SnapperConfig
+
+        config = SnapperConfig(name="root", subvolume=tmp_path / "local")
+        raw_ep = MagicMock()
+        send_proc = MagicMock()
+        send_proc.stdout = MagicMock()
+        send_proc.returncode = 0
+        raw_ep.send.return_value = send_proc
+        raw_snap = MagicMock()
+        raw_snap.name = "root-1"
+        recv_proc = MagicMock()
+        recv_proc.communicate.return_value = (b"", b"")
+        recv_proc.returncode = 0
+        return config, raw_ep, raw_snap, recv_proc
+
+    def _restore(self, tmp_path, meta):
+        from btrfs_backup_ng.core.restore import restore_snapper_snapshot
+
+        config, raw_ep, raw_snap, recv_proc = self._setup(tmp_path)
+        with (
+            patch("btrfs_backup_ng.snapper.SnapperScanner") as scanner,
+            patch(
+                "btrfs_backup_ng.core.restore._resolve_raw_snapper_backup",
+                return_value=(raw_ep, raw_snap, meta),
+            ),
+            patch(
+                "btrfs_backup_ng.core.restore.subprocess.Popen", return_value=recv_proc
+            ),
+            patch(
+                "btrfs_backup_ng.core.restore.progress_utils.is_interactive",
+                return_value=False,
+            ),
+            patch("os.geteuid", return_value=0),
+        ):
+            scanner.return_value.get_config.return_value = config
+            scanner.return_value.get_next_snapshot_number.return_value = 42
+            restore_snapper_snapshot(
+                backup_path="raw:///backups/root",
+                backup_number=1,
+                snapper_config_name="root",
+                options={"show_progress": False},
+            )
+        return (config.snapshots_dir / "42" / "info.xml").read_text()
+
+    def test_multi_entry_userdata_survives_restore(self, tmp_path):
+        """Multiple userdata entries all round-trip into the restored info.xml."""
+        meta = _make_backup_meta(1, userdata={"reason": "manual", "ticket": "ABC-123"})
+        info_xml = self._restore(tmp_path, meta)
+        assert "<key>reason</key>" in info_xml and "<value>manual</value>" in info_xml
+        assert "<key>ticket</key>" in info_xml and "<value>ABC-123</value>" in info_xml
+
+    def test_old_sidecar_prefers_original_over_misparsed_dict(self, tmp_path):
+        """A pre-fix mis-parsed userdata dict is ignored; original_info_xml wins."""
+        from btrfs_backup_ng.snapper.metadata import BackupMetadata
+
+        original = (
+            "<?xml version='1.0'?><snapshot>"
+            "<type>single</type><num>1</num><date>2025-10-01 12:00:00</date>"
+            "<userdata><key>reason</key><value>manual</value></userdata>"
+            "<userdata><key>ticket</key><value>ABC-123</value></userdata>"
+            "</snapshot>"
+        )
+        # Older sidecar stored the lossy {'key':..,'value':..} form in the dict field.
+        meta = BackupMetadata(
+            snapper_config="root",
+            snapper_number=1,
+            snapper_type="single",
+            snapper_description="",
+            snapper_cleanup="",
+            snapper_pre_num=None,
+            snapper_userdata={"key": "ticket", "value": "ABC-123"},
+            snapper_date="2025-10-01 12:00:00",
+            original_info_xml=original,
+        )
+        info_xml = self._restore(tmp_path, meta)
+        # Both entries present => original_info_xml (not the bad dict) drove info.xml.
+        assert "<key>reason</key>" in info_xml and "<value>manual</value>" in info_xml
+        assert "<key>ticket</key>" in info_xml and "<value>ABC-123</value>" in info_xml
+
+    def test_falls_back_to_dict_when_no_original(self, tmp_path):
+        """With no original_info_xml, restore uses the parsed sidecar fields."""
+        from btrfs_backup_ng.snapper.metadata import BackupMetadata
+
+        meta = BackupMetadata(
+            snapper_config="root",
+            snapper_number=1,
+            snapper_type="single",
+            snapper_description="fallback case",
+            snapper_cleanup="number",
+            snapper_pre_num=None,
+            snapper_userdata={"reason": "manual"},
+            snapper_date="2025-10-01 12:00:00",
+            original_info_xml="",  # legacy sidecar without the raw xml
+        )
+        info_xml = self._restore(tmp_path, meta)
+        assert "fallback case" in info_xml
+        assert "<key>reason</key>" in info_xml and "<value>manual</value>" in info_xml
+        assert "<num>42</num>" in info_xml

--- a/tests/test_snapper_cmd.py
+++ b/tests/test_snapper_cmd.py
@@ -1685,3 +1685,55 @@ class TestSnapperEndpointRouting:
         cfg = mock_choose.call_args[0][1]
         assert cfg.get("ssh_sudo") is True
         assert cfg.get("ssh_identity_file") == "/home/u/.ssh/id"
+
+
+class TestRestoreSnapperdCacheHint:
+    """R11: restore prints a snapperd-rescan hint (a)+(c) decision."""
+
+    def _args(self, dry_run=False):
+        return argparse.Namespace(
+            source="/mnt/backup",
+            config="root",
+            snapshot=[559],
+            all=False,
+            list=False,
+            dry_run=dry_run,
+            json=False,
+            verbose=False,
+            quiet=False,
+            log_level=None,
+        )
+
+    def _run(self, args, mock_snapper_configs, capsys):
+        from pathlib import Path
+
+        from btrfs_backup_ng.cli.snapper_cmd import _handle_restore
+
+        with (
+            patch("btrfs_backup_ng.cli.snapper_cmd.SnapperScanner") as scanner_cls,
+            patch("btrfs_backup_ng.core.restore.list_snapper_backups") as mock_list,
+            patch(
+                "btrfs_backup_ng.core.restore.restore_snapper_snapshot"
+            ) as mock_restore,
+        ):
+            scanner = MagicMock()
+            scanner.get_config.return_value = mock_snapper_configs[0]
+            scanner_cls.return_value = scanner
+            mock_list.return_value = [{"number": 559, "metadata": MagicMock()}]
+            mock_restore.return_value = (1, Path("/x/.snapshots/1/snapshot"))
+            result = _handle_restore(args)
+        captured = capsys.readouterr()
+        # Rich wraps log lines; normalize whitespace before substring checks.
+        text = " ".join((captured.out + captured.err).split())
+        return result, text
+
+    def test_hint_printed_after_successful_restore(self, capsys, mock_snapper_configs):
+        result, text = self._run(self._args(), mock_snapper_configs, capsys)
+        assert result == 0
+        assert "daemon picks up the restored" in text
+        assert "snapper -c root list" in text
+
+    def test_no_hint_on_dry_run(self, capsys, mock_snapper_configs):
+        result, text = self._run(self._args(dry_run=True), mock_snapper_configs, capsys)
+        assert result == 0
+        assert "daemon picks up the restored" not in text

--- a/tests/test_snapper_metadata.py
+++ b/tests/test_snapper_metadata.py
@@ -11,6 +11,7 @@ from btrfs_backup_ng.snapper.metadata import (
     generate_info_xml,
     load_backup_metadata,
     parse_info_xml,
+    parse_info_xml_string,
     save_backup_metadata,
 )
 
@@ -333,7 +334,7 @@ class TestGenerateInfoXml:
         assert "<pre_num>199</pre_num>" in xml
 
     def test_generate_with_userdata(self):
-        """Test generating info.xml with userdata."""
+        """Test generating info.xml with userdata (snapper <key>/<value> pairs)."""
         meta = SnapperMetadata(
             type="single",
             num=100,
@@ -342,8 +343,10 @@ class TestGenerateInfoXml:
         )
         xml = generate_info_xml(meta)
         assert "<userdata>" in xml
-        assert "<key1>value1</key1>" in xml
-        assert "<key2>value2</key2>" in xml
+        assert "<key>key1</key>" in xml
+        assert "<value>value1</value>" in xml
+        assert "<key>key2</key>" in xml
+        assert "<value>value2</value>" in xml
         assert "</userdata>" in xml
 
     def test_generate_escapes_special_chars(self):
@@ -493,3 +496,102 @@ class TestSaveLoadBackupMetadata:
             data = json.load(f)
         assert data["snapper_config"] == "test"
         assert data["snapper_number"] == 1
+
+
+class TestUserdataKeyValueFormat:
+    """R11: snapper stores userdata as <key>/<value> pairs; parse+generate round-trip."""
+
+    # Snapper's real 0.13.0 format: ONE <userdata> block per entry (siblings).
+    SNAPPER_MULTI = (
+        "<?xml version='1.0'?><snapshot>"
+        "<type>single</type><num>7</num><date>2026-07-29 03:12:48</date>"
+        "<userdata><key>reason</key><value>manual</value></userdata>"
+        "<userdata><key>ticket</key><value>ABC-123</value></userdata>"
+        "</snapshot>"
+    )
+    # An alternative single-block-multi-pair form we also accept.
+    SNAPPER_SINGLE_BLOCK = (
+        "<?xml version='1.0'?><snapshot>"
+        "<type>single</type><num>7</num><date>2026-07-29 03:12:48</date>"
+        "<userdata>"
+        "<key>reason</key><value>manual</value>"
+        "<key>ticket</key><value>ABC-123</value>"
+        "</userdata></snapshot>"
+    )
+
+    def test_parse_string_multi_entry_userdata(self):
+        """Snapper's sibling <userdata> blocks parse to a full {name: value} dict."""
+        meta = parse_info_xml_string(self.SNAPPER_MULTI)
+        assert meta.userdata == {"reason": "manual", "ticket": "ABC-123"}
+        assert meta.type == "single"
+        assert meta.num == 7
+
+    def test_parse_single_block_multi_pair_also_supported(self):
+        """A single <userdata> block with several key/value pairs also parses."""
+        meta = parse_info_xml_string(self.SNAPPER_SINGLE_BLOCK)
+        assert meta.userdata == {"reason": "manual", "ticket": "ABC-123"}
+
+    def test_parse_file_multi_entry_userdata(self, tmp_path):
+        """The file parser shares the fixed logic (not just the string variant)."""
+        xml_file = tmp_path / "info.xml"
+        xml_file.write_text(self.SNAPPER_MULTI)
+        meta = parse_info_xml(xml_file)
+        assert meta.userdata == {"reason": "manual", "ticket": "ABC-123"}
+
+    def test_generate_emits_key_value_pairs(self):
+        """generate emits snapper's <key>/<value> form, not <name>value</name>."""
+        meta = SnapperMetadata(
+            type="single",
+            num=7,
+            date=datetime(2026, 7, 29, 3, 12, 48),
+            userdata={"reason": "manual", "ticket": "ABC-123"},
+        )
+        xml = generate_info_xml(meta)
+        assert "<key>reason</key>" in xml
+        assert "<value>manual</value>" in xml
+        assert "<key>ticket</key>" in xml
+        assert "<value>ABC-123</value>" in xml
+        assert "<reason>manual</reason>" not in xml  # the old, wrong form
+
+    def test_round_trip_preserves_multi_entry(self):
+        """parse(generate(x)) == x for multi-entry userdata (the real regression)."""
+        userdata = {"reason": "manual", "ticket": "ABC-123", "important": "yes"}
+        meta = SnapperMetadata(
+            type="pre",
+            num=42,
+            date=datetime(2026, 7, 29, 3, 12, 48),
+            description="before upgrade",
+            cleanup="number",
+            userdata=userdata,
+        )
+        reparsed = parse_info_xml_string(generate_info_xml(meta))
+        assert reparsed.userdata == userdata
+        assert reparsed.type == "pre"
+        assert reparsed.description == "before upgrade"
+        assert reparsed.cleanup == "number"
+
+    def test_legacy_name_value_form_still_parses(self):
+        """A legacy <name>value</name> userdata child is still read (back-compat)."""
+        legacy = (
+            "<?xml version='1.0'?><snapshot>"
+            "<type>single</type><num>1</num><date>2026-07-29 03:12:48</date>"
+            "<userdata><reason>manual</reason></userdata></snapshot>"
+        )
+        meta = parse_info_xml_string(legacy)
+        assert meta.userdata == {"reason": "manual"}
+
+    def test_value_without_key_is_ignored(self):
+        """A malformed <value> with no preceding <key> does not corrupt the dict."""
+        malformed = (
+            "<?xml version='1.0'?><snapshot>"
+            "<type>single</type><num>1</num><date>2026-07-29 03:12:48</date>"
+            "<userdata><value>orphan</value><key>k</key><value>v</value></userdata>"
+            "</snapshot>"
+        )
+        meta = parse_info_xml_string(malformed)
+        assert meta.userdata == {"k": "v"}
+
+    def test_parse_string_rejects_malformed_xml(self):
+        """A non-XML original_info_xml raises ValueError (restore falls back)."""
+        with pytest.raises(ValueError):
+            parse_info_xml_string("{not xml")

--- a/tests/test_snapper_metadata.py
+++ b/tests/test_snapper_metadata.py
@@ -595,3 +595,100 @@ class TestUserdataKeyValueFormat:
         """A non-XML original_info_xml raises ValueError (restore falls back)."""
         with pytest.raises(ValueError):
             parse_info_xml_string("{not xml")
+
+
+class TestRenumberInfoXml:
+    """R11 #4: renumber preserves snapper's xml verbatim (incl. unmodeled <uid>)."""
+
+    SNAP_WITH_UID = (
+        "<?xml version='1.0'?>\n<snapshot>\n"
+        "  <type>single</type>\n  <num>6052</num>\n"
+        "  <date>2026-07-31 10:40:37</date>\n"
+        "  <description>Fedora restore point</description>\n"
+        "  <cleanup>number</cleanup>\n"
+        "  <uid>1000</uid>\n"
+        "  <userdata>\n    <key>reason</key>\n    <value>manual</value>\n  </userdata>\n"
+        "  <userdata>\n    <key>ticket</key>\n    <value>OP-1</value>\n  </userdata>\n"
+        "</snapshot>\n"
+    )
+
+    def test_changes_only_num_and_preserves_uid(self):
+        from btrfs_backup_ng.snapper.metadata import renumber_info_xml
+
+        out = renumber_info_xml(self.SNAP_WITH_UID, 99)
+        assert "<num>99</num>" in out
+        assert "<num>6052</num>" not in out
+        # everything else verbatim
+        assert "<uid>1000</uid>" in out  # the unmodeled element R11 must NOT drop
+        assert "<key>reason</key>" in out and "<value>manual</value>" in out
+        assert "<key>ticket</key>" in out and "<value>OP-1</value>" in out
+        assert "Fedora restore point" in out
+        assert "<cleanup>number</cleanup>" in out
+
+    def test_reparses_to_same_metadata_with_new_num(self):
+        from btrfs_backup_ng.snapper.metadata import (
+            parse_info_xml_string,
+            renumber_info_xml,
+        )
+
+        m = parse_info_xml_string(renumber_info_xml(self.SNAP_WITH_UID, 99))
+        assert m.num == 99
+        assert m.userdata == {"reason": "manual", "ticket": "OP-1"}
+
+    def test_rejects_missing_num(self):
+        from btrfs_backup_ng.snapper.metadata import renumber_info_xml
+
+        with pytest.raises(ValueError):
+            renumber_info_xml(
+                "<?xml version='1.0'?><snapshot><type>single</type></snapshot>", 1
+            )
+
+    def test_rejects_malformed_xml(self):
+        from btrfs_backup_ng.snapper.metadata import renumber_info_xml
+
+        with pytest.raises(ValueError):
+            renumber_info_xml("{not xml", 1)
+
+
+class TestUserdataEscaping:
+    """R11 #5: userdata keys/values with XML special chars round-trip safely."""
+
+    def test_special_chars_round_trip(self):
+        meta = SnapperMetadata(
+            type="single",
+            num=1,
+            date=datetime(2026, 7, 31, 10, 40, 37),
+            userdata={"a&b": "x<y>z", "note": "tom & jerry <fwd>"},
+        )
+        xml = generate_info_xml(meta)
+        # raw xml must be escaped (not literal & < >)
+        assert "&amp;" in xml and "&lt;" in xml and "&gt;" in xml
+        assert "<value>x<y>z</value>" not in xml  # unescaped would be malformed
+        # and it must parse back to the exact original dict
+        reparsed = parse_info_xml_string(xml)
+        assert reparsed.userdata == {"a&b": "x<y>z", "note": "tom & jerry <fwd>"}
+
+
+class TestSaveBackupMetadataAtomic:
+    """R11 #6 / pt1: sidecar is written atomically at 0600."""
+
+    def test_saved_file_is_0600_and_no_temp_left(self, tmp_path):
+        import os
+
+        meta = BackupMetadata(
+            snapper_config="root",
+            snapper_number=1,
+            snapper_type="single",
+            snapper_description="d",
+            snapper_cleanup="number",
+            snapper_pre_num=None,
+            snapper_userdata={},
+            snapper_date="2026-07-31 10:40:37",
+            original_info_xml="",
+        )
+        path = tmp_path / "root-1.snapper-meta.json"
+        save_backup_metadata(path, meta)
+        # tightened mode from pt1 -- a revert to open('w') would yield 0644
+        assert oct(os.stat(path).st_mode & 0o777) == oct(0o600)
+        # atomic write leaves no stray temp sibling in the dir
+        assert [p.name for p in tmp_path.iterdir()] == ["root-1.snapper-meta.json"]


### PR DESCRIPTION
## R11 — Restore snapper backups from `raw://` / `raw+ssh://` targets

Snapper backups sent to `raw://` / `raw+ssh://` targets were **write-only**: they enumerated as empty and could not be restored, and their metadata round-trip was lossy. This branch makes them **first-class and restorable** — with full metadata fidelity, dual-transport parity, and behavior verified against real Snapper 0.13.0 (not just byte comparison).

Closes the R11 root of the 0.9.2 reliability audit (tracker #77).

### What changed

1. **Full metadata fidelity** — atomic `.snapper-meta.json` sidecars (crash-safe, `0600`); exact multi-entry `<userdata>` preservation (Snapper writes one `<userdata>` block *per entry* — the old parser kept only the first and mislabeled keys); `info.xml` renumbered by editing **only** `<num>` in Snapper's own stored XML, so unmodeled elements like `<uid>` survive verbatim; restored slot dirs use Snapper's native `0755`.
2. **Dual-transport parity** — `raw://` (local) and `raw+ssh://` (remote, stream read back over ssh, decrypt/decompress kept **local**). SSH options (`--ssh-sudo` / `--ssh-key` / `--ssh-auth-sock` / host-key policy) are threaded into the restore endpoint, and an unreachable/denied remote now reports an **actionable error** instead of a silent "no backups".
3. **Crash-safe materialization** — receives into the fresh `get_next_snapshot_number()` slot with cleanup-on-failure (mirroring the proven btrfs restore path); the stream integrity check fires **before** any receive, rejecting corrupt streams up front.
4. **Deterministic duplicate resolution** — Snapper reuses numbers after a prune, so a raw target can hold two same-number backups (differing by date). `--snapshot N` now restores the **newest by date** deterministically and **warns**, instead of picking nondeterministically from set order.
5. **snapperd cache hint** — a restored slot is created out-of-band, so snapperd doesn't see it until it rescans; restore prints a one-line hint (`snapper -c <config> list` or reboot) before `diff`/`undochange`/rollback. Documented in CLI-REFERENCE, the manpage, and SNAPPER-INTEGRATION.

### Verification

- **Adversarial multi-lens review** of the whole branch (5 lenses, per-finding refutation): 7 confirmed findings all fixed, 6 refuted on empirical grounds (billion-laughs — expat guard on ≥3.11; stderr deadlock — decoders emit ~0 stderr; etc.).
- **Operational-fidelity hardware probe** on real Snapper 0.13.0 (isolated throwaway config, torn down): a restored snapshot supports `snapper diff`, `status`, `undochange` (apply), and `cleanup` — it behaves as if Snapper created it. `received_uuid` differences are a non-issue.
- **Hardware-proven this branch**: byte-identical restore over `raw://` **and** `raw+ssh://` (a real LAN box); multi-entry userdata preserved on both; restored slot is `0755` and Snapper operates on it; duplicate-number restore picks newest + warns; a denied `raw+ssh` target reports the real permission error.
- All fix tests are **mutation-verified**. Full suite green (the two real-`ssh localhost` integration files are environment-gated in this dev box by an unreachable-KDC GSSAPI stall, unrelated to these changes; they pass in CI).

### Commits

| Commit | Description |
|---|---|
| pt1 | atomic `.snapper-meta.json` write |
| pt2 | enumerate `raw://` / `raw+ssh://` snapper backups via sidecars |
| pt3 | materialize raw streams on restore (4-seam, receive-into-fresh-slot) |
| userdata | multi-entry `<userdata>` round-trip + backward compatibility |
| review | 7 review findings (resolution, perms, ssh options, `<uid>` fidelity, tests) |
| hint | snapperd-cache hint + docs |

### Immediate follow-up (separate PR)

Name/date-based addressing (`--date` or backup name) so an *older* same-number raw backup is CLI-reachable — today `--snapshot N` can only reach the newest of a colliding pair (it restores that one and warns).
