### PR TITLE
fix(btrbk): translate retention without losing policy fidelity (0.9.2 Phase 2B-i)

### DIFF
--- a/docs/MIGRATING-FROM-BTRBK.md
+++ b/docs/MIGRATING-FROM-BTRBK.md
@@ -120,11 +120,27 @@ btrbk's retention syntax can be confusing. Here's how it maps:
 | btrbk | btrfs-backup-ng | Notes |
 |-------|-----------------|-------|
 | `snapshot_preserve_min 2d` | `min = "2d"` | Minimum retention period |
+| `snapshot_preserve 24h` | `hourly = 24` | Hourly snapshots to keep |
 | `snapshot_preserve 14d` | `daily = 14` | Daily snapshots to keep |
 | `snapshot_preserve 4w` | `weekly = 4` | Weekly snapshots to keep |
-| `snapshot_preserve 6m` | `monthly = 6` | Monthly snapshots to keep |
-| `target_preserve_min` | `min = "..."` | Same as snapshot (applied to backups) |
-| `target_preserve` | Same as above | Same retention for targets |
+| `snapshot_preserve 6m` | `monthly = 6` | **Monthly** — btrbk's `m` is *months* |
+| `snapshot_preserve 2y` | `yearly = 2` | Yearly snapshots to keep |
+| `snapshot_preserve_min 3m` | `min = "3M"` | btrbk `m` (months) → btrfs-backup-ng `M`; note the case (`m` alone is *minutes*) |
+| `snapshot_preserve_min no` | `min = "0s"` | No age floor — count rules apply fully |
+| `target_preserve` / `target_preserve_min` | *(warned)* | See note below |
+
+> **`target_preserve` is not applied separately.** btrbk lets the destination keep a
+> *different* schedule than the source (`target_preserve` vs `snapshot_preserve`).
+> btrfs-backup-ng uses **one** retention policy per volume, so the importer maps from
+> `snapshot_preserve*` and **emits a warning** when `target_preserve*` differs, rather than
+> silently applying only one. If your source and destination schedules differed, review the
+> generated `[…].retention` and adjust.
+>
+> **Directives with no equivalent are warned, not dropped silently.** `preserve_day_of_week`
+> and `preserve_hour_of_day` (which anchor btrbk retention to a specific weekday/hour) have no
+> btrfs-backup-ng counterpart; the importer warns that they were dropped. A `snapshot_preserve`
+> value it cannot parse (e.g. `latest`) is also warned rather than silently becoming a
+> keep-nothing policy. **Always review the importer's warnings** after a migration.
 
 **Important**: btrfs-backup-ng uses a simpler mental model:
 1. `min` - Keep everything for at least this duration

--- a/src/btrfs_backup_ng/btrbk_import.py
+++ b/src/btrfs_backup_ng/btrbk_import.py
@@ -190,6 +190,10 @@ class BtrbkLexer:
             "snapshot_preserve_min",
             "target_preserve",
             "target_preserve_min",
+            # Captured only so the converter can WARN they have no btrfs-backup-ng
+            # equivalent (rather than silently dropping the retention rule).
+            "preserve_day_of_week",
+            "preserve_hour_of_day",
             "incremental",
             "ssh_identity",
             "ssh_user",
@@ -469,6 +473,152 @@ def parse_btrbk_retention(value: str) -> dict[str, int]:
     return result
 
 
