### PR TITLE
snapper restore: add --backup-name and --date addressing for collisions & fix double-restore bug

### DIFF
--- a/completions/btrfs-backup-ng.bash
+++ b/completions/btrfs-backup-ng.bash
@@ -44,7 +44,7 @@ _btrfs_backup_ng() {
     local snapper_list_opts="--config --type --json"
     local snapper_backup_opts="--snapshot --type --min-age --dry-run --ssh-sudo --ssh-key --compress --rate-limit --progress --no-progress"
     local snapper_status_opts="--json"
-    local snapper_restore_opts="--snapshot --dry-run --ssh-sudo --ssh-key"
+    local snapper_restore_opts="--snapshot --backup-name --date --all --list --json --config --dry-run --ssh-sudo --ssh-key --ssh-auth-sock"
     local snapper_generate_config_opts="-o --output"
     local raw_list_opts="--json --ssh-sudo"
     local raw_verify_opts="--snapshot --json --ssh-sudo"

--- a/completions/btrfs-backup-ng.fish
+++ b/completions/btrfs-backup-ng.fish
@@ -339,6 +339,8 @@ complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_snapper_using_subcommand 
 # snapper restore
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_snapper_using_subcommand restore' -l dry-run -d 'Show what would be done without making changes'
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_snapper_using_subcommand restore' -l snapshot -d 'Restore specific snapshot by number' -x
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_snapper_using_subcommand restore' -l backup-name -d 'Restore the exact raw backup by name (from --list)' -x
+complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_snapper_using_subcommand restore' -l date -d 'Restrict to backups whose date matches DATE (YYYY-MM-DD prefix)' -x
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_snapper_using_subcommand restore' -l all -d 'Restore all snapshots'
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_snapper_using_subcommand restore' -l compress -d 'Compression method' -xa "$compress_methods"
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_snapper_using_subcommand restore' -l rate-limit -d 'Bandwidth limit (e.g., 10M, 1G)' -x

--- a/completions/btrfs-backup-ng.zsh
+++ b/completions/btrfs-backup-ng.zsh
@@ -378,7 +378,12 @@ _btrfs-backup-ng() {
                                     ;;
                                 restore)
                                     _arguments \
-                                        '--snapshot[Restore specific snapshot number]:snapshot number:' \
+                                        '*--snapshot[Restore specific snapshot number]:snapshot number:' \
+                                        '*--backup-name[Restore the exact raw backup by name (from --list)]:backup name:' \
+                                        '--date[Restrict to backups whose date matches DATE (YYYY-MM-DD prefix)]:date:' \
+                                        '--all[Restore all snapshots]' \
+                                        '--list[List available backups]' \
+                                        '--json[Output in JSON format]' \
                                         '--dry-run[Show what would be done]' \
                                         '--ssh-sudo[Use sudo on remote host]' \
                                         '--ssh-key[SSH private key file]:key file:_files' \

--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -764,7 +764,7 @@ btrfs-backup-ng snapper list [OPTIONS]
 btrfs-backup-ng snapper list
 
 # List only 'root' config snapshots
-btrfs-backup-ng snapper list --config root
+btrfs-backup-ng snapper list root
 
 # List only 'single' type snapshots
 btrfs-backup-ng snapper list --type single
@@ -868,57 +868,56 @@ btrfs-backup-ng snapper status --target /mnt/backup/root
 Restore snapper snapshots from backup.
 
 ```bash
-btrfs-backup-ng snapper restore SOURCE --config NAME [OPTIONS]
+btrfs-backup-ng snapper restore SOURCE CONFIG [OPTIONS]
 ```
 
-**Arguments:**
+**Arguments** (both positional, in this order):
 | Argument | Description |
 |----------|-------------|
-| `SOURCE` | Backup source path (local or ssh://user@host:/path) |
+| `SOURCE` | Backup source: a local path, `ssh://user@host:/path` (btrfs), or `raw://path` / `raw+ssh://user@host/path` (non-btrfs) |
+| `CONFIG` | Local snapper config to restore **into** (e.g. `root`, `home`) — required |
 
 **Options:**
 | Option | Description |
 |--------|-------------|
-| `--config NAME` | Local snapper config to restore into (required) |
-| `--list` | List available backups instead of restoring |
-| `--snapshot NUM` | Restore specific snapshot by number (can be repeated) |
+| `-l`, `--list` | List available backups instead of restoring |
+| `-s`, `--snapshot NUM` | Restore snapshot by number (can be repeated). On a reused (duplicate) number, restores the newest by date and warns |
 | `--backup-name NAME` | Restore the exact raw backup by name from `--list` (can be repeated); reaches an older copy when a snapper number was reused |
-| `--date DATE` | Restrict the selection to backups whose date matches `DATE` (`YYYY-MM-DD[ HH:MM:SS]` prefix); disambiguates a reused `--snapshot NUM` |
-| `--all` | Restore all snapshots |
+| `--date DATE` | Restrict the selection to backups whose date matches `DATE` (`YYYY-MM-DD[ HH:MM:SS]` prefix; an ISO-8601 `T` separator is accepted); disambiguates a reused `--snapshot NUM` |
+| `-a`, `--all` | Restore all backups |
+| `--from-config NAME` | Only restore backups that were made from this snapper config (overrides the target `CONFIG` for matching) |
 | `--dry-run` | Show what would be done without making changes |
-| `--compress METHOD` | Compression method |
-| `--rate-limit RATE` | Bandwidth limit |
-| `--ssh-sudo` | Use sudo on remote host |
+| `--ssh-sudo` | Use `sudo` on the remote host (`ssh://` / `raw+ssh://`); required to read a root-owned target written with `--ssh-sudo` |
 | `--ssh-key FILE` | SSH private key file |
-| `--ssh-auth-sock PATH` | Explicit ssh-agent socket (overrides auto-discovery) |
-| `--progress` | Show progress bars |
-| `--json` | Output in JSON format (for --list) |
+| `--ssh-auth-sock PATH` | Explicit ssh-agent socket (overrides auto-discovery; useful under `sudo`) |
+| `--ssh-host-key-policy {accept-new,strict}` | Host-key verification policy (default `accept-new`) |
+| `--json` | Output in JSON format (for `--list`) |
 
 **Examples:**
 ```bash
 # List available backups
-btrfs-backup-ng snapper restore /mnt/backup/root --config root --list
+btrfs-backup-ng snapper restore /mnt/backup/root root --list
 
 # Restore specific snapshot
-btrfs-backup-ng snapper restore /mnt/backup/root --config root --snapshot 559
+btrfs-backup-ng snapper restore /mnt/backup/root root --snapshot 559
 
 # Restore multiple snapshots
-btrfs-backup-ng snapper restore /mnt/backup/root --config root --snapshot 559 --snapshot 560
+btrfs-backup-ng snapper restore /mnt/backup/root root --snapshot 559 --snapshot 560
 
 # Restore all snapshots
-btrfs-backup-ng snapper restore /mnt/backup/root --config root --all
+btrfs-backup-ng snapper restore /mnt/backup/root root --all
 
 # Dry run
-btrfs-backup-ng snapper restore /mnt/backup/root --config root --all --dry-run
+btrfs-backup-ng snapper restore /mnt/backup/root root --all --dry-run
 
 # Restore a root-owned raw+ssh:// backup (written with --ssh-sudo): pass it again
-btrfs-backup-ng snapper restore raw+ssh://user@host/backups/root --config root --snapshot 559 --ssh-sudo
+btrfs-backup-ng snapper restore raw+ssh://user@host/backups/root root --snapshot 559 --ssh-sudo
 
 # Reused snapper number: restore an OLDER copy by exact name (from --list) ...
-btrfs-backup-ng snapper restore /mnt/backup/root --config root --backup-name root-559-20240101-120000
+btrfs-backup-ng snapper restore /mnt/backup/root root --backup-name root-559-20240101-120000
 
 # ... or by number + date
-btrfs-backup-ng snapper restore /mnt/backup/root --config root --snapshot 559 --date 2024-01-01
+btrfs-backup-ng snapper restore /mnt/backup/root root --snapshot 559 --date 2024-01-01
 ```
 
 > **Note — snapper daemon cache.** A restored snapshot is written directly into
@@ -962,7 +961,7 @@ btrfs-backup-ng snapper generate-config [OPTIONS]
 btrfs-backup-ng snapper generate-config
 
 # Generate for specific config with target
-btrfs-backup-ng snapper generate-config --config root --target ssh://backup@server:/backups
+btrfs-backup-ng snapper generate-config root --target ssh://backup@server:/backups
 
 # Write to file
 btrfs-backup-ng snapper generate-config -o ~/.config/btrfs-backup-ng/snapper.toml

--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -882,6 +882,8 @@ btrfs-backup-ng snapper restore SOURCE --config NAME [OPTIONS]
 | `--config NAME` | Local snapper config to restore into (required) |
 | `--list` | List available backups instead of restoring |
 | `--snapshot NUM` | Restore specific snapshot by number (can be repeated) |
+| `--backup-name NAME` | Restore the exact raw backup by name from `--list` (can be repeated); reaches an older copy when a snapper number was reused |
+| `--date DATE` | Restrict the selection to backups whose date matches `DATE` (`YYYY-MM-DD[ HH:MM:SS]` prefix); disambiguates a reused `--snapshot NUM` |
 | `--all` | Restore all snapshots |
 | `--dry-run` | Show what would be done without making changes |
 | `--compress METHOD` | Compression method |
@@ -911,6 +913,12 @@ btrfs-backup-ng snapper restore /mnt/backup/root --config root --all --dry-run
 
 # Restore a root-owned raw+ssh:// backup (written with --ssh-sudo): pass it again
 btrfs-backup-ng snapper restore raw+ssh://user@host/backups/root --config root --snapshot 559 --ssh-sudo
+
+# Reused snapper number: restore an OLDER copy by exact name (from --list) ...
+btrfs-backup-ng snapper restore /mnt/backup/root --config root --backup-name root-559-20240101-120000
+
+# ... or by number + date
+btrfs-backup-ng snapper restore /mnt/backup/root --config root --snapshot 559 --date 2024-01-01
 ```
 
 > **Note — snapper daemon cache.** A restored snapshot is written directly into
@@ -924,8 +932,9 @@ btrfs-backup-ng snapper restore raw+ssh://user@host/backups/root --config root -
 > **Note — duplicate snapper numbers.** Snapper reuses snapshot numbers after a prune, so a
 > `raw://` / `raw+ssh://` target can accumulate two retained backups with the same number
 > (they differ by the date in the backup name). `--snapshot N` restores the **newest** of
-> them by date and warns; addressing an older same-number copy by name/date is a planned
-> enhancement.
+> them by date and warns. To reach an **older** copy, use `--backup-name NAME` (the unique
+> name is shown by `--list`, and in `--list --json` as `backup_name`) or narrow `--snapshot N`
+> with `--date YYYY-MM-DD`. `--list` shows a **NAME** column whenever names are available.
 
 #### snapper generate-config
 

--- a/docs/SNAPPER-INTEGRATION.md
+++ b/docs/SNAPPER-INTEGRATION.md
@@ -51,7 +51,7 @@ Found 2 snapper configuration(s):
 ### 2. List Available Snapshots
 
 ```bash
-btrfs-backup-ng snapper list --config root
+btrfs-backup-ng snapper list root
 ```
 
 Output:
@@ -95,10 +95,10 @@ btrfs-backup-ng snapper status --target /mnt/backup/root
 
 ```bash
 # List available backups
-btrfs-backup-ng snapper restore /mnt/backup/root --config root --list
+btrfs-backup-ng snapper restore /mnt/backup/root root --list
 
 # Restore specific snapshot
-btrfs-backup-ng snapper restore /mnt/backup/root --config root --snapshot 559
+btrfs-backup-ng snapper restore /mnt/backup/root root --snapshot 559
 ```
 
 A restored snapshot lands in the config's `.snapshots/{N}/` and integrates with snapper —
@@ -256,7 +256,7 @@ Backing up snapshot 561...
 Before restoring, list available backups:
 
 ```bash
-btrfs-backup-ng snapper restore /mnt/backup/root --config root --list
+btrfs-backup-ng snapper restore /mnt/backup/root root --list
 ```
 
 Output:
@@ -272,40 +272,111 @@ Snapper backups at /mnt/backup/root:
 Total: 3 backup(s)
 ```
 
+> **Command form.** `snapper restore` takes two **positional** arguments —
+> `snapper restore SOURCE CONFIG` — where `SOURCE` is the backup location and `CONFIG`
+> is the local snapper config to restore **into**. It is *not* `--config NAME`.
+> Restoring writes into the local snapper store, so run it with `sudo` (or as root).
+
 ### Restoring Snapshots
 
 ```bash
-# Restore single snapshot
-btrfs-backup-ng snapper restore /mnt/backup/root --config root --snapshot 559
+# Restore a single snapshot by number into the local 'root' config
+sudo btrfs-backup-ng snapper restore /mnt/backup/root root --snapshot 559
 
-# Restore multiple
-btrfs-backup-ng snapper restore /mnt/backup/root --config root --snapshot 559 --snapshot 560
+# Restore several
+sudo btrfs-backup-ng snapper restore /mnt/backup/root root --snapshot 559 --snapshot 560
 
 # Restore all
-btrfs-backup-ng snapper restore /mnt/backup/root --config root --all
+sudo btrfs-backup-ng snapper restore /mnt/backup/root root --all
+
+# Preview without changing anything
+sudo btrfs-backup-ng snapper restore /mnt/backup/root root --snapshot 559 --dry-run
 ```
 
-### How Restoration Works
+### Reused snapshot numbers on raw targets (and how to pick a specific backup)
 
-1. **Read backup info.xml** to get snapshot metadata
-2. **Determine next snapshot number** by scanning local `.snapshots/`
-3. **Create target directory** at `/.snapshots/{new_num}/`
-4. **Transfer via btrfs receive** (incremental when possible)
-5. **Copy info.xml** with updated snapshot number
-6. **Run snapper cleanup** if needed (optional)
-
-### Restored Snapshot Numbers
-
-Restored snapshots get new numbers to avoid conflicts:
+Snapper **reuses** snapshot numbers after a prune. On a `raw://` / `raw+ssh://` target,
+which accumulates backups over time, that means two retained backups can share the same
+number — they differ only by the **date** embedded in their unique **backup name**
+(`{config}-{number}-{timestamp}`, e.g. `root-559-20240101-120000`). `--list` shows a
+**NAME** column when names are available:
 
 ```
-Original (backup)         Restored (local)
-559 (timeline)      -->   890 (next available)
-560 (pre dnf)       -->   891
-561 (post dnf)      -->   892
+     NUM  TYPE    DATE                 DESCRIPTION      NAME
+  ------  ------  -------------------  ---------------  ------------------------
+     559  single  2024-01-01 12:00:00  before upgrade   root-559-20240101-120000
+     559  single  2024-06-01 09:30:00  before upgrade   root-559-20240601-093000
 ```
 
-The original metadata is preserved in `info.xml`, including the original number and description.
+- **By number (default):** `--snapshot 559` restores the **newest** matching backup and
+  prints a warning naming the ambiguity:
+  ```
+  WARNING  Multiple backups share number 559; restoring the newest
+           (root-559-20240601-093000). Use --backup-name or --date to restore an older copy.
+  ```
+- **An older copy by exact name** (copy the NAME from `--list`):
+  ```bash
+  sudo btrfs-backup-ng snapper restore /mnt/backup/root root \
+      --backup-name root-559-20240101-120000
+  ```
+- **An older copy by date** (a `YYYY-MM-DD[ HH:MM:SS]` prefix; an ISO-8601 `T` is also
+  accepted):
+  ```bash
+  sudo btrfs-backup-ng snapper restore /mnt/backup/root root --snapshot 559 --date 2024-01-01
+  ```
+
+`--date` is a *filter*, not a selector — combine it with `--snapshot`, `--backup-name`,
+or `--all`.
+
+### After a restore: refresh the snapper daemon
+
+A restored snapshot is written **directly** into `.snapshots/{N}/` (not via
+`snapper create`), so the snapper **daemon caches** its snapshot list and will not see the
+new slot until it rescans — `snapper diff`/`undochange`/rollback may report *"Snapshot 'N'
+not found"* immediately after a restore. The command prints a reminder; run `snapper list`
+(or reboot) first:
+
+```bash
+sudo btrfs-backup-ng snapper restore /mnt/backup/root root --snapshot 559
+#   -> "Restored ... Note: run 'snapper -c root list' (or reboot) so snapper's daemon
+#      picks up the restored snapshot(s) before 'snapper diff'/'undochange'/rollback."
+
+snapper -c root list          # triggers the daemon rescan
+snapper -c root diff 890..0   # now works against the restored slot (890 = new number)
+```
+
+The on-disk snapshot is complete and correct — only the daemon's in-memory view lags.
+Restored slot directories use snapper's native `0755` permissions.
+
+**To roll back**, prefer snapper's own flow: boot the read-only `grub-btrfs` entry for the
+restored snapshot, then `snapper rollback`. (For bare-metal recovery to an arbitrary
+subvolume without snapper, use the generic `btrfs-backup-ng restore` command instead.)
+
+### Restoring from raw:// and raw+ssh:// targets
+
+Raw backups restore the same way; the stream is decrypted/decompressed locally. If the
+remote target was **written** with `--ssh-sudo` (its directory/streams are root-owned),
+pass `--ssh-sudo` to `restore` as well — otherwise it reports an actionable permission
+error instead of the backups:
+
+```bash
+sudo btrfs-backup-ng snapper restore \
+    raw+ssh://backup@server/mnt/nas/root root --snapshot 559 --ssh-sudo
+```
+
+### How restoration works
+
+1. **Resolve the requested backup** (by number → newest on a collision, or by exact
+   `--backup-name` / `--date`).
+2. **Determine the next local snapshot number** by scanning the config's `.snapshots/`.
+3. **Receive the stream** into that fresh `.snapshots/{new_num}/` slot (crash-safe:
+   cleaned up on failure), verifying stream integrity first.
+4. **Write `info.xml`** renumbered to the new slot, preserving the original type,
+   description, cleanup, and **all userdata** (and any element snapper wrote, e.g.
+   `<uid>`), so the restored snapshot is a first-class snapper snapshot.
+
+Restored snapshots get **new** local numbers (the next available) to avoid conflicts; the
+original metadata — including description and userdata — is preserved in `info.xml`.
 
 ## Remote Backups
 
@@ -495,7 +566,7 @@ btrfs-backup-ng doctor --check transfers
 Periodically verify backups work:
 ```bash
 # Dry run restore
-btrfs-backup-ng snapper restore /mnt/backup/root --config root --snapshot 559 --dry-run
+btrfs-backup-ng snapper restore /mnt/backup/root root --snapshot 559 --dry-run
 ```
 
 ## See Also

--- a/man/man1/btrfs-backup-ng-snapper.1
+++ b/man/man1/btrfs-backup-ng-snapper.1
@@ -135,7 +135,17 @@ Options:
 List available backups at the source location.
 .TP
 .BI \-\-snapshot " NUM"
-Restore specific snapshot number. Can be specified multiple times.
+Restore specific snapshot number. Can be specified multiple times. On a reused
+(duplicate) snapper number, restores the newest by date and warns.
+.TP
+.BI \-\-backup-name " NAME"
+Restore the exact raw backup by its unique name (shown by \fB\-\-list\fR). Can be
+specified multiple times. Use this to reach an older copy when a snapper number
+was reused after a prune.
+.TP
+.BI \-\-date " DATE"
+Restrict the selection to backups whose date matches DATE
+(\fIYYYY-MM-DD\fR[\fI HH:MM:SS\fR] prefix). Disambiguates a reused \fB\-\-snapshot\fR.
 .TP
 .BR \-a ", " \-\-all
 Restore all available backups.
@@ -166,7 +176,9 @@ For a \fBraw+ssh://\fR source written with \fB\-\-ssh-sudo\fR (root\-owned remot
 directory), pass \fB\-\-ssh-sudo\fR to \fBrestore\fR as well, or it will report a
 permission error instead of the backups. When Snapper has reused a number after a prune,
 a raw target can hold two backups with the same number; \fB\-\-snapshot \fINUM\fR restores
-the newest by date and warns.
+the newest by date and warns. To restore an older copy, use \fB\-\-backup-name \fINAME\fR
+(names are shown by \fB\-\-list\fR) or narrow \fB\-\-snapshot \fINUM\fR with
+\fB\-\-date \fIYYYY-MM-DD\fR.
 .SS status
 Show backup status for Snapper configurations.
 .PP

--- a/src/btrfs_backup_ng/cli/dispatcher.py
+++ b/src/btrfs_backup_ng/cli/dispatcher.py
@@ -1436,6 +1436,20 @@ Examples:
         help="Restore all snapper backups",
     )
     snapper_restore.add_argument(
+        "--backup-name",
+        action="append",
+        metavar="NAME",
+        help="Restore the exact raw backup by its name (from --list); can be "
+        "repeated. Use this to restore an older backup when a snapper number was "
+        "reused (see --list for names).",
+    )
+    snapper_restore.add_argument(
+        "--date",
+        metavar="DATE",
+        help="Restrict the selection to backups whose date matches DATE "
+        "(YYYY-MM-DD[ HH:MM:SS] prefix). Disambiguates a reused --snapshot NUM.",
+    )
+    snapper_restore.add_argument(
         "--from-config",
         metavar="NAME",
         help="Only restore from this snapper config in backup",

--- a/src/btrfs_backup_ng/cli/snapper_cmd.py
+++ b/src/btrfs_backup_ng/cli/snapper_cmd.py
@@ -506,6 +506,28 @@ def _handle_status(args: argparse.Namespace) -> int:
     return 0
 
 
+def _backup_date_matches(backup: dict, date_filter: str) -> bool:
+    """True if the backup's snapper date starts with date_filter (prefix match).
+
+    A prefix lets "2024-01-01" match any time that day, and a full
+    "2024-01-01 12:00:00" match exactly -- the same format shown in --list.
+    """
+    meta = backup.get("metadata")
+    if meta is None or getattr(meta, "date", None) is None:
+        return False
+    return str(meta.date).startswith(date_filter)
+
+
+def _backup_recency_key(backup: dict) -> tuple[str, str]:
+    """Sort key for choosing the newest of a colliding snapper number.
+
+    Newest snapper date wins; backup_name breaks a same-date tie for determinism.
+    """
+    meta = backup.get("metadata")
+    date = str(meta.date) if meta and getattr(meta, "date", None) else ""
+    return (date, backup.get("backup_name") or "")
+
+
 def _handle_restore(args: argparse.Namespace) -> int:
     """Handle 'snapper restore' command."""
     from ..core.restore import (
@@ -556,6 +578,9 @@ def _handle_restore(args: argparse.Namespace) -> int:
                         "description": b["metadata"].description
                         if b.get("metadata")
                         else None,
+                        # backup_name is the unique identity for raw backups (None for
+                        # btrfs) -- pass it to --backup-name to restore an exact copy.
+                        "backup_name": b.get("backup_name"),
                     }
                     for b in backups
                 ],
