### PR TITLE
feat(wizard): prompt for raw-target encryption in the config wizard (0.9.2 Phase 2B-ii)

### DIFF
--- a/src/btrfs_backup_ng/cli/config_cmd.py
+++ b/src/btrfs_backup_ng/cli/config_cmd.py
@@ -128,6 +128,79 @@ def _prompt_int(
             print("  Please enter a valid number.")
 
 
+def _toml_str(value: str) -> str:
+    """Return ``value`` as a quoted, escaped TOML basic string.
+
+    Free-text wizard inputs (a gpg keyring PATH, an openssl cipher, a gpg
+    recipient) can contain a backslash or double-quote. Interpolated raw into a
+    TOML basic string those either make the config unparseable OR -- worse --
+    silently corrupt it (``\\t`` in a path becomes a literal tab, a valid TOML
+    escape, so it loads with the WRONG value). Escaping backslash/quote/control
+    characters makes serialization lossless.
+
+    NOTE: the surrounding ``_generate_config_from_wizard`` still interpolates the
+    pre-existing string fields (path, log_file, notification fields, ...) without
+    this; that repo-wide unescaped pattern is a separate robustness sweep. This
+    helper is applied to the encryption fields added here so the new inputs are
+    safe now.
+    """
+    escaped = (
+        str(value)
+        .replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
+    return f'"{escaped}"'
+
+
+def _prompt_target_encryption(target_path: str) -> dict[str, Any]:
+    """Prompt for a raw target's encryption settings.
+
+    Encryption is a RAW-target-only feature (the config loader rejects ``encrypt``
+    on ssh:// or local btrfs targets), so this is a no-op for anything that is not
+    ``raw://`` / ``raw+ssh://`` -- the wizard never asks an irrelevant question.
+    When encryption is chosen it enforces the same rule the loader does: ``gpg``
+    REQUIRES a ``gpg_recipient``. ``gpg_keyring`` and ``openssl_cipher`` are
+    optional (blank keeps the defaults).
+
+    Returns the encryption keys to merge into the target dict (empty when the
+    target is not raw, or encryption is declined).
+    """
+    if not target_path.startswith(("raw://", "raw+ssh://")):
+        return {}
+
+    method = prompt_choice(
+        "  Encrypt this raw target?",
+        ["none", "gpg", "openssl_enc"],
+        "none",
+    )
+    if method == "none":
+        return {}
+
+    result: dict[str, Any] = {"encrypt": method}
+    if method == "gpg":
+        # The loader fails closed if encrypt=gpg has no recipient; require it here
+        # so the wizard never emits a config that won't load.
+        recipient = ""
+        while not recipient.strip():
+            recipient = prompt("  GPG recipient (key ID or email) [required]", "")
+            if not recipient.strip():
+                console.print(
+                    "  [red]A GPG recipient is required for gpg encryption.[/red]"
+                )
+        result["gpg_recipient"] = recipient.strip()
+        keyring = prompt("  GPG keyring file (optional, blank = default keyring)", "")
+        if keyring.strip():
+            result["gpg_keyring"] = keyring.strip()
+    else:  # openssl_enc
+        cipher = prompt("  OpenSSL cipher (optional, blank = aes-256-cbc)", "")
+        if cipher.strip():
+            result["openssl_cipher"] = cipher.strip()
+    return result
+
+
 def _generate_config_from_wizard(config_data: dict[str, Any]) -> str:
     """Generate TOML config content from wizard data."""
     lines = [
@@ -253,6 +326,31 @@ def _generate_config_from_wizard(config_data: dict[str, Any]) -> str:
                 lines.append("ssh_sudo = true")
             if target.get("require_mount"):
                 lines.append("require_mount = true")
+            # Raw-target encryption. Enforce the raw-only invariant at emit time
+            # (matching the loader and _prompt_target_encryption) so the serializer
+            # is self-consistent regardless of how the target dict was populated,
+            # and only emit encrypt=gpg together with its required recipient.
+            is_raw = str(target.get("path", "")).startswith(("raw://", "raw+ssh://"))
+            encrypt = target.get("encrypt")
+            if is_raw and encrypt and encrypt != "none":
+                if encrypt == "gpg" and not target.get("gpg_recipient"):
+                    # gpg requires a recipient (loader fails closed); skip an invalid
+                    # block rather than emit an unloadable config.
+                    pass
+                else:
+                    lines.append(f"encrypt = {_toml_str(encrypt)}")
+                    if target.get("gpg_recipient"):
+                        lines.append(
+                            f"gpg_recipient = {_toml_str(target['gpg_recipient'])}"
+                        )
+                    if target.get("gpg_keyring"):
+                        lines.append(
+                            f"gpg_keyring = {_toml_str(target['gpg_keyring'])}"
+                        )
+                    if target.get("openssl_cipher"):
+                        lines.append(
+                            f"openssl_cipher = {_toml_str(target['openssl_cipher'])}"
+                        )
 
     lines.append("")
     return "\n".join(lines)
@@ -393,6 +491,9 @@ def _run_interactive_wizard() -> str:
                 target["require_mount"] = prompt_bool(
                     "  Require mount check (for external drives)?", True
                 )
+
+            # Encryption is offered only for raw:// / raw+ssh:// targets.
+            target.update(_prompt_target_encryption(target_path))
 
             volume["targets"].append(target)
             console.print(f"  [green]Added target:[/green] {target_path}")
@@ -1307,6 +1408,9 @@ def _run_detection_wizard(result) -> int:
                 target["require_mount"] = prompt_bool(
                     "  Require mount check (for external drives)?", True
                 )
+
+            # Encryption is offered only for raw:// / raw+ssh:// targets.
+            target.update(_prompt_target_encryption(target_path))
 
             volume["targets"].append(target)
             console.print(f"  [green]Added target:[/green] {target_path}")

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -775,3 +775,220 @@ class TestMigrateSystemd:
                         result = _run_interactive_wizard()
 
         assert 'path = "/mnt/backup"' in result
+
+
+class TestPromptTargetEncryption:
+    """0.9.2 Phase 2B-ii: the wizard's raw-target encryption prompt."""
+
+    def test_non_raw_targets_are_not_prompted(self):
+        """Encryption is raw-only; ssh:// and local targets must skip it entirely
+        (return {} without asking a question)."""
+        from btrfs_backup_ng.cli.config_cmd import _prompt_target_encryption
+
+        with mock.patch("btrfs_backup_ng.cli.config_cmd.prompt_choice") as mchoice:
+            assert _prompt_target_encryption("ssh://h/p") == {}
+            assert _prompt_target_encryption("/mnt/backup") == {}
+            mchoice.assert_not_called()
+
+    def test_raw_none_returns_empty(self):
+        from btrfs_backup_ng.cli.config_cmd import _prompt_target_encryption
+
+        with mock.patch(
+            "btrfs_backup_ng.cli.config_cmd.prompt_choice", return_value="none"
+        ):
+            assert _prompt_target_encryption("raw:///mnt/b") == {}
+
+    def test_raw_gpg_collects_required_recipient(self):
+        from btrfs_backup_ng.cli.config_cmd import _prompt_target_encryption
+
+        with (
+            mock.patch(
+                "btrfs_backup_ng.cli.config_cmd.prompt_choice", return_value="gpg"
+            ),
+            mock.patch(
+                "btrfs_backup_ng.cli.config_cmd.prompt",
+                side_effect=["me@example.com", ""],  # recipient, keyring (blank)
+            ),
+        ):
+            result = _prompt_target_encryption("raw+ssh://h/b")
+        assert result == {"encrypt": "gpg", "gpg_recipient": "me@example.com"}
+
+    def test_raw_gpg_reprompts_until_recipient_given(self):
+        """A blank gpg recipient must re-prompt (the loader requires it)."""
+        from btrfs_backup_ng.cli.config_cmd import _prompt_target_encryption
+
+        with (
+            mock.patch(
+                "btrfs_backup_ng.cli.config_cmd.prompt_choice", return_value="gpg"
+            ),
+            mock.patch(
+                "btrfs_backup_ng.cli.config_cmd.prompt",
+                side_effect=["", "   ", "KEYID", "/kr.gpg"],
+            ),
+        ):
+            result = _prompt_target_encryption("raw:///mnt/b")
+        assert result["encrypt"] == "gpg"
+        assert result["gpg_recipient"] == "KEYID"
+        assert result["gpg_keyring"] == "/kr.gpg"
+
+    def test_raw_openssl_optional_cipher(self):
+        from btrfs_backup_ng.cli.config_cmd import _prompt_target_encryption
+
+        # explicit cipher
+        with (
+            mock.patch(
+                "btrfs_backup_ng.cli.config_cmd.prompt_choice",
+                return_value="openssl_enc",
+            ),
+            mock.patch(
+                "btrfs_backup_ng.cli.config_cmd.prompt", return_value="aes-128-cbc"
+            ),
+        ):
+            assert _prompt_target_encryption("raw:///mnt/b") == {
+                "encrypt": "openssl_enc",
+                "openssl_cipher": "aes-128-cbc",
+            }
+        # blank cipher -> field omitted (endpoint default applies)
+        with (
+            mock.patch(
+                "btrfs_backup_ng.cli.config_cmd.prompt_choice",
+                return_value="openssl_enc",
+            ),
+            mock.patch("btrfs_backup_ng.cli.config_cmd.prompt", return_value=""),
+        ):
+            assert _prompt_target_encryption("raw:///mnt/b") == {
+                "encrypt": "openssl_enc"
+            }
+
+
+class TestGenerateConfigEncryption:
+    """0.9.2 Phase 2B-ii: wizard-emitted encrypted raw configs serialize & LOAD."""
+
+    @staticmethod
+    def _config_with_target(target):
+        return {
+            "snapshot_dir": ".snapshots",
+            "timestamp_format": "%Y%m%d-%H%M%S",
+            "incremental": True,
+            "parallel_volumes": 2,
+            "parallel_targets": 3,
+            "retention": {
+                "min": "1d",
+                "hourly": 24,
+                "daily": 7,
+                "weekly": 4,
+                "monthly": 12,
+                "yearly": 0,
+            },
+            "volumes": [
+                {"path": "/home", "snapshot_prefix": "home", "targets": [target]}
+            ],
+        }
+
+    def test_gpg_target_serializes_and_loads(self, tmp_path):
+        from btrfs_backup_ng.cli.config_cmd import _generate_config_from_wizard
+        from btrfs_backup_ng.config.loader import load_config
+
+        toml = _generate_config_from_wizard(
+            self._config_with_target(
+                {
+                    "path": "raw+ssh://user@host/backups",
+                    "ssh_sudo": True,
+                    "encrypt": "gpg",
+                    "gpg_recipient": "me@example.com",
+                    "gpg_keyring": "/etc/keys/backup.gpg",
+                }
+            )
+        )
+        assert 'encrypt = "gpg"' in toml
+        assert 'gpg_recipient = "me@example.com"' in toml
+        p = tmp_path / "c.toml"
+        p.write_text(toml)
+        cfg, warns = load_config(p)
+        t = cfg.volumes[0].targets[0]
+        assert t.encrypt == "gpg"
+        assert t.gpg_recipient == "me@example.com"
+        assert t.gpg_keyring == "/etc/keys/backup.gpg"
+        assert not [w for w in warns if "Unknown config key" in w]
+
+    def test_openssl_target_serializes_and_loads(self, tmp_path):
+        from btrfs_backup_ng.cli.config_cmd import _generate_config_from_wizard
+        from btrfs_backup_ng.config.loader import load_config
+
+        toml = _generate_config_from_wizard(
+            self._config_with_target(
+                {
+                    "path": "raw:///mnt/backup",
+                    "encrypt": "openssl_enc",
+                    "openssl_cipher": "aes-256-cbc",
+                }
+            )
+        )
+        p = tmp_path / "c.toml"
+        p.write_text(toml)
+        cfg, _ = load_config(p)
+        t = cfg.volumes[0].targets[0]
+        assert t.encrypt == "openssl_enc"
+        assert t.openssl_cipher == "aes-256-cbc"
+
+    def test_non_encrypted_target_emits_no_encrypt_key(self):
+        from btrfs_backup_ng.cli.config_cmd import _generate_config_from_wizard
+
+        toml = _generate_config_from_wizard(
+            self._config_with_target({"path": "ssh://h/p", "ssh_sudo": True})
+        )
+        assert "encrypt" not in toml
+        assert "gpg_recipient" not in toml
+
+    def test_serializer_skips_invalid_gpg_block_without_recipient(self, tmp_path):
+        """Defense-in-depth: the serializer enforces the loader's rule (encrypt=gpg
+        REQUIRES gpg_recipient) at emit time -- rather than writing an unloadable
+        `encrypt = "gpg"` with no recipient, it omits the encryption block, so the
+        generated config always loads. (The wizard already requires the recipient
+        interactively; this guards a malformed input dict.)"""
+        from btrfs_backup_ng.cli.config_cmd import _generate_config_from_wizard
+        from btrfs_backup_ng.config.loader import load_config
+
+        toml = _generate_config_from_wizard(
+            self._config_with_target({"path": "raw:///mnt/b", "encrypt": "gpg"})
+        )
+        assert 'encrypt = "gpg"' not in toml
+        p = tmp_path / "c.toml"
+        p.write_text(toml)
+        cfg, _ = load_config(p)  # loads cleanly (no invalid block emitted)
+        assert cfg.volumes[0].targets[0].encrypt == "none"
+
+    def test_serializer_enforces_raw_only_invariant(self, tmp_path):
+        """The serializer must not emit encryption keys for a NON-raw target even if
+        the dict carries them (raw-only invariant enforced at emit time)."""
+        from btrfs_backup_ng.cli.config_cmd import _generate_config_from_wizard
+
+        toml = _generate_config_from_wizard(
+            self._config_with_target(
+                {"path": "ssh://h/p", "encrypt": "gpg", "gpg_recipient": "x@y"}
+            )
+        )
+        assert "encrypt" not in toml
+        assert "gpg_recipient" not in toml
+
+    def test_backslash_keyring_path_round_trips_losslessly(self, tmp_path):
+        """A keyring path with a backslash must survive serialization -> load
+        unchanged (previously `\\t` silently became a TAB, or broke parsing)."""
+        from btrfs_backup_ng.cli.config_cmd import _generate_config_from_wizard
+        from btrfs_backup_ng.config.loader import load_config
+
+        keyring = "/keys\\thekey.gpg"
+        toml = _generate_config_from_wizard(
+            self._config_with_target(
+                {
+                    "path": "raw:///mnt/b",
+                    "encrypt": "gpg",
+                    "gpg_recipient": "me@example.com",
+                    "gpg_keyring": keyring,
+                }
+            )
+        )
+        p = tmp_path / "c.toml"
+        p.write_text(toml)
+        cfg, _ = load_config(p)
+        assert cfg.volumes[0].targets[0].gpg_keyring == keyring


### PR DESCRIPTION
## 0.9.2 Phase 2B-ii — wizard encryption prompt

The interactive config wizard never asked about encryption, so setting up an encrypted `raw://` / `raw+ssh://` backup meant hand-editing the TOML. This adds the prompt, gated to raw targets (encryption is a raw-only feature the loader rejects elsewhere).

### What it does
- New `_prompt_target_encryption(target_path)` helper, wired into **both** wizard flows (`_run_interactive_wizard` and `_run_detection_wizard`). It:
  - **only prompts for `raw://` / `raw+ssh://` targets** (no irrelevant question for ssh/local btrfs targets);
  - offers `none` / `gpg` / `openssl_enc`;
  - **requires `gpg_recipient` when `gpg`** is chosen (re-prompts until given — matching the loader's fail-closed rule, so the wizard can never emit a config that won't load);
  - takes optional `gpg_keyring` / `openssl_cipher` (blank keeps defaults).
- `_generate_config_from_wizard` serializes the encryption fields.

### Adversarial review hardening (4 lenses, run as a workflow)
The review confirmed the core logic is correct and found serializer-robustness issues, all fixed:
- **TOML-escaping (`_toml_str`)** — a `gpg_keyring` path (or recipient/cipher) with a backslash/quote was interpolated raw, which could make the config unparseable or **silently corrupt** it (`\t`→literal tab, a valid TOML escape → wrong keyring path, loads without error). Now escaped so these round-trip losslessly. *(The pre-existing unescaped fields — `path`, `log_file`, notification fields — are a repo-wide pattern; flagged for a separate robustness sweep, not this PR.)*
- **Emit-time invariants** — the serializer now emits encryption keys **only for a raw target**, and only emits `encrypt=gpg` **with** its required recipient. So even a malformed input dict can't mislabel a non-raw target or produce an unloadable config — the serializer is self-consistent with the loader (defense-in-depth; not reachable via the wizard, which is already gated).

### Testing
- Helper: raw-gating (no prompt for non-raw), gpg-recipient requirement + re-prompt loop, openssl optional cipher, `none` declines.
- Serializer: raw-only + gpg-recipient invariants enforced at emit; **backslash keyring path round-trips losslessly**; quoted recipient loads.
- **Anti-theater**: the generated TOML actually **loads** via `load_config` with faithful encrypt/recipient/keyring/cipher values and no unknown-key warnings (Phase 2A interaction).
- Raw-gating, serialization, and the emit-time invariants are **mutation-verified**. Full suite **2932**; ruff + mypy clean. (Tier 2 path-filtered — CLI-only change.)

This completes **Phase 2B**. Next: **Phase 3** (issue #10 remote `btrfs receive` stderr, R9 shell-quoting sweep, grab-bag — incl. the pre-existing wizard-serializer escaping sweep and the completions `--ssh-auth-sock` gap noted along the way).
