### PR TITLE
0.9.2 Phase 1: CONFIG optional for 'snapper restore --list' + drop stale run completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1964,9 +1964,9 @@ command: a local path or `ssh://` for btrfs destinations, and `raw://` /
 (`ssh://`) and non-btrfs `raw://` / `raw+ssh://` sources alike.
 
 ```bash
-# List available backups at a location (CONFIG is still required)
-btrfs-backup-ng snapper restore /mnt/backup/root root --list
-btrfs-backup-ng snapper restore raw:///mnt/usb/backups/root root --list
+# List available backups at a location (CONFIG is optional with --list)
+btrfs-backup-ng snapper restore /mnt/backup/root --list
+btrfs-backup-ng snapper restore raw:///mnt/usb/backups/root --list
 
 # Restore a specific snapshot by number
 sudo btrfs-backup-ng snapper restore /mnt/backup/root root --snapshot 559
@@ -2172,13 +2172,13 @@ sudo btrfs-backup-ng install --timer=hourly
 mount /dev/sda2 /mnt/newroot
 
 # 3. List available backups
-btrfs-backup-ng snapper restore ssh://backup@nas:/backups/root root --list
+btrfs-backup-ng snapper restore ssh://backup@nas:/backups/root --list
 
-# 4. Restore the snapshot you need
+# 4. Restore the snapshot you need (CONFIG comes right after SOURCE)
 sudo btrfs-backup-ng snapper restore \
     ssh://backup@nas:/backups/root \
-    --snapshot 560 \
-    root
+    root \
+    --snapshot 560
 
 # 5. The restore reports a NEW local number, e.g. "restored as local snapshot 4".
 #    Refresh the snapper daemon so it sees the out-of-band slot, then roll back to

--- a/completions/btrfs-backup-ng.bash
+++ b/completions/btrfs-backup-ng.bash
@@ -17,7 +17,7 @@ _btrfs_backup_ng() {
     local global_opts="-h --help -v --verbose -q --quiet --debug -V --version -c --config"
 
     # Command-specific options
-    local run_opts="--dry-run --parallel-volumes --parallel-targets --compress --rate-limit --progress --no-progress --check-space --no-check-space --force --fs-checks"
+    local run_opts="--dry-run --parallel-volumes --parallel-targets --compress --rate-limit --progress --no-progress --no-check-space --force"
     local snapshot_opts="--dry-run --volume"
     local transfer_opts="--dry-run --volume --compress --rate-limit --progress --no-progress"
     local prune_opts="--dry-run"

--- a/completions/btrfs-backup-ng.fish
+++ b/completions/btrfs-backup-ng.fish
@@ -86,10 +86,8 @@ complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_using_command run' -l com
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_using_command run' -l rate-limit -d 'Bandwidth limit (e.g., 10M, 1G)' -x
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_using_command run' -l progress -d 'Show progress bars'
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_using_command run' -l no-progress -d 'Disable progress bars'
-complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_using_command run' -l check-space -d 'Check destination space before transfer'
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_using_command run' -l no-check-space -d 'Skip destination space check'
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_using_command run' -l force -d 'Proceed despite insufficient space'
-complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_using_command run' -l fs-checks -d 'Filesystem validation mode' -xa "$fs_checks_modes"
 
 # snapshot command
 complete -c btrfs-backup-ng -n '__fish_btrfs_backup_ng_using_command snapshot' -l dry-run -d 'Show what would be done without making changes'

--- a/completions/btrfs-backup-ng.zsh
+++ b/completions/btrfs-backup-ng.zsh
@@ -68,10 +68,8 @@ _btrfs-backup-ng() {
                         '--rate-limit[Bandwidth limit]:rate:' \
                         '(--progress --no-progress)'--progress'[Show progress bars]' \
                         '(--progress --no-progress)'--no-progress'[Disable progress bars]' \
-                        '--check-space[Check destination space before transfer]' \
                         '--no-check-space[Skip destination space check]' \
-                        '--force[Proceed despite insufficient space]' \
-                        '--fs-checks[Filesystem validation mode]:mode:(${fs_checks_modes})'
+                        '--force[Proceed despite insufficient space]'
                     ;;
                 snapshot)
                     _arguments \

--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -868,14 +868,14 @@ btrfs-backup-ng snapper status --target /mnt/backup/root
 Restore snapper snapshots from backup.
 
 ```bash