@@ -566,19 +591,40 @@ def _handle_restore(args: argparse.Namespace) -> int:
                 logger.info("No snapper backups found at %s", source_path)
                 return 0
 
+            # A NAME column is only meaningful for raw targets (btrfs uses the number,
+            # which is unique there); show it only when at least one backup has a name.
+            has_names = any(b.get("backup_name") for b in backups)
             logger.info("Snapper backups at %s:", source_path)
             print()
-            print(f"  {'NUM':>6}  {'TYPE':<6}  {'DATE':<19}  {'DESCRIPTION'}")
-            print(f"  {'-' * 6}  {'-' * 6}  {'-' * 19}  {'-' * 30}")
+            if has_names:
+                print(
+                    f"  {'NUM':>6}  {'TYPE':<6}  {'DATE':<19}  {'DESCRIPTION':<30}  NAME"
+                )
+                print(f"  {'-' * 6}  {'-' * 6}  {'-' * 19}  {'-' * 30}  {'-' * 24}")
+            else:
+                print(f"  {'NUM':>6}  {'TYPE':<6}  {'DATE':<19}  {'DESCRIPTION'}")
+                print(f"  {'-' * 6}  {'-' * 6}  {'-' * 19}  {'-' * 30}")
 
             for b in backups:
                 meta = b.get("metadata")
                 snap_type = meta.type if meta else "?"
                 date = str(meta.date)[:19] if meta and meta.date else "?"
                 desc = (meta.description or "")[:30] if meta else ""
