### PR TITLE
docs: audit README so every example command parses against the real CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,13 @@ See the [LICENSE](LICENSE) file for full copyright attribution.
 - **Real-time Preview**: Shows configuration as you build it
 
 ### Snapper Integration
-- **Full Snapper Support**: Back up and restore Snapper-managed snapshots
-- **Metadata Preservation**: Preserves `info.xml` for seamless Snapper restoration
+- **Full Snapper Support**: Back up and restore Snapper-managed snapshots — to btrfs
+  (`ssh://`) **and** non-btrfs `raw://` / `raw+ssh://` targets
+- **Metadata Preservation**: Restores a first-class snapper snapshot — `info.xml` with the
+  original type, description, cleanup, and multi-entry `<userdata>` (and elements like
+  `<uid>`), native `0755` slot permissions
+- **Collision Addressing**: When snapper reuses a number after a prune, reach a specific
+  backup with `--backup-name` or `--date` (`--snapshot N` restores the newest and warns)
 - **Pre/Post Pairs**: Supports single, pre, and post snapshot types
 - **Incremental Transfers**: Efficient delta-based transfers between snapshots, with the parent
   matched by btrfs UUID correspondence (name for raw targets) — so a re-created snapshot with the
@@ -807,7 +812,7 @@ Check your configuration for errors before running backups:
 btrfs-backup-ng config validate
 
 # Validate a specific file
-btrfs-backup-ng config validate -c /path/to/config.toml
+btrfs-backup-ng -c /path/to/config.toml config validate
 ```
 
 #### Import btrbk Configuration
@@ -1723,7 +1728,7 @@ btrfs-backup-ng restore /mnt/backup /mnt/restore-new --no-fs-checks
 btrfs-backup-ng restore ssh://...:/backups/home /mnt/restore --compress=zstd
 
 # Check if incremental is working (should show "incremental from X")
-btrfs-backup-ng restore ssh://...:/backups/home /mnt/restore -v
+btrfs-backup-ng -v restore ssh://...:/backups/home /mnt/restore
 
 # Limit bandwidth if needed
 btrfs-backup-ng restore ssh://...:/backups/home /mnt/restore --rate-limit=50M
@@ -1845,7 +1850,7 @@ sudo btrfs-backup-ng snapper backup root /mnt/backup/root
 sudo btrfs-backup-ng snapper backup root ssh://backup@server:/backups/root
 
 # 5. Generate TOML config for automated backups
-btrfs-backup-ng snapper generate-config root --target /mnt/backup
+btrfs-backup-ng snapper generate-config --config root --target /mnt/backup
 ```
 
 ### Snapper CLI Commands
@@ -1954,30 +1959,54 @@ command: a local path or `ssh://` for btrfs destinations, and `raw://` /
 
 #### Restore Snapshots
 
+`snapper restore` takes two **positional** arguments — `SOURCE CONFIG` — where
+`CONFIG` is the local snapper config to restore **into**. Works with btrfs
+(`ssh://`) and non-btrfs `raw://` / `raw+ssh://` sources alike.
+
 ```bash
-# List available backups at a location
-btrfs-backup-ng snapper restore --list /mnt/backup/root
-btrfs-backup-ng snapper restore --list ssh://server:/backups/root
+# List available backups at a location (CONFIG is still required)
+btrfs-backup-ng snapper restore /mnt/backup/root root --list
+btrfs-backup-ng snapper restore raw:///mnt/usb/backups/root root --list
 
-# Restore a specific snapshot
-sudo btrfs-backup-ng snapper restore /mnt/backup/root --snapshot 559 root
+# Restore a specific snapshot by number
+sudo btrfs-backup-ng snapper restore /mnt/backup/root root --snapshot 559
 
-# Restore multiple snapshots
-sudo btrfs-backup-ng snapper restore /mnt/backup/root --snapshot 559 --snapshot 560 root
-
-# Restore all backups
-sudo btrfs-backup-ng snapper restore /mnt/backup/root --all root
+# Restore several, or all
+sudo btrfs-backup-ng snapper restore /mnt/backup/root root --snapshot 559 --snapshot 560
+sudo btrfs-backup-ng snapper restore /mnt/backup/root root --all
 
 # Dry run
-sudo btrfs-backup-ng snapper restore /mnt/backup/root --snapshot 559 root --dry-run
+sudo btrfs-backup-ng snapper restore /mnt/backup/root root --snapshot 559 --dry-run
+
+# raw+ssh target written with --ssh-sudo (root-owned): pass --ssh-sudo to read it back
+sudo btrfs-backup-ng snapper restore raw+ssh://backup@server/mnt/nas/root root \
+    --snapshot 559 --ssh-sudo
 ```
 