-btrfs-backup-ng snapper restore SOURCE CONFIG [OPTIONS]
+btrfs-backup-ng snapper restore SOURCE [CONFIG] [OPTIONS]
 ```
 
-**Arguments** (both positional, in this order):
+**Arguments** (positional, in this order):
 | Argument | Description |
 |----------|-------------|
 | `SOURCE` | Backup source: a local path, `ssh://user@host:/path` (btrfs), or `raw://path` / `raw+ssh://user@host/path` (non-btrfs) |
-| `CONFIG` | Local snapper config to restore **into** (e.g. `root`, `home`) — required |
+| `CONFIG` | Local snapper config to restore **into** (e.g. `root`, `home`). Required to restore; **optional with `--list`** (listing only reads the source) |
 
 **Options:**
 | Option | Description |
@@ -896,7 +896,7 @@ btrfs-backup-ng snapper restore SOURCE CONFIG [OPTIONS]
 **Examples:**
 ```bash
 # List available backups
-btrfs-backup-ng snapper restore /mnt/backup/root root --list
+btrfs-backup-ng snapper restore /mnt/backup/root --list
 
 # Restore specific snapshot
 btrfs-backup-ng snapper restore /mnt/backup/root root --snapshot 559

--- a/docs/SNAPPER-INTEGRATION.md
+++ b/docs/SNAPPER-INTEGRATION.md
@@ -95,7 +95,7 @@ btrfs-backup-ng snapper status /mnt/backup/root
 
 ```bash
 # List available backups
-btrfs-backup-ng snapper restore /mnt/backup/root root --list
+btrfs-backup-ng snapper restore /mnt/backup/root --list
 
 # Restore specific snapshot
 btrfs-backup-ng snapper restore /mnt/backup/root root --snapshot 559
@@ -256,7 +256,7 @@ Backing up snapshot 561...
 Before restoring, list available backups:
 
 ```bash
-btrfs-backup-ng snapper restore /mnt/backup/root root --list
+btrfs-backup-ng snapper restore /mnt/backup/root --list
 ```
 
 Output:

--- a/man/man1/btrfs-backup-ng-snapper.1
+++ b/man/man1/btrfs-backup-ng-snapper.1
@@ -13,7 +13,7 @@ btrfs-backup-ng-snapper \- back up and restore snapper-managed snapshots
 \fICONFIG\fR \fITARGET\fR [\fIOPTIONS\fR]
 .br
 .B btrfs-backup-ng snapper restore
-\fISOURCE\fR [\fB\-\-list\fR | \fB\-\-snapshot\fR \fINUM\fR | \fB\-\-all\fR] \fICONFIG\fR
+\fISOURCE\fR [\fB\-\-list\fR | \fB\-\-snapshot\fR \fINUM\fR | \fB\-\-all\fR] [\fICONFIG\fR]
 .br
 .B btrfs-backup-ng snapper status
 [\fB\-\-config\fR \fINAME\fR] [\fB\-\-target\fR \fIPATH\fR] [\fB\-\-json\fR]
@@ -120,14 +120,14 @@ Restore Snapper snapshots from a backup location.
 .PP
 .RS
 .B btrfs-backup-ng snapper restore
-\fISOURCE\fR [\fIOPTIONS\fR] \fICONFIG\fR
+\fISOURCE\fR [\fIOPTIONS\fR] [\fICONFIG\fR]
 .RE
 .TP
 .I SOURCE
 Backup location to restore from. Can be local or SSH URL.
 .TP
 .I CONFIG
-Local Snapper configuration name to restore into.
+Local Snapper configuration name to restore into. Required to restore; optional with \fB\-\-list\fR (listing only reads the source).
 .PP
 Options:
 .TP