-                print(f"  {b['number']:>6}  {snap_type:<6}  {date}  {desc}")
+                if has_names:
+                    # NAME is untruncated so it can be copied into --backup-name.
+                    name = b.get("backup_name") or ""
+                    print(
+                        f"  {b['number']:>6}  {snap_type:<6}  {date}  {desc:<30}  {name}"
+                    )
+                else:
+                    print(f"  {b['number']:>6}  {snap_type:<6}  {date}  {desc}")
 
             print(f"\nTotal: {len(backups)} backup(s)")
+            if has_names:
+                print(
+                    "\nTip: when a snapper number was reused, restore a specific copy "
+                    "with --backup-name <NAME> or --snapshot <NUM> --date <DATE>."
+                )
 
         return 0
 
@@ -595,10 +641,14 @@ def _handle_restore(args: argparse.Namespace) -> int:
 
     # Determine what to restore
     snapshot_numbers = args.snapshot if args.snapshot else None
+    backup_names = getattr(args, "backup_name", None) or None
     restore_all = getattr(args, "all", False)
+    date_filter = getattr(args, "date", None)
 
-    if not snapshot_numbers and not restore_all:
-        logger.error("Specify --snapshot NUM or --all to restore snapshots.")
+    if not snapshot_numbers and not backup_names and not restore_all:
+        logger.error(
+            "Specify --snapshot NUM, --backup-name NAME, or --all to restore snapshots."
+        )
         logger.info("Use --list to see available backups.")
         return 1
 