-The restore command:
-1. Lists available backups at the source location
-2. Transfers snapshots using incremental `btrfs send/receive`
-3. Creates the snapshot in your local Snapper directory (e.g., `/.snapshots/{new_num}/`)
-4. Generates `info.xml` from the backup metadata
-5. The snapshot is immediately visible to Snapper
+**Reused snapshot numbers.** Snapper reuses numbers after a prune, so a `raw://` /
+`raw+ssh://` target can hold two backups sharing a number (differing by the date in
+their unique name, shown in the `--list` **NAME** column). `--snapshot N` restores the
+**newest** and warns; reach an older copy explicitly:
+
+```bash
+# By exact name (copy the NAME from --list)
+sudo btrfs-backup-ng snapper restore /mnt/backup/root root \
+    --backup-name root-559-20240101-120000
+
+# ...or by number + date (YYYY-MM-DD[ HH:MM:SS] prefix)
+sudo btrfs-backup-ng snapper restore /mnt/backup/root root --snapshot 559 --date 2024-01-01
+```
+
+The restore command resolves the requested backup, receives it into a fresh
+`.snapshots/{new_num}/` slot, and writes a renumbered `info.xml` preserving the original
+type, description, cleanup, and **all userdata**. The restored snapshot is a first-class
+snapper snapshot (native `0755` slot permissions).
+
+> **After a restore, refresh the daemon.** The slot is written directly to disk (not via
+> `snapper create`), so the snapper **daemon caches** its list and won't see it until it
+> rescans — `snapper diff`/`undochange`/rollback may say *"Snapshot 'N' not found"*. Run
+> `snapper -c <config> list` (or reboot) first (the command prints a reminder). See
+> [Snapper Integration](docs/SNAPPER-INTEGRATION.md#restoration) for the full workflow.
 
 #### Check Backup Status
 
@@ -1986,8 +2015,8 @@ The restore command:
 btrfs-backup-ng snapper status
 
 # Check what's backed up to a target
-btrfs-backup-ng snapper status --target /mnt/backup/root
-btrfs-backup-ng snapper status --target ssh://server:/backups/root
+btrfs-backup-ng snapper status /mnt/backup/root
+btrfs-backup-ng snapper status ssh://server:/backups/root
 
 # Status for specific config
 btrfs-backup-ng snapper status --config root
@@ -2005,22 +2034,22 @@ Generate TOML configuration for automated snapper backups:
 btrfs-backup-ng snapper generate-config
 
 # Generate for specific configs
-btrfs-backup-ng snapper generate-config root home
+btrfs-backup-ng snapper generate-config --config root --config home
 
 # With target path
-btrfs-backup-ng snapper generate-config root --target ssh://server:/backups
+btrfs-backup-ng snapper generate-config --config root --target ssh://server:/backups
 
 # Save to file
-btrfs-backup-ng snapper generate-config root --target /mnt/backup -o snapper.toml
+btrfs-backup-ng snapper generate-config --config root --target /mnt/backup -o snapper.toml
 
 # Append to existing config
-btrfs-backup-ng snapper generate-config root --target /mnt/backup --append ~/.config/btrfs-backup-ng/config.toml
+btrfs-backup-ng snapper generate-config --config root --target /mnt/backup --append ~/.config/btrfs-backup-ng/config.toml
 
 # Filter snapshot types
-btrfs-backup-ng snapper generate-config root --type single --type pre
+btrfs-backup-ng snapper generate-config --config root --type single --type pre
 
 # With SSH sudo
-btrfs-backup-ng snapper generate-config root --target ssh://server:/backups --ssh-sudo
+btrfs-backup-ng snapper generate-config --config root --target ssh://server:/backups --ssh-sudo
 ```
 
 ### Configuration File Integration
@@ -2117,7 +2146,7 @@ btrfs-backup-ng snapper detect
 sudo btrfs-backup-ng snapper backup root /mnt/external-drive/backups/root
 
 # 3. Generate configuration
-btrfs-backup-ng snapper generate-config root \
+btrfs-backup-ng snapper generate-config --config root \
     --target ssh://backup@nas:/backups \
     --type single \
     --min-age 1h \
@@ -2143,7 +2172,7 @@ sudo btrfs-backup-ng install --timer=hourly
 mount /dev/sda2 /mnt/newroot
 
 # 3. List available backups
-btrfs-backup-ng snapper restore --list ssh://backup@nas:/backups/root
+btrfs-backup-ng snapper restore ssh://backup@nas:/backups/root root --list
 
 # 4. Restore the snapshot you need
 sudo btrfs-backup-ng snapper restore \
@@ -2151,9 +2180,11 @@ sudo btrfs-backup-ng snapper restore \
     --snapshot 560 \
     root
 
-# 5. The snapshot is now in /.snapshots/
-# Use snapper rollback or manual subvolume operations to restore
-snapper -c root rollback 560
+# 5. The restore reports a NEW local number, e.g. "restored as local snapshot 4".
+#    Refresh the snapper daemon so it sees the out-of-band slot, then roll back to
+#    that NEW number (not the backup's original 560).
+snapper -c root list           # refresh the daemon cache
+snapper -c root rollback 4     # use the number the restore reported
 ```
 
 ### Snapper Integration vs Native Mode
@@ -2331,9 +2362,6 @@ When quotas are enabled on the destination, the space check uses the **more rest
 ### Config-Driven Estimation
 
 ```bash
-# List configured volumes and their targets
-btrfs-backup-ng estimate --list-volumes
-
 # Estimate for a specific volume from config
 btrfs-backup-ng estimate --volume /home
 
@@ -2479,9 +2507,6 @@ btrfs-backup-ng /source/subvolume /destination/path
 
 # Remote backup
 btrfs-backup-ng /home ssh://backup@server:/backups/home
-
-# With options
-btrfs-backup-ng --ssh-sudo --num-snapshots 10 /source ssh://user@host:/dest
 ```
 
 Legacy mode is auto-detected when the first argument is a path.
@@ -2675,7 +2700,7 @@ btrfs-backup-ng performs filesystem verification checks to ensure sources are va
 btrfs-backup-ng estimate /mnt/snapshots /mnt/backup
 
 # Strict mode - fail on any check issue
-btrfs-backup-ng run --fs-checks=strict
+btrfs-backup-ng verify /mnt/backup --fs-checks=strict
 
 # Skip checks entirely (useful for listing backup directories)
 btrfs-backup-ng restore --list /mnt/backup/home --fs-checks=skip

--- a/docs/SNAPPER-INTEGRATION.md
+++ b/docs/SNAPPER-INTEGRATION.md
@@ -51,7 +51,7 @@ Found 2 snapper configuration(s):
 ### 2. List Available Snapshots
 
 ```bash
-btrfs-backup-ng snapper list root
+btrfs-backup-ng snapper list --config root
 ```
 
 Output:
@@ -88,7 +88,7 @@ command: a local path or `ssh://` for btrfs destinations, and `raw://` /
 ### 4. Check Backup Status
 
 ```bash
-btrfs-backup-ng snapper status --target /mnt/backup/root
+btrfs-backup-ng snapper status /mnt/backup/root
 ```
 
 ### 5. Restore When Needed
@@ -557,7 +557,7 @@ compress = "zstd"
 
 Regularly check backup health:
 ```bash
-btrfs-backup-ng snapper status --target /mnt/backup/root
+btrfs-backup-ng snapper status /mnt/backup/root
 btrfs-backup-ng doctor --check transfers
 ```
 

--- a/tests/test_docs_commands.py
+++ b/tests/test_docs_commands.py
@@ -1,0 +1,113 @@
+"""Regression guard: every example command in the user-facing docs must parse.
+
+Extracts `btrfs-backup-ng ...` commands from fenced code blocks in README.md and
+docs/SNAPPER-INTEGRATION.md and asserts each parses against the real CLI parser, so a
+doc example can never drift into an unrecognized-flag / wrong-positional form that would
+fail the moment a user copy-pastes it (as `snapper restore --config NAME` once did).
+"""
+
+import contextlib
+import io
+import re
+import shlex
+from pathlib import Path
+
+import pytest
+
+from btrfs_backup_ng.cli.dispatcher import create_subcommand_parser
+
+_REPO = Path(__file__).resolve().parent.parent
+_DOCS = [_REPO / "README.md", _REPO / "docs" / "SNAPPER-INTEGRATION.md"]
+
+# The top-level parser rejects the bare legacy `SRC DST` form (a shim in main() handles
+# it) and output banners / prose; those first tokens are neither a subcommand nor a flag,
+# so the "first arg is a subcommand or a global flag" filter below skips them cleanly.
+_SUBCOMMANDS = {
+    "run",
+    "snapshot",
+    "transfer",
+    "prune",
+    "list",
+    "status",
+    "config",
+    "raw",
+    "install",
+    "uninstall",
+    "restore",
+    "verify",
+    "completions",
+    "manpages",
+    "estimate",
+    "transfers",
+    "doctor",
+    "snapper",
+}
+
+
+def _iter_doc_commands(path: Path):
+    """Yield (path, lineno, command) for btrfs-backup-ng commands in fenced blocks."""
+    lines = path.read_text().splitlines()
+    in_block = False
+    i = 0
+    while i < len(lines):
+        ln = lines[i]
+        if ln.strip().startswith("```"):
+            in_block = not in_block
+            i += 1
+            continue
+        if in_block:
+            joined = ln
+            while joined.rstrip().endswith("\\") and i + 1 < len(lines):
+                i += 1
+                joined = joined.rstrip()[:-1] + " " + lines[i]
+            s = joined.strip()
+            if s.startswith("$ "):
+                s = s[2:].strip()
+            if s.startswith("sudo "):
+                s = s[5:].strip()
+            s = re.sub(r"\s+#.*$", "", s)  # strip trailing inline comment
+            if s.startswith("btrfs-backup-ng"):
+                yield path, i + 1, s
+        i += 1
+
+
+def _collect():
+    out = []
+    for p in _DOCS:
+        for path, lineno, cmd in _iter_doc_commands(p):
+            # skip shell pipelines/redirects/substitutions we can't treat as one argv
+            if any(t in cmd for t in ["|", "$(", "&&", ">", "<", "`"]):
+                continue
+            try:
+                argv = shlex.split(cmd)[1:]
+            except ValueError:
+                continue
+            if not argv:
+                continue
+            first = argv[0]
+            # only real command lines: first token is a subcommand or a global flag
+            if not (first.startswith("-") or first in _SUBCOMMANDS):
+                continue
+            out.append((f"{path.name}:{lineno}", cmd, argv))
+    return out
+
+
+_COMMANDS = _collect()
+
+
+def test_docs_have_example_commands():
+    # guard against the extractor silently finding nothing
+    assert len(_COMMANDS) > 30
+
+
+@pytest.mark.parametrize("loc,cmd,argv", _COMMANDS, ids=[c[0] for c in _COMMANDS])
+def test_doc_command_parses(loc, cmd, argv):
+    parser = create_subcommand_parser()
+    buf = io.StringIO()
+    try:
+        with contextlib.redirect_stderr(buf), contextlib.redirect_stdout(buf):
+            parser.parse_args(argv)
+    except SystemExit as e:
+        # 0/None = --help/--version (fine); 2 = a real parse error
+        if e.code not in (0, None):
+            pytest.fail(f"{loc}: `{cmd}` does not parse:\n{buf.getvalue().strip()}")


### PR DESCRIPTION
## docs: audit README (+ SNAPPER-INTEGRATION) so every example command actually works

`README.md` is the front door — a broken example is a real user failure, especially
mid-recovery. This audits **every** `btrfs-backup-ng` command in the docs against the real
argument parser and fixes the ones that would fail the moment a user copy-pastes them.

### Fixed (~18 broken commands, all verified against the CLI)
- **Global options before the subcommand:** `config validate -c FILE` → `-c FILE config validate`; `restore … -v` → `-v restore …`.
- **`snapper generate-config`** uses `--config NAME` (repeatable), not a positional (`generate-config root` → `generate-config --config root`).
- **`snapper restore --list`** still requires the positional `CONFIG` (`snapper restore SOURCE CONFIG --list`).
- **`snapper status TARGET`** is positional (not `--target`); **`snapper list`** uses `--config` (not a positional).
- **`estimate --list-volumes`** — no such flag (removed).
- **`run --fs-checks=strict`** — `run` has no `--fs-checks` (verify/estimate/restore do); switched to `verify`.
- **Legacy `--ssh-sudo --num-snapshots 10 SRC DST`** — the `main()` compat shim only accepts a *bare* `SRC DST`; the options form never worked (removed). The bare legacy form still works and stays documented.

### Corrected inaccurate claims / represented R11 accurately
- Removed *"The snapshot is immediately visible to Snapper"* (it is **not** — the snapper daemon caches its list).
- Fixed a disaster-recovery example that rolled back to the *backup's* number instead of the *new local* number, and added the `snapper list` cache-refresh step.
- Feature highlights + the restore section now cover `raw://` / `raw+ssh://` snapper restore, `--backup-name` / `--date` collision addressing, metadata fidelity (multi-entry `<userdata>`, `<uid>`, `0755`), and the post-restore workflow (pointing to `docs/SNAPPER-INTEGRATION.md`).

### Regression guard
Adds `tests/test_docs_commands.py`: parses **every** example command in README and
SNAPPER-INTEGRATION against the real CLI (241 cases), so a doc example can never drift
into an unrecognized-flag / wrong-positional form again. Output banners and the bare
legacy `SRC DST` shim form are excluded by a "first token is a subcommand or a global
flag" filter.

Docs-only + a test; full suite green (2865 passed).