--- a/src/btrfs_backup_ng/cli/dispatcher.py
+++ b/src/btrfs_backup_ng/cli/dispatcher.py
@@ -1419,7 +1419,9 @@ Examples:
     snapper_restore.add_argument(
         "config",
         metavar="CONFIG",
-        help="Local snapper config to restore to (e.g., root, home)",
+        nargs="?",
+        help="Local snapper config to restore into (e.g., root, home). Required when "
+        "restoring; optional with --list (listing only reads the source).",
     )
     snapper_restore.add_argument(
         "-s",

--- a/src/btrfs_backup_ng/cli/snapper_cmd.py
+++ b/src/btrfs_backup_ng/cli/snapper_cmd.py
@@ -632,6 +632,16 @@ def _handle_restore(args: argparse.Namespace) -> int:
 
         return 0
 
+    # CONFIG is optional only in --list mode (listing just reads the source). For an
+    # actual restore it names the local config to restore INTO, so require it here.
+    if not args.config:
+        logger.error(
+            "CONFIG is required to restore (it is only optional with --list). "
+            "Example: btrfs-backup-ng snapper restore %s root --snapshot NUM",
+            source_path,
+        )
+        return 1
+
     # Validate local snapper config exists
     try:
         scanner = SnapperScanner()

--- a/tests/test_completions.py
+++ b/tests/test_completions.py
@@ -479,3 +479,29 @@ class TestSnapperRestoreCompletionFlags:
             text = (d / fname).read_text()
             for needle in needles:
                 assert needle in text, f"{fname} missing {needle!r}"
+
+
+class TestRunCompletionNoStaleFlags:
+    """0.9.2: `run` completions must not offer flags run doesn't accept."""
+
+    def _dir(self):
+        return Path(__file__).resolve().parent.parent / "completions"
+
+    def test_run_has_no_fs_checks_or_positive_check_space(self):
+        import re
+
+        d = self._dir()
+        fish = (d / "btrfs-backup-ng.fish").read_text()
+        assert "_using_command run' -l fs-checks" not in fish
+        assert "_using_command run' -l check-space" not in fish  # positive is stale
+
+        bash = (d / "btrfs-backup-ng.bash").read_text()
+        run_opts = next(line for line in bash.splitlines() if "run_opts=" in line)
+        assert "--fs-checks" not in run_opts
+        assert "--check-space" not in run_opts.replace("--no-check-space", "")
+
+        zsh = (d / "btrfs-backup-ng.zsh").read_text()
+        block = re.search(r"\brun\)(.*?);;", zsh, re.S)
+        assert block is not None
+        assert "--fs-checks" not in block.group(1)
+        assert "--check-space" not in block.group(1).replace("--no-check-space", "")

--- a/tests/test_snapper_cmd.py
+++ b/tests/test_snapper_cmd.py
@@ -1963,3 +1963,43 @@ class TestBackupSelectionHelpers:
         old = self._b("old", "2024-01-01T00:00:00")
         new = self._b("new", "2024-06-01T00:00:00")
         assert max([old, new], key=_backup_recency_key)["backup_name"] == "new"
+
+
+class TestRestoreConfigOptionalWithList:
+    """0.9.2: CONFIG is optional with --list, required for an actual restore."""
+
+    def _args(self, **kw):
+        base = dict(
+            source="raw:///b",
+            config=None,
+            snapshot=None,
+            backup_name=None,
+            all=False,
+            date=None,
+            list=False,
+            json=False,
+            dry_run=False,
+            verbose=False,
+            quiet=False,
+            log_level=None,
+        )
+        base.update(kw)
+        return argparse.Namespace(**base)
+
+    def test_list_without_config_lists(self, capsys):
+        from btrfs_backup_ng.cli.snapper_cmd import _handle_restore
+
+        with patch(
+            "btrfs_backup_ng.core.restore.list_snapper_backups", return_value=[]
+        ) as mock_list:
+            result = _handle_restore(self._args(list=True))  # config=None
+        assert result == 0
+        mock_list.assert_called_once()  # listing proceeded without a CONFIG
+
+    def test_restore_without_config_errors(self, capsys):
+        from btrfs_backup_ng.cli.snapper_cmd import _handle_restore
+
+        result = _handle_restore(self._args(snapshot=[1]))  # config=None, not --list
+        assert result == 1
+        cap = capsys.readouterr()
+        assert "CONFIG is required" in " ".join((cap.out + cap.err).split())


### PR DESCRIPTION
## 0.9.2 Phase 1 — CLI UX polish

First of the 0.9.2 follow-up batches (comprehensive 0.9.x stability/config/restore polish).

- **`snapper restore --list` no longer requires `CONFIG`.** Listing only reads the `SOURCE`
  backup location — the target config is irrelevant — yet the positional `CONFIG` was required,
  a needless barrier. `CONFIG` is now `nargs="?"`, required only for an actual restore (a clear
  error names it otherwise). `btrfs-backup-ng snapper restore SOURCE --list` now works.
- **Removed stale `run` completions** across bash/zsh/fish: `--fs-checks` and the positive
  `--check-space` — `run` accepts neither (only `--no-check-space` / `--force`). restore/verify/
  estimate keep `--fs-checks` (they do accept it). Added a completion regression test.

Docs (CLI-REFERENCE, snapper manpage, README, SNAPPER-INTEGRATION) updated to show `CONFIG`
optional-with-`--list`; the 241-case doc-command guard still passes.

Tested (mutation-verified): `--list` without config lists; restore without config errors; run
completions carry no stale flags. Full suite: 2868 passed.