@@ -613,15 +663,75 @@ def _handle_restore(args: argparse.Namespace) -> int:
         logger.error("No backups found at %s", source_path)
         return 1
 
-    # Filter to requested snapshots
-    if restore_all:
-        to_restore = backups
-    else:
-        # snapshot_numbers is guaranteed non-None here due to early return above
-        to_restore = [b for b in backups if b["number"] in (snapshot_numbers or [])]
-        if not to_restore:
-            logger.error("None of the requested snapshots found in backup")
+    # A --date refinement narrows the candidate pool BEFORE selection, so
+    # `--snapshot N --date D` picks the D-dated copy of N rather than the newest.
+    candidates = backups
+    if date_filter:
+        candidates = [b for b in backups if _backup_date_matches(b, date_filter)]
+        if not candidates:
+            logger.error("No backups match --date %s", date_filter)
             return 1
+
+    # Build the selection.
+    #   --backup-name : EXACT identity, restored as-is (no dedup).
+    #   --snapshot    : by number; on a reused-number collision, restore the NEWEST
+    #                   and warn (Option A) -- --backup-name/--date reach an older one.
+    #   --all         : everything (after any --date filter).
+    to_restore: list[dict] = []
+    seen: set = set()
+
+    def _add(b: dict) -> None:
+        key = b.get("backup_name") or ("num", b["number"])
+        if key not in seen:
+            seen.add(key)
+            to_restore.append(b)
+
+    if restore_all:
+        for b in candidates:
+            _add(b)
+
+    if backup_names:
+        for name in backup_names:
+            matches = [b for b in candidates if b.get("backup_name") == name]
+            if not matches:
+                logger.error(
+                    "Backup name %r not found at %s%s",
+                    name,
+                    source_path,
+                    f" matching --date {date_filter}" if date_filter else "",
+                )
+                return 1
+            for b in matches:
+                _add(b)
+
+    if snapshot_numbers:
+        for num in snapshot_numbers:
+            matches = [b for b in candidates if b["number"] == num]
+            if not matches:
+                logger.error(
+                    "Snapshot number %d not found at %s%s",
+                    num,
+                    source_path,
+                    f" matching --date {date_filter}" if date_filter else "",
+                )
+                return 1
+            if len(matches) > 1:
+                # Reused number: newest wins (Option A), warn with an actionable path.
+                matches.sort(key=_backup_recency_key, reverse=True)
+                chosen = matches[0]
+                logger.warning(
+                    "Multiple backups share number %d; restoring the newest (%s). "
+                    "Use --backup-name or --date to restore an older copy.",
+                    num,
+                    chosen.get("backup_name") or chosen["number"],
+                )
+                _add(chosen)
+            else:
+                _add(matches[0])
+
+    if not to_restore:
+        logger.error("None of the requested snapshots found in backup")
+        return 1
 
     # Sort by number (oldest first for proper incremental chain)
     to_restore.sort(key=lambda b: b["number"])