+def _translate_preserve_min(value: str) -> tuple[str, list[str]]:
+    """Translate a btrbk ``*_preserve_min`` value into a btrfs-backup-ng retention
+    ``min`` duration.
+
+    Two btrbk-vs-btrfs-backup-ng mismatches make a straight passthrough wrong:
+
+    * **Unit clash on ``m``.** btrbk retention uses ``m`` for MONTHS, but
+      btrfs-backup-ng's duration parser uses ``m`` for minutes and ``M`` for months.
+      A btrbk ``3m`` (3 months) passed through verbatim would silently become 3
+      *minutes*. We remap ``m`` -> ``M``.
+    * **Special tokens.** btrbk ``no``/``all``/``latest`` are not durations; passed
+      through they produce a ``min`` the loader rejects (fails to load). ``no`` maps
+      cleanly to ``0s`` (no age floor); ``all``/``latest`` have no age equivalent, so
+      we fall back to ``1d`` and warn.
+
+    Returns ``(min_string, warnings)``.
+    """
+    warnings: list[str] = []
+    low = value.strip().lower()
+    if low in ("no", "none"):
+        # No minimum age -- count-based rules apply fully. Faithful 1:1 mapping.
+        return "0s", warnings
+    if low in ("all", "latest"):
+        warnings.append(
+            f"btrbk '*_preserve_min {value.strip()}' has no btrfs-backup-ng equivalent "
+            f'(there is no infinite/"keep-latest" minimum age); using min = "1d" -- '
+            f"review the generated [.retention] min"
+        )
+        return "1d", warnings
+    m = re.fullmatch(r"(\d+)\s*([hdwmy])", low)
+    if m:
+        count, unit = m.groups()
+        # btrbk m=months -> btrfs-backup-ng M=months (h/d/w/y are identical).
+        bbng_unit = "M" if unit == "m" else unit
+        return f"{count}{bbng_unit}", warnings
+    warnings.append(
+        f"btrbk retention minimum {value.strip()!r} was not understood; "
+        f'using min = "1d" -- review the generated [.retention] min'
+    )
+    return "1d", warnings
+
+
+def _parse_preserve_counts(value: str) -> tuple[dict[str, int], list[str]]:
+    """``parse_btrbk_retention`` plus a warning when the value is not understood.
+
+    A value that matches no period token and is not an explicit ``no``/``all`` yields
+    an all-zero policy -- i.e. *keep no periodic snapshots*. That silent
+    prune-everything outcome (e.g. from btrbk ``latest``, or a typo) is dangerous, so
+    surface it as a warning instead.
+    """
+    counts = parse_btrbk_retention(value)
+    warnings: list[str] = []
+    low = value.strip().lower()
+    if low in ("no", "none", "all", "*"):
+        return counts, warnings
+    matched_a_token = bool(re.search(r"(\d+|\*)[hdwmy]", low))
+    if not matched_a_token:
+        # Nothing recognizable (e.g. btrbk 'latest', or a typo) -> silently all-zero.
+        warnings.append(
+            f"btrbk retention value {value.strip()!r} was not understood -- it maps to "
+            f"keeping NO periodic snapshots. btrbk 'latest' and day/hour-of-week rules "
+            f"have no btrfs-backup-ng equivalent; review the generated [.retention]"
+        )
+    elif all(c == 0 for c in counts.values()):
+        # Parsed fine but every bucket is 0 (e.g. '0d') -> also keeps nothing.
+        warnings.append(
+            f"btrbk retention value {value.strip()!r} keeps NO periodic snapshots "
+            f"(all buckets are 0) -- review the generated [.retention]"
+        )
+    return counts, warnings
+
+
+def _retention_block(
+    header: str,
+    scope: str,
+    preserve: str | None,
+    preserve_min: str | None,
+    target_preserve: str | None,
+    target_preserve_min: str | None,
+) -> tuple[list[str], list[str]]:
+    """Build a ``[<header>.retention]`` TOML block from btrbk preserve directives.
+
+    btrfs-backup-ng has a SINGLE retention policy per scope, so btrbk's separate
+    SNAPSHOT (source) and TARGET (destination) schedules cannot both be represented.
+    We map from ``snapshot_preserve*`` and warn when ``target_preserve*`` differs, so
+    the operator knows the destination schedule was not applied separately.
+
+    ``scope`` is a human-readable label (e.g. ``"the global retention"`` or
+    ``'volume "/mnt/pool/home"'``) embedded in the divergence warnings so that
+    per-volume warnings stay DISTINCT through de-duplication (two subvolumes with
+    the same ``target_preserve`` value must each be reported).
+
+    Returns ``(toml_lines, warnings)``.
+    """
+    lines = [f"[{header}.retention]"]
+    warnings: list[str] = []
+
+    if preserve_min is not None:
+        min_str, w = _translate_preserve_min(preserve_min)
+        warnings += w
+    else:
+        min_str = "1d"
+    lines.append(f'min = "{min_str}"')
+
+    if preserve is not None:
+        counts, w = _parse_preserve_counts(preserve)
+        warnings += w
+    else:
+        # btrfs-backup-ng defaults when btrbk specified no snapshot_preserve.
+        counts = {"hourly": 24, "daily": 7, "weekly": 4, "monthly": 12, "yearly": 0}
+    for key in ("hourly", "daily", "weekly", "monthly", "yearly"):
+        lines.append(f"{key} = {counts[key]}")
+
+    # Divergence warnings compare the PARSED policy (so reordered-but-equal token
+    # lists don't warn) and state accurately what was actually used -- the source
+    # schedule, or the defaults when no snapshot_preserve was present.
+    if target_preserve is not None and (
+        preserve is None or parse_btrbk_retention(target_preserve) != counts
+    ):
+        used = (
+            "snapshot_preserve was used"
+            if preserve is not None
+            else "the default retention was used"
+        )
+        warnings.append(
+            f"btrbk 'target_preserve {target_preserve}' sets a destination schedule "
+            f"that differs from the source; btrfs-backup-ng uses one retention per "
+            f"volume, so it was NOT applied separately -- {used} for {scope}"
+        )
+    if target_preserve_min is not None:
+        target_min, _ = _translate_preserve_min(target_preserve_min)
+        if target_min != min_str:
+            used = (
+                "snapshot_preserve_min was used"
+                if preserve_min is not None
+                else "the default minimum was used"
+            )
+            warnings.append(
+                f"btrbk 'target_preserve_min {target_preserve_min}' differs from the "
+                f"source minimum; btrfs-backup-ng uses one retention minimum -- "
+                f"{used} for {scope}"
+            )
+
+    return lines, warnings
+
+
 def convert_to_toml(btrbk_config: BtrbkConfig) -> tuple[str, list[str]]:
     """Convert parsed btrbk config to TOML format.
 
@@ -514,32 +664,20 @@ def convert_to_toml(btrbk_config: BtrbkConfig) -> tuple[str, list[str]]:
 
     lines.append("")
 
-    # Global retention
-    lines.append("[global.retention]")
-    if "snapshot_preserve_min" in btrbk_config.global_options:
-        min_val = btrbk_config.global_options["snapshot_preserve_min"]
-        # Convert btrbk duration (e.g., "2d") to our format
-        lines.append(f'min = "{min_val}"')
-    else:
-        lines.append('min = "1d"')
-
-    if "snapshot_preserve" in btrbk_config.global_options:
-        retention = parse_btrbk_retention(
-            btrbk_config.global_options["snapshot_preserve"]
-        )
-        lines.append(f"hourly = {retention['hourly']}")
-        lines.append(f"daily = {retention['daily']}")
-        lines.append(f"weekly = {retention['weekly']}")
-        lines.append(f"monthly = {retention['monthly']}")
-    else:
-        lines.extend(
-            [
-                "hourly = 24",
-                "daily = 7",
-                "weekly = 4",
-                "monthly = 12",
-            ]
-        )
+    # Global retention. Routed through _retention_block so the min unit/token
+    # translation, the yearly field, and the target_preserve divergence warning are
+    # applied consistently here and for per-volume overrides below.
+    g = btrbk_config.global_options
+    global_ret_lines, global_ret_warnings = _retention_block(
+        "global",
+        "the global retention",
+        g.get("snapshot_preserve"),
+        g.get("snapshot_preserve_min"),
+        g.get("target_preserve"),
+        g.get("target_preserve_min"),
+    )
+    lines.extend(global_ret_lines)
+    warnings.extend(global_ret_warnings)
 
     lines.append("")
 
@@ -587,6 +725,33 @@ def convert_to_toml(btrbk_config: BtrbkConfig) -> tuple[str, list[str]]:
                 ),
             )
             lines.append(f'snapshot_dir = "{snap_dir}"')
+
+            # Per-volume retention override. Emit a [volumes.retention] block only
+            # when the subvolume or its parent volume explicitly set a preserve
+            # directive (otherwise [global.retention] already applies). Inherit the
+            # global preserve for whichever half was not overridden, so a subvolume
+            # that overrides only the min still keeps the global counts.
+            sub_preserve = subvolume.options.get(
+                "snapshot_preserve"
+            ) or volume.options.get("snapshot_preserve")
+            sub_preserve_min = subvolume.options.get(
+                "snapshot_preserve_min"
+            ) or volume.options.get("snapshot_preserve_min")
+            if sub_preserve is not None or sub_preserve_min is not None:
+                sub_ret_lines, sub_ret_warnings = _retention_block(
+                    "volumes",
+                    f'volume "{full_path}"',
+                    sub_preserve
+                    or btrbk_config.global_options.get("snapshot_preserve"),
+                    sub_preserve_min
+                    or btrbk_config.global_options.get("snapshot_preserve_min"),
+                    subvolume.options.get("target_preserve")
+                    or volume.options.get("target_preserve"),
+                    subvolume.options.get("target_preserve_min")
+                    or volume.options.get("target_preserve_min"),
+                )
+                lines.extend(sub_ret_lines)
+                warnings.extend(sub_ret_warnings)
 
             lines.append("")
 
@@ -706,6 +871,26 @@ def convert_to_toml(btrbk_config: BtrbkConfig) -> tuple[str, list[str]]:
 
                 lines.append("")
 
+    # Warn about btrbk retention directives that have NO btrfs-backup-ng equivalent
+    # (rather than silently dropping them). Scan every scope where they can appear.
+    all_option_scopes = [btrbk_config.global_options]
+    for volume in btrbk_config.volumes:
+        all_option_scopes.append(volume.options)
+        for subvolume in volume.subvolumes:
+            all_option_scopes.append(subvolume.options)
+    unsupported = {
+        "preserve_day_of_week": "its schedule-anchoring effect on retention is not preserved",
+        "preserve_hour_of_day": "its schedule-anchoring effect on retention is not preserved",
+        "archive_preserve": "btrfs-backup-ng has no separate archive-retention concept",
+        "archive_preserve_min": "btrfs-backup-ng has no separate archive-retention concept",
+    }
+    for directive, detail in unsupported.items():
+        if any(directive in opts for opts in all_option_scopes):
+            warnings.append(
+                f"btrbk '{directive}' has no btrfs-backup-ng equivalent and was "
+                f"dropped; {detail}"
+            )
+
     # Final warnings check
     if not btrbk_config.volumes:
         warnings.append("No volumes found in configuration")
@@ -714,7 +899,15 @@ def convert_to_toml(btrbk_config: BtrbkConfig) -> tuple[str, list[str]]:
     if total_subvols == 0:
         warnings.append("No subvolumes found - check your configuration structure")
 
-    return "\n".join(lines), warnings
+    # De-duplicate while preserving order: the divergence/unsupported warnings can
+    # legitimately recur across scopes, but the operator only needs to see each once.
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for warning in warnings:
+        if warning not in seen:
+            seen.add(warning)
+            deduped.append(warning)
+    return "\n".join(lines), deduped
 
 
 def import_btrbk_config(path: str | Path) -> tuple[str, list[str]]:

--- a/tests/test_btrbk_import.py
+++ b/tests/test_btrbk_import.py
@@ -507,3 +507,218 @@ volume /mnt/pool
         # Should fall back to 'long' and generate warning
         assert 'timestamp_format = "%Y%m%dT%H%M"' in toml_output
         assert any("custom_format" in w for w in warnings)
+
+
+class TestBtrbkRetentionFidelity:
+    """0.9.2 Phase 2B-i: btrbk retention must translate without silent policy loss."""
+
+    @staticmethod
+    def _toml(config: str):
+        from btrfs_backup_ng.btrbk_import import convert_to_toml, parse_btrbk_config
+
+        return convert_to_toml(parse_btrbk_config(config))
+
+    # --- _translate_preserve_min --------------------------------------------
+
+    def test_min_months_unit_remapped(self):
+        """btrbk 'm' = MONTHS must become btrfs-backup-ng 'M', not minutes ('m')."""
+        from btrfs_backup_ng.btrbk_import import _translate_preserve_min
+
+        assert _translate_preserve_min("3m") == ("3M", [])
+
+    def test_min_hours_days_weeks_years_passthrough(self):
+        from btrfs_backup_ng.btrbk_import import _translate_preserve_min
+
+        assert _translate_preserve_min("48h")[0] == "48h"
+        assert _translate_preserve_min("2d")[0] == "2d"
+        assert _translate_preserve_min("4w")[0] == "4w"
+        assert _translate_preserve_min("1y")[0] == "1y"
+
+    def test_min_no_maps_to_zero_age(self):
+        from btrfs_backup_ng.btrbk_import import _translate_preserve_min
+
+        assert _translate_preserve_min("no") == ("0s", [])
+
+    def test_min_all_and_latest_warn_and_fall_back(self):
+        from btrfs_backup_ng.btrbk_import import _translate_preserve_min
+
+        for token in ("all", "latest"):
+            value, warns = _translate_preserve_min(token)
+            assert value == "1d"
+            assert warns, f"{token} should warn"
+
+    def test_min_unrecognized_warns(self):
+        from btrfs_backup_ng.btrbk_import import _translate_preserve_min
+
+        value, warns = _translate_preserve_min("bogus")
+        assert value == "1d"
+        assert warns
+
+    # --- yearly (BUG #3) -----------------------------------------------------
+
+    def test_yearly_is_emitted(self):
+        """A btrbk yearly count must survive to the TOML (was silently dropped)."""
+        toml, _ = self._toml(
+            "snapshot_preserve 5y\n\nvolume /mnt/p\n  subvolume s\n    target /mnt/b\n"
+        )
+        assert "yearly = 5" in toml
+
+    def test_yearly_default_emitted_when_absent(self):
+        toml, _ = self._toml("volume /mnt/p\n  subvolume s\n    target /mnt/b\n")
+        assert "yearly = 0" in toml
+
+    # --- subvolume override (BUG #2) ----------------------------------------
+
+    def test_subvolume_override_emits_volumes_retention(self):
+        toml, _ = self._toml(
+            "snapshot_preserve 30d\n\nvolume /mnt/p\n"
+            "  subvolume home\n    snapshot_preserve 7d 2w\n    target /mnt/b\n"
+        )
+        assert "[volumes.retention]" in toml
+        assert "daily = 7" in toml
+        assert "weekly = 2" in toml
+
+    def test_no_override_omits_volumes_retention(self):
+        toml, _ = self._toml(
+            "snapshot_preserve 30d\n\nvolume /mnt/p\n  subvolume home\n    target /mnt/b\n"
+        )
+        assert "[volumes.retention]" not in toml
+
+    # --- warnings (BUG #1/#4/#5/#6) -----------------------------------------
+
+    def test_target_preserve_divergence_warns(self):
+        _, warns = self._toml(
+            "snapshot_preserve 7d\ntarget_preserve 30d\n\n"
+            "volume /mnt/p\n  subvolume s\n    target /mnt/b\n"
+        )
+        assert any(
+            "target_preserve" in w and "NOT applied separately" in w for w in warns
+        )
+
+    def test_day_of_week_warns(self):
+        _, warns = self._toml(
+            "preserve_day_of_week sunday\n\nvolume /mnt/p\n  subvolume s\n    target /mnt/b\n"
+        )
+        assert any("preserve_day_of_week" in w for w in warns)
+
+    def test_unrecognized_preserve_warns_not_silent_prune(self):
+        """A 'latest' snapshot_preserve maps to all-zeros; warn instead of silently
+        keeping no snapshots."""
+        _, warns = self._toml(
+            "snapshot_preserve latest\n\nvolume /mnt/p\n  subvolume s\n    target /mnt/b\n"
+        )
+        assert any("not understood" in w or "NO periodic" in w for w in warns)
+
+    def test_warnings_are_deduped(self):
+        _, warns = self._toml(
+            "preserve_day_of_week sunday\n\nvolume /mnt/p\n  subvolume s\n    target /mnt/b\n"
+        )
+        assert len(warns) == len(set(warns))
+
+    # --- anti-theater: generated TOML must LOAD -----------------------------
+
+    def test_generated_toml_loads_and_is_faithful(self, tmp_path):
+        from btrfs_backup_ng.config.loader import load_config
+
+        toml, _ = self._toml(
+            "snapshot_preserve_min 3m\nsnapshot_preserve 24h 14d 4w 6m 2y\n\n"
+            "volume /mnt/pool\n"
+            "  subvolume home\n    snapshot_preserve_min 2w\n    snapshot_preserve 7d\n    target /mnt/b/home\n"
+        )
+        p = tmp_path / "out.toml"
+        p.write_text(toml)
+        cfg, load_warns = load_config(p)
+
+        gr = cfg.global_config.retention
+        assert gr.min == "3M"  # months, not minutes
+        assert gr.yearly == 2  # not dropped
+        assert gr.daily == 14
+        v = cfg.volumes[0]
+        assert v.retention is not None
+        assert v.retention.min == "2w"
+        assert v.retention.daily == 7
+        # Phase 2A interaction: the generated config trips no unknown-key warnings.
+        assert not [w for w in load_warns if "Unknown config key" in w]
+
+    def test_special_min_token_produces_loadable_config(self, tmp_path):
+        """btrbk 'snapshot_preserve_min latest' previously emitted min = "latest",
+        which the loader REJECTS. It must now produce a loadable config."""
+        from btrfs_backup_ng.config.loader import load_config
+
+        toml, _ = self._toml(
+            "snapshot_preserve_min latest\n\nvolume /mnt/p\n  subvolume s\n    target /mnt/b\n"
+        )
+        p = tmp_path / "out.toml"
+        p.write_text(toml)
+        cfg, _ = load_config(p)  # must not raise ConfigError
+        assert cfg.global_config.retention.min == "1d"
+
+
+class TestBtrbkRetentionWarningQuality:
+    """0.9.2 Phase 2B-i review fixes: retention warnings must be accurate & distinct."""
+
+    @staticmethod
+    def _toml(config: str):
+        from btrfs_backup_ng.btrbk_import import convert_to_toml, parse_btrbk_config
+
+        return convert_to_toml(parse_btrbk_config(config))
+
+    def test_per_subvolume_divergence_warnings_are_distinct(self):
+        """Two subvolumes diverging with the SAME target_preserve value must each be
+        reported (the dedup must not collapse them)."""
+        _, warns = self._toml(
+            "volume /mnt/p\n"
+            "  subvolume home\n    snapshot_preserve 7d\n    target_preserve 30d\n    target /mnt/b/home\n"
+            "  subvolume data\n    snapshot_preserve 7d\n    target_preserve 30d\n    target /mnt/b/data\n"
+        )
+        div = [w for w in warns if "target_preserve" in w]
+        assert len(div) == 2
+        assert any("/mnt/p/home" in w for w in div)
+        assert any("/mnt/p/data" in w for w in div)
+
+    def test_divergence_message_accurate_when_no_snapshot_preserve(self):
+        """When target_preserve is set but snapshot_preserve is absent, the warning
+        must say the DEFAULT was used (not 'snapshot_preserve was used')."""
+        _, warns = self._toml(
+            "target_preserve 30d\n\nvolume /mnt/p\n  subvolume s\n    target /mnt/b\n"
+        )
+        div = [w for w in warns if "target_preserve" in w]
+        assert div
+        assert any("default retention was used" in w for w in div)
+        assert not any("snapshot_preserve was used" in w for w in div)
+
+    def test_zero_bucket_value_not_labelled_not_understood(self):
+        """'0d' parses fine (intentional zero) -- warn it keeps nothing, but do NOT
+        label it 'not understood'."""
+        from btrfs_backup_ng.btrbk_import import _parse_preserve_counts
+
+        _, warns = _parse_preserve_counts("0d")
+        assert warns
+        assert all("not understood" not in w for w in warns)
+
+    def test_unparseable_value_labelled_not_understood(self):
+        from btrfs_backup_ng.btrbk_import import _parse_preserve_counts
+
+        _, warns = _parse_preserve_counts("latest")
+        assert any("not understood" in w for w in warns)
+
+    def test_reordered_target_preserve_does_not_warn(self):
+        """Semantically-equal target_preserve (reordered tokens) must NOT warn."""
+        _, warns = self._toml(
+            "snapshot_preserve 14d 4w\ntarget_preserve 4w 14d\n\n"
+            "volume /mnt/p\n  subvolume s\n    target /mnt/b\n"
+        )
+        assert not any("target_preserve" in w for w in warns)
+
+    def test_differing_target_preserve_still_warns(self):
+        _, warns = self._toml(
+            "snapshot_preserve 14d\ntarget_preserve 30d\n\n"
+            "volume /mnt/p\n  subvolume s\n    target /mnt/b\n"
+        )
+        assert any("target_preserve" in w for w in warns)
+
+    def test_archive_preserve_warns(self):
+        _, warns = self._toml(
+            "archive_preserve 12m\n\nvolume /mnt/p\n  subvolume s\n    target /mnt/b\n"
+        )
+        assert any("archive_preserve" in w for w in warns)


### PR DESCRIPTION
## 0.9.2 Phase 2B-i — btrbk migration retention fidelity

The btrbk importer silently altered or dropped retention policy on migration. This fixes the representable cases and **warns loudly** on anything btrfs-backup-ng cannot represent — no silent policy loss. (Decision ①: map from `snapshot_preserve` and warn on `target_preserve` divergence.)

### Silent-data-loss bugs fixed
| Bug | Before | After |
|---|---|---|
| **`yearly` dropped** | `parse_btrbk_retention` parsed `5y`→yearly=5, but the output loop wrote only hourly/daily/weekly/monthly | `yearly` emitted |
| **`min` months→minutes** | btrbk `m`=months, but bbng's parser has `m`=minutes / `M`=months; `snapshot_preserve_min 3m` passed through as `min="3m"` = **3 minutes** | remapped `m`→`M` (`3m`→`3M`) |
| **Invalid `min` from special tokens** | btrbk `no`/`all`/`latest` written straight to `min="..."` → **config the loader rejects** (unloadable migration output) | `no`→`0s`; `all`/`latest`→`1d`+warn; unrecognized→`1d`+warn |
| **Subvolume retention ignored** | a per-subvolume `snapshot_preserve` never produced `[volumes.retention]` → fell back to the global default | emitted (inheriting the global for any un-overridden half) |

### Honest warnings where btrbk has no 1:1 equivalent
- **`target_preserve` divergence** — btrbk can keep a different schedule on the destination; bbng has one retention per volume, so the importer maps from `snapshot_preserve*` and warns when `target_preserve*` differs (compared by *parsed* policy, so reordered-but-equal token lists don't false-warn; labelled by volume path so per-subvolume warnings stay distinct).
- **`preserve_day_of_week` / `preserve_hour_of_day` / `archive_preserve*`** — no equivalent; captured and warned as dropped (previously swallowed).
- **Unparseable `snapshot_preserve`** (e.g. `latest`) → warned, instead of silently becoming a keep-nothing policy.

Global and per-volume retention share one `_retention_block` helper so the unit translation, `yearly`, and divergence warnings apply consistently. Warnings de-duplicated.

### Process
- **Adversarial 4-lens review** (clean — no critical/high; confirmed the core fixes are correct and load-verified). It caught five warning-*accuracy* issues, all fixed: distinct per-subvolume divergence warnings, accurate "default vs snapshot_preserve was used" wording, `0d` not mislabelled "not understood", reordered-equal `target_preserve` not warned, `archive_preserve*` warned.
- **Anti-theater integration test:** the *generated TOML actually loads* via `load_config` with faithful retention values — including the special-token case that previously produced an unloadable config, and a check that it trips no unknown-key warnings (Phase 2A interaction).
- The two silent bugs (yearly, month-unit) are **mutation-verified**; so is the distinct-warning dedup fix.
- Docs: `MIGRATING-FROM-BTRBK.md` retention table corrected (`m`=months, `yearly`, `no`→`0s`; `target_preserve` no longer claimed "same as snapshot" — it's warned).
- Full suite **2921 passed**; ruff + mypy clean.

Next in Phase 2B: **2B-ii** — the wizard encryption prompt (`cli/config_cmd.py`).