@@ -668,6 +778,9 @@ def _handle_restore(args: argparse.Namespace) -> int:
                 options=options,
                 dry_run=args.dry_run,
                 endpoint_options=endpoint_options,
+                # Restore the EXACT enumerated backup (raw carries a unique name);
+                # None for btrfs -> number-based path. Fixes the collision double-restore.
+                backup_name=backup.get("backup_name"),
             )
 
             if not args.dry_run:

--- a/src/btrfs_backup_ng/cli/snapper_cmd.py
+++ b/src/btrfs_backup_ng/cli/snapper_cmd.py
@@ -515,6 +515,10 @@ def _backup_date_matches(backup: dict, date_filter: str) -> bool:
     meta = backup.get("metadata")
     if meta is None or getattr(meta, "date", None) is None:
         return False
+    # Accept an ISO-8601 'T' separator (what datetime.isoformat() emits, and the
+    # intuitive form to type) even though str(meta.date) is space-separated.
+    if len(date_filter) > 10 and date_filter[10] == "T":
+        date_filter = date_filter[:10] + " " + date_filter[11:]
     return str(meta.date).startswith(date_filter)
 
 
@@ -646,9 +650,19 @@ def _handle_restore(args: argparse.Namespace) -> int:
     date_filter = getattr(args, "date", None)
 
     if not snapshot_numbers and not backup_names and not restore_all:
-        logger.error(
-            "Specify --snapshot NUM, --backup-name NAME, or --all to restore snapshots."
-        )
+        if date_filter:
+            # --date is a narrowing FILTER, not a selector -- point the user there
+            # instead of the generic message (they likely expected --date to select).
+            logger.error(
+                "--date only narrows a selection; combine it with --snapshot NUM, "
+                "--backup-name NAME, or --all (e.g. --all --date %s).",
+                date_filter,
+            )
+        else:
+            logger.error(
+                "Specify --snapshot NUM, --backup-name NAME, or --all to restore "
+                "snapshots."
+            )
         logger.info("Use --list to see available backups.")
         return 1
 
@@ -669,7 +683,11 @@ def _handle_restore(args: argparse.Namespace) -> int:
     if date_filter:
         candidates = [b for b in backups if _backup_date_matches(b, date_filter)]
         if not candidates:
-            logger.error("No backups match --date %s", date_filter)
+            logger.error(
+                "No backups match --date %s (expected a YYYY-MM-DD[ HH:MM:SS] prefix; "
+                "see --list for exact dates).",
+                date_filter,
+            )
             return 1
 
     # Build the selection.
@@ -704,7 +722,10 @@ def _handle_restore(args: argparse.Namespace) -> int:
             for b in matches:
                 _add(b)
 
-    if snapshot_numbers:
+    # --all already added every candidate, so an explicit --snapshot adds nothing --
+    # skip it to avoid a FALSE "restoring the newest, older unreachable" warning when
+    # the older copy is in fact already being restored under --all.
+    if snapshot_numbers and not restore_all:
         for num in snapshot_numbers:
             matches = [b for b in candidates if b["number"] == num]
             if not matches:

--- a/src/btrfs_backup_ng/core/restore.py
+++ b/src/btrfs_backup_ng/core/restore.py
@@ -848,17 +848,28 @@ def _list_raw_snapper_backups(
 
 
 def _resolve_raw_snapper_backup(
-    backup_path: str, backup_number: int, endpoint_options: dict | None = None
+    backup_path: str,
+    backup_number: int,
+    endpoint_options: dict | None = None,
+    backup_name: str | None = None,
 ) -> tuple[Any, Any, Any]:
-    """Resolve a raw snapper backup number to (endpoint, RawSnapshot, BackupMetadata).
+    """Resolve a raw snapper backup to (endpoint, RawSnapshot, BackupMetadata).
 
-    Maps a snapper number -> backup_name (via the ``.snapper-meta.json`` sidecars)
-    -> the matching RawSnapshot (by ``.name``, the shared cross-type backup identity
-    set when the stream and sidecar were written from one ``get_backup_name()``). One
-    endpoint is built and reused for both the lookup and the later ``send()``. The
-    returned BackupMetadata carries the snapper fields used to regenerate info.xml.
+    Two resolution modes:
 
-    Raises RestoreError if the number has no sidecar or its stream file is missing.
+    * ``backup_name`` given (EXACT) -- resolve that specific sidecar by its unique
+      name. This is what the CLI threads once it has enumerated the exact backup the
+      user selected (``--snapshot`` after collision-dedup, ``--backup-name``,
+      ``--date``), so restore materializes precisely that backup rather than
+      re-guessing by number.
+    * ``backup_name`` None (FALLBACK, bare-number API callers) -- match by
+      ``snapper_number``; on a collision (snapper reuses numbers after a prune, and
+      raw targets accumulate streams), pick the NEWEST by snapper_date and warn.
+
+    The matched name maps to a RawSnapshot by ``.name`` (the shared cross-type backup
+    identity). One endpoint is built and reused for the lookup and the later ``send()``.
+
+    Raises RestoreError if the requested backup has no sidecar or its stream is missing.
     """
     from ..endpoint import choose_endpoint
 
@@ -866,45 +877,50 @@ def _resolve_raw_snapper_backup(
         backup_path, _raw_endpoint_config(backup_path, endpoint_options)
     )
 
-    # Collect ALL sidecars matching this snapper number, not just the first. Snapper
-    # reuses numbers after a prune (see operations.py: "the snapper number, which
-    # snapper reuses after a prune"), and raw targets accumulate streams over time, so
-    # two RETAINED sidecars can share a number, differing only by the date in their
-    # backup_name. Iterating the UNORDERED set and breaking on the first match would
-    # pick nondeterministically (Python's salted set order) -- a wrong-snapshot restore.
-    # Iterate a sorted list and, on a collision, pick the NEWEST by snapper_date and warn
-    # loudly so the ambiguity is visible (name/date-based addressing is a follow-up).
-    matches: list[tuple[str, Any]] = []
-    for name in sorted(_list_snapper_backups_at_destination(endpoint)):
+    if backup_name is not None:
+        # EXACT: load this specific sidecar by its unique name (no number guessing).
         try:
-            backup_meta = _load_snapper_sidecar(endpoint, name)
+            match_meta = _load_snapper_sidecar(endpoint, backup_name)
         except Exception as e:
-            logger.warning(
-                "Skipping raw snapper backup %r (unreadable sidecar): %s", name, e
+            raise RestoreError(
+                f"Snapper backup {backup_name!r} not found at {backup_path}: {e}"
+            ) from e
+        match_name = backup_name
+    else:
+        # FALLBACK: collect ALL sidecars matching this snapper number, then pick the
+        # newest on a collision. Iterating a sorted list keeps the choice deterministic
+        # (the underlying set order is salted -> would otherwise be nondeterministic).
+        matches: list[tuple[str, Any]] = []
+        for name in sorted(_list_snapper_backups_at_destination(endpoint)):
+            try:
+                meta = _load_snapper_sidecar(endpoint, name)
+            except Exception as e:
+                logger.warning(
+                    "Skipping raw snapper backup %r (unreadable sidecar): %s", name, e
+                )
+                continue
+            if meta.snapper_number == backup_number:
+                matches.append((name, meta))
+
+        if not matches:
+            raise RestoreError(
+                f"Snapper backup number {backup_number} not found at {backup_path}"
             )
-            continue
-        if backup_meta.snapper_number == backup_number:
-            matches.append((name, backup_meta))
 
-    if not matches:
-        raise RestoreError(
-            f"Snapper backup number {backup_number} not found at {backup_path}"
-        )
+        if len(matches) > 1:
+            # Deterministic: newest snapper_date wins (name breaks a date tie).
+            matches.sort(key=lambda nm: (nm[1].snapper_date, nm[0]), reverse=True)
+            logger.warning(
+                "Multiple raw snapper backups share number %d at %s: %s. Restoring the "
+                "newest (%s, %s); use --backup-name or --date to restore an older copy.",
+                backup_number,
+                backup_path,
+                ", ".join(f"{n} ({m.snapper_date})" for n, m in matches),
+                matches[0][0],
+                matches[0][1].snapper_date,
+            )
 
-    if len(matches) > 1:
-        # Deterministic: newest snapper_date wins (name breaks a date tie).
-        matches.sort(key=lambda nm: (nm[1].snapper_date, nm[0]), reverse=True)
-        logger.warning(
-            "Multiple raw snapper backups share number %d at %s: %s. Restoring the "
-            "newest (%s, %s); the older copies are not reachable by number alone.",
-            backup_number,
-            backup_path,
-            ", ".join(f"{n} ({m.snapper_date})" for n, m in matches),
-            matches[0][0],
-            matches[0][1].snapper_date,
-        )
-
-    match_name, match_meta = matches[0]
+        match_name, match_meta = matches[0]
 
     raw_snapshot = next(
         (s for s in endpoint.list_snapshots() if s.name == match_name), None
@@ -926,6 +942,7 @@ def restore_snapper_snapshot(
     options: dict | None = None,
     dry_run: bool = False,
     endpoint_options: dict | None = None,
+    backup_name: str | None = None,
 ) -> tuple[int, Path]:
     """Restore a snapper backup to local snapper format.
 
@@ -986,7 +1003,7 @@ def restore_snapper_snapshot(
 
     if is_raw:
         raw_endpoint, raw_snapshot, raw_backup_meta = _resolve_raw_snapper_backup(
-            backup_path, backup_number, endpoint_options
+            backup_path, backup_number, endpoint_options, backup_name
         )
         source_desc = raw_snapshot.name
     else:

--- a/tests/test_completions.py
+++ b/tests/test_completions.py
@@ -459,3 +459,23 @@ class TestShellConfigTypes:
     def test_fish_config_has_required_keys(self):
         """Test fish config has all required keys."""
         pass
+
+
+class TestSnapperRestoreCompletionFlags:
+    """R11b: new snapper-restore flags stay in lockstep across all shell completions."""
+
+    def _completions_dir(self):
+        return Path(__file__).resolve().parent.parent / "completions"
+
+    def test_backup_name_and_date_in_all_shells(self):
+        d = self._completions_dir()
+        # bash/zsh spell long flags "--name"; fish uses "-l name".
+        expected = {
+            "btrfs-backup-ng.bash": ("--backup-name", "--date"),
+            "btrfs-backup-ng.zsh": ("--backup-name", "--date"),
+            "btrfs-backup-ng.fish": ("-l backup-name", "-l date"),
+        }
+        for fname, needles in expected.items():
+            text = (d / fname).read_text()
+            for needle in needles:
+                assert needle in text, f"{fname} missing {needle!r}"

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -4331,3 +4331,67 @@ class TestRemoteSnapperEnumerationErrors:
         )
         with pytest.raises(RuntimeError, match="host.example"):
             _list_snapper_backups_at_destination(ep)
+
+
+class TestRawSnapperExactNameResolution:
+    """R11b: _resolve_raw_snapper_backup resolves the EXACT backup by name."""
+
+    def _fake_local_ep(self, tmp_path, stream_names):
+        streams = []
+        for nm in stream_names:
+            s = MagicMock()
+            s.name = nm
+            streams.append(s)
+
+        class _Ep:
+            def __init__(self):
+                self.config = {"path": tmp_path}
+
+            def list_snapshots(self, flush_cache=False):
+                return streams
+
+        return _Ep()
+
+    def _two_colliding(self, tmp_path):
+        _write_named_sidecar(tmp_path, "root-100-old", 100, "2024-01-01 00:00:00")
+        _write_named_sidecar(tmp_path, "root-100-new", 100, "2024-06-01 00:00:00")
+        return self._fake_local_ep(tmp_path, ["root-100-old", "root-100-new"])
+
+    def test_backup_name_resolves_exact_older_copy(self, tmp_path, caplog):
+        from btrfs_backup_ng.core.restore import _resolve_raw_snapper_backup
+
+        fake = self._two_colliding(tmp_path)
+        with patch("btrfs_backup_ng.endpoint.choose_endpoint", return_value=fake):
+            with caplog.at_level("WARNING"):
+                _ep, snap, meta = _resolve_raw_snapper_backup(
+                    f"raw://{tmp_path}", 100, None, "root-100-old"
+                )
+        assert snap.name == "root-100-old"  # the OLDER copy, exactly
+        assert meta.snapper_date == "2024-01-01 00:00:00"
+        # exact name => no newest-by-number collision warning
+        assert "share number" not in caplog.text
+
+    def test_backup_name_not_found_raises(self, tmp_path):
+        from btrfs_backup_ng.core.restore import (
+            RestoreError,
+            _resolve_raw_snapper_backup,
+        )
+
+        fake = self._two_colliding(tmp_path)
+        with patch("btrfs_backup_ng.endpoint.choose_endpoint", return_value=fake):
+            with pytest.raises(RestoreError, match="not found"):
+                _resolve_raw_snapper_backup(
+                    f"raw://{tmp_path}", 100, None, "root-100-missing"
+                )
+
+    def test_bare_number_still_picks_newest_and_warns(self, tmp_path, caplog):
+        """Fallback (no backup_name) keeps the R11 newest+warn behavior."""
+        from btrfs_backup_ng.core.restore import _resolve_raw_snapper_backup
+
+        fake = self._two_colliding(tmp_path)
+        with patch("btrfs_backup_ng.endpoint.choose_endpoint", return_value=fake):
+            with caplog.at_level("WARNING"):
+                _ep, snap, _m = _resolve_raw_snapper_backup(f"raw://{tmp_path}", 100)
+        assert snap.name == "root-100-new"
+        assert "share number 100" in caplog.text
+        assert "--backup-name or --date" in caplog.text

--- a/tests/test_snapper_cmd.py
+++ b/tests/test_snapper_cmd.py
@@ -1877,6 +1877,56 @@ class TestRestoreNameDateSelection:
         names = [e["backup_name"] for e in data["backups"]]
         assert "root-100-old" in names and "root-100-new" in names
 
+    def test_overlapping_selectors_restore_each_once(self, mock_snapper_configs):
+        """The _add() dedup guard: overlapping --backup-name + --snapshot restore once.
+
+        Kills a mutation that removes the guard (which would double-restore the newest).
+        """
+        result, mr = self._run(
+            self._args(backup_name=["root-100-new"], snapshot=[100]),
+            mock_snapper_configs,
+        )
+        assert result == 0
+        names = self._restored_names(mr)
+        assert names == ["root-100-new"]  # exactly once, not twice
+        assert len(names) == len(set(names))
+
+    def test_all_plus_snapshot_collision_no_false_warning(
+        self, capsys, mock_snapper_configs
+    ):
+        """--all --snapshot N restores each once and does NOT emit the newest-only warn."""
+        result, mr = self._run(
+            self._args(all=True, snapshot=[100]), mock_snapper_configs
+        )
+        assert result == 0
+        assert sorted(self._restored_names(mr)) == [
+            "root-100-new",
+            "root-100-old",
+            "root-3-x",
+        ]
+        cap = capsys.readouterr()
+        text = " ".join((cap.out + cap.err).split())
+        assert "Multiple backups share number" not in text  # older IS restored
+
+    def test_date_alone_errors_mentioning_date(self, capsys, mock_snapper_configs):
+        """--date with no selector explains it is a filter (not a selector)."""
+        result, mr = self._run(self._args(date="2024-01-01"), mock_snapper_configs)
+        assert result == 1
+        assert mr.call_count == 0
+        cap = capsys.readouterr()
+        text = " ".join((cap.out + cap.err).split())
+        # message names --date and points at combining it
+        assert "--date" in text
+
+    def test_iso_t_separator_date_matches(self, mock_snapper_configs):
+        """--date with an ISO 'T' separator resolves (normalized to a space)."""
+        result, mr = self._run(
+            self._args(snapshot=[100], date="2024-06-01T00:00:00"),
+            mock_snapper_configs,
+        )
+        assert result == 0
+        assert self._restored_names(mr) == ["root-100-new"]  # the 2024-06-01 copy
+
 
 class TestBackupSelectionHelpers:
     """R11b: the date-match and recency-key helpers."""

--- a/tests/test_snapper_cmd.py
+++ b/tests/test_snapper_cmd.py
@@ -1737,3 +1737,179 @@ class TestRestoreSnapperdCacheHint:
         result, text = self._run(self._args(dry_run=True), mock_snapper_configs, capsys)
         assert result == 0
         assert "daemon picks up the restored" not in text
+
+
+class TestRestoreNameDateSelection:
+    """R11b: --backup-name / --date selection + collision dedup + name threading."""
+
+    def _mk_backups(self):
+        from datetime import datetime
+
+        from btrfs_backup_ng.snapper.metadata import SnapperMetadata
+
+        def mk(num, name, date):
+            return {
+                "number": num,
+                "metadata": SnapperMetadata(
+                    type="single",
+                    num=num,
+                    date=datetime.fromisoformat(date),
+                    description="d",
+                ),
+                "raw": True,
+                "backup_name": name,
+            }
+
+        # two backups share number 100 (reused after prune); 3 is unique
+        return [
+            mk(3, "root-3-x", "2024-01-01T00:00:00"),
+            mk(100, "root-100-old", "2024-01-01T00:00:00"),
+            mk(100, "root-100-new", "2024-06-01T00:00:00"),
+        ]
+
+    def _args(self, **kw):
+        base = dict(
+            source="raw:///b",
+            config="root",
+            snapshot=None,
+            backup_name=None,
+            all=False,
+            date=None,
+            list=False,
+            json=False,
+            dry_run=False,
+            verbose=False,
+            quiet=False,
+            log_level=None,
+        )
+        base.update(kw)
+        return argparse.Namespace(**base)
+
+    def _run(self, args, mock_snapper_configs):
+        from pathlib import Path
+
+        from btrfs_backup_ng.cli.snapper_cmd import _handle_restore
+
+        with (
+            patch("btrfs_backup_ng.cli.snapper_cmd.SnapperScanner") as scanner_cls,
+            patch(
+                "btrfs_backup_ng.core.restore.list_snapper_backups",
+                return_value=self._mk_backups(),
+            ),
+            patch(
+                "btrfs_backup_ng.core.restore.restore_snapper_snapshot"
+            ) as mock_restore,
+        ):
+            scanner = MagicMock()
+            scanner.get_config.return_value = mock_snapper_configs[0]
+            scanner_cls.return_value = scanner
+            mock_restore.return_value = (1, Path("/x/snapshot"))
+            result = _handle_restore(args)
+        return result, mock_restore
+
+    @staticmethod
+    def _restored_names(mock_restore):
+        return [c.kwargs.get("backup_name") for c in mock_restore.call_args_list]
+
+    def test_backup_name_restores_exact_older(self, mock_snapper_configs):
+        result, mr = self._run(
+            self._args(backup_name=["root-100-old"]), mock_snapper_configs
+        )
+        assert result == 0
+        assert self._restored_names(mr) == ["root-100-old"]
+
+    def test_snapshot_collision_restores_newest_only_and_warns(
+        self, capsys, mock_snapper_configs
+    ):
+        result, mr = self._run(self._args(snapshot=[100]), mock_snapper_configs)
+        assert result == 0
+        assert self._restored_names(mr) == ["root-100-new"]  # newest only, once
+        cap = capsys.readouterr()
+        text = " ".join((cap.out + cap.err).split())
+        assert "Multiple backups share number 100" in text
+        assert "--backup-name or --date" in text
+
+    def test_snapshot_with_date_picks_dated_copy(self, mock_snapper_configs):
+        result, mr = self._run(
+            self._args(snapshot=[100], date="2024-01-01"), mock_snapper_configs
+        )
+        assert result == 0
+        assert self._restored_names(mr) == ["root-100-old"]  # the 2024-01-01 copy
+
+    def test_all_restores_each_backup_once(self, mock_snapper_configs):
+        result, mr = self._run(self._args(all=True), mock_snapper_configs)
+        assert result == 0
+        assert sorted(self._restored_names(mr)) == [
+            "root-100-new",
+            "root-100-old",
+            "root-3-x",
+        ]
+
+    def test_backup_name_not_found_errors_without_restoring(self, mock_snapper_configs):
+        result, mr = self._run(
+            self._args(backup_name=["root-does-not-exist"]), mock_snapper_configs
+        )
+        assert result == 1
+        assert mr.call_count == 0
+
+    def test_date_with_no_match_errors(self, mock_snapper_configs):
+        result, mr = self._run(
+            self._args(snapshot=[100], date="1999-12-31"), mock_snapper_configs
+        )
+        assert result == 1
+        assert mr.call_count == 0
+
+    def test_no_selection_errors(self, mock_snapper_configs):
+        result, mr = self._run(self._args(), mock_snapper_configs)
+        assert result == 1
+        assert mr.call_count == 0
+
+    def test_list_table_shows_name_column_and_tip(self, capsys, mock_snapper_configs):
+        self._run(self._args(list=True), mock_snapper_configs)
+        out = capsys.readouterr().out
+        assert "NAME" in out
+        assert "root-100-old" in out and "root-100-new" in out
+        assert "--backup-name" in out  # the disambiguation tip
+
+    def test_list_json_includes_backup_name(self, capsys, mock_snapper_configs):
+        self._run(self._args(list=True, json=True), mock_snapper_configs)
+        data = json.loads(capsys.readouterr().out)
+        names = [e["backup_name"] for e in data["backups"]]
+        assert "root-100-old" in names and "root-100-new" in names
+
+
+class TestBackupSelectionHelpers:
+    """R11b: the date-match and recency-key helpers."""
+
+    def _b(self, name, date):
+        from datetime import datetime
+
+        from btrfs_backup_ng.snapper.metadata import SnapperMetadata
+
+        return {
+            "number": 1,
+            "backup_name": name,
+            "metadata": SnapperMetadata(
+                type="single", num=1, date=datetime.fromisoformat(date)
+            ),
+        }
+
+    def test_date_matches_prefix(self):
+        from btrfs_backup_ng.cli.snapper_cmd import _backup_date_matches
+
+        b = self._b("x", "2024-01-01T12:30:00")
+        assert _backup_date_matches(b, "2024-01-01")
+        assert _backup_date_matches(b, "2024-01-01 12:30:00")
+        assert not _backup_date_matches(b, "2024-01-02")
+
+    def test_date_matches_handles_missing_metadata(self):
+        from btrfs_backup_ng.cli.snapper_cmd import _backup_date_matches
+
+        assert not _backup_date_matches({"number": 1}, "2024-01-01")
+
+    def test_recency_key_orders_newest_last(self):
+        from btrfs_backup_ng.cli.snapper_cmd import _backup_recency_key
+
+        old = self._b("old", "2024-01-01T00:00:00")
+        new = self._b("new", "2024-06-01T00:00:00")
+        assert max([old, new], key=_backup_recency_key)["backup_name"] == "new"


### PR DESCRIPTION
## snapper restore: `--backup-name` / `--date` addressing for reused numbers + double-restore fix

Follow-up to R11 (#78). When snapper reuses a snapshot number after a prune, a `raw://` /
`raw+ssh://` target can hold two retained backups with the **same** number, differing only by the
date in their unique `backup_name`. R11 restored the newest and warned, but the older copy was
unreachable — and there was a latent bug: `--snapshot N` on a collision put both dicts in the
restore set, then each re-resolved by number to the newest, restoring the newest **twice** while
the older stayed orphaned.

### What changed
- **`--backup-name NAME`** (repeatable) — restore the exact raw backup by its unique name (shown by
  `--list`). Reaches an older same-number copy.
- **`--date DATE`** — narrow the selection by a `YYYY-MM-DD[ HH:MM:SS]` prefix (an ISO-8601 `T`
  separator is accepted too); disambiguates a reused `--snapshot N`.
- **`--list`** (table + `--json`) now surfaces `backup_name` (a **NAME** column when any backup has
  one, untruncated so it's copyable) with a disambiguation tip.
- **Core fix:** the CLI threads the *selected* backup's `backup_name` down to
  `restore_snapper_snapshot → _resolve_raw_snapper_backup`, which resolves that **exact** sidecar
  instead of re-guessing by number. This makes the CLI selection authoritative and fixes the
  double-restore. The bare-number newest+warn path stays as the API fallback. btrfs backups
  (`backup_name=None`) keep the unchanged number path.
- **Docs + completions:** CLI-REFERENCE, snapper manpage, and bash/zsh/fish completions updated
  (with a 3-shell test guard).

Design: **Option A** — `--snapshot N` stays newest-only + warn; the explicit flags are the way to
reach an older copy.

### Verification
- **Adversarial multi-lens review** (17 agents): 11 raised → 5 confirmed / 6 refuted,
  ready-with-minor-fixes. All 5 confirmed (low/nit UX polish) fixed in this branch: ISO-`T` date
  normalization + actionable zero-match error; suppressed false collision warning under
  `--all --snapshot N`; `--date`-alone error now names `--date`; completions for the new flags;
  a mutation-verified dedup-guard test.
- **Hardware-proven on real snapper 0.13** (isolated, torn down): a crafted number-1 collision with
  distinct content (STATE-A older / STATE-B newer) — `--snapshot 1` → newest (STATE-B) + warn;
  `--backup-name <older>` → STATE-A; `--snapshot 1 --date 2026-08-01` → STATE-A;
  `--date …T19:07:37` (ISO `T`) → STATE-A; `--all --snapshot 1` → both, no false warn. Name/date
  select the correct **point-in-time**, not just the right sidecar.
- All new/changed tests mutation-verified. Full suite green (2624 passed; the 2 real-`ssh localhost`
  integration files are environment-gated in the dev box by a GSSAPI/KDC stall, unrelated — they
  pass in CI).
