### PR TITLE
fix(ssh): surface remote btrfs receive stderr in the raised transfer error (#10)

### DIFF
--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -907,15 +907,24 @@ def _do_direct_pipe_transfer(
             timeout=3600,  # 1 hour timeout
             show_progress=show_progress,
         )
-
-        if not success:
-            raise __util__.SnapshotTransferError("SSH direct pipe transfer failed")
-
-        return [0, 0]
-
     except Exception as e:
         logger.error("Error during SSH direct pipe transfer: %s", e)
         raise __util__.SnapshotTransferError(f"SSH direct pipe transfer failed: {e}")
+
+    # A clean (non-exception) failure: surface the actionable cause the endpoint
+    # captured from the send/receive stderr (issue #10) so the raised error -- which
+    # is what the run summary and transaction log record -- names the real reason
+    # (e.g. "cannot find parent subvolume", "No space left on device") instead of a
+    # generic message. Raised OUTSIDE the try so it is not re-wrapped by the except.
+    if not success:
+        reason = getattr(destination_endpoint, "_last_transfer_error", None)
+        if reason:
+            raise __util__.SnapshotTransferError(
+                f"SSH direct pipe transfer failed: {reason}"
+            )
+        raise __util__.SnapshotTransferError("SSH direct pipe transfer failed")
+
+    return [0, 0]
 
 
 def _do_process_transfer(

--- a/src/btrfs_backup_ng/endpoint/ssh.py
+++ b/src/btrfs_backup_ng/endpoint/ssh.py
@@ -3447,6 +3447,12 @@ print(json.dumps(result))
         """
         logger.debug("Starting direct SSH pipe transfer for %s", snapshot)
 
+        # Reset the per-transfer diagnostic. A failing monitor records the send/
+        # receive stderr here so _do_direct_pipe_transfer can surface the actionable
+        # cause in the raised error (not just a separate ERROR log line). Reset once
+        # up front; across retries it holds the LAST attempt's cause.
+        self._last_transfer_error: Optional[str] = None
+
         # Get snapshot details
         snapshot_path = str(snapshot.get_path())
         snapshot_name = snapshot.get_name()
@@ -3860,13 +3866,15 @@ print(json.dumps(result))
             logger.error(
                 f"FAILED: Send process failed (exit code: {send_process.returncode})"
             )
-            self._log_process_error(send_process, "send")
+            self._last_transfer_error = self._log_process_error(send_process, "send")
             return False
         if receive_process.returncode != 0:
             logger.error(
                 f"FAILED: Receive process failed (exit code: {receive_process.returncode})"
             )
-            self._log_process_error(receive_process, "receive")
+            self._last_transfer_error = self._log_process_error(
+                receive_process, "receive"
+            )
             return False
 
         # Secondary confirmation only AFTER both processes exited 0.
@@ -3918,15 +3926,20 @@ print(json.dumps(result))
         if elapsed > 60:  # After 1 minute
             logger.debug("   STATUS: Transfer progressing normally...")
 
-    def _log_process_error(self, process: Any, process_name: str) -> None:
-        """Log detailed error information for a failed process."""
+    def _log_process_error(self, process: Any, process_name: str) -> Optional[str]:
+        """Log a failed process's stderr and RETURN it (stripped), or None.
+
+        Returning the text lets the caller thread the actionable cause into the
+        raised transfer error instead of leaving it only in a separate log line."""
         try:
             if process.stderr:
                 stderr_data = process.stderr.read().decode("utf-8", errors="replace")
                 if stderr_data.strip():
                     logger.error(f"{process_name} process stderr: {stderr_data}")
+                    return stderr_data.strip()
         except Exception as e:
             logger.debug(f"Could not read stderr from {process_name} process: {e}")
+        return None
 
     def _simple_transfer_monitor(
         self,
@@ -4018,7 +4031,9 @@ print(json.dumps(result))
         send_code = send_process.returncode
         if send_code != 0:
             logger.error(f"FAILED: Send process failed with exit code {send_code}")
-            self._log_simple_process_error(send_process, "send")
+            self._last_transfer_error = self._log_simple_process_error(
+                send_process, "send"
+            )
             return False
 
         logger.info("SUCCESS: Send process completed successfully")
@@ -4031,7 +4046,9 @@ print(json.dumps(result))
             logger.error(
                 f"FAILED: Receive process failed with exit code {receive_code}"
             )
-            self._log_simple_process_error(receive_process, "receive")
+            self._last_transfer_error = self._log_simple_process_error(
+                receive_process, "receive"
+            )
             return False
         logger.info("SUCCESS: Receive process completed successfully")
 
@@ -4062,12 +4079,19 @@ print(json.dumps(result))
             logger.error(f"ERROR: Final verification failed: {e}")
             return False
 
-    def _log_simple_process_error(self, process: Any, process_name: str) -> None:
-        """Log error information for a failed process in simple monitoring mode."""
+    def _log_simple_process_error(
+        self, process: Any, process_name: str
+    ) -> Optional[str]:
+        """Log a failed process's stderr and RETURN it (stripped), or None.
+
+        Simple-monitor twin of ``_log_process_error``; returning the text lets the
+        caller surface the actionable cause in the raised transfer error."""
         try:
             if hasattr(process, "stderr") and process.stderr:
                 stderr_data = process.stderr.read().decode("utf-8", errors="replace")
                 if stderr_data.strip():
                     logger.error(f"{process_name} process stderr: {stderr_data}")
+                    return stderr_data.strip()
         except Exception as e:
             logger.debug(f"Could not read stderr from {process_name} process: {e}")
+        return None

--- a/tests/test_r1_transfer_success_contract.py
+++ b/tests/test_r1_transfer_success_contract.py
@@ -18,6 +18,8 @@ import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 import btrfs_backup_ng.endpoint.ssh as ssh_mod
 from btrfs_backup_ng.endpoint.ssh import SSHEndpoint
 
@@ -442,3 +444,95 @@ class TestReceiveChunkedCleanupGating:
         result, cleanup = self._run(monkeypatch, return_code=0, verify_result=True)
         assert result is True
         cleanup.assert_not_called()
+
+
+class TestReceiveStderrThreadedToError:
+    """Issue #10: a failed send/receive threads its stderr CAUSE into the raised
+    SnapshotTransferError, so the run summary / transaction log names the real
+    reason instead of a generic "SSH direct pipe transfer failed"."""
+
+    @staticmethod
+    def _proc_with_stderr(returncode: int, stderr: bytes = b"") -> MagicMock:
+        p = _proc(returncode)
+        p.stderr = io.BytesIO(stderr)
+        return p
+
+    def test_simple_monitor_captures_receive_stderr(self):
+        ep = _bare_endpoint()
+        ep._last_transfer_error = None
+        send = self._proc_with_stderr(0)
+        receive = self._proc_with_stderr(1, b"ERROR: cannot find parent subvolume")
+        ok = ep._simple_transfer_monitor(
+            {"send": send, "receive": receive, "buffer": None},
+            start_time=time.time(),
+            dest_path="/d",
+            snapshot_name="s",
+            max_wait_time=5,
+        )
+        assert ok is False
+        assert ep._last_transfer_error == "ERROR: cannot find parent subvolume"
+
+    def test_simple_monitor_captures_send_stderr(self):
+        ep = _bare_endpoint()
+        ep._last_transfer_error = None
+        send = self._proc_with_stderr(1, b"ERROR: could not find subvolume")
+        receive = self._proc_with_stderr(0)
+        ok = ep._simple_transfer_monitor(
+            {"send": send, "receive": receive, "buffer": None},
+            start_time=time.time(),
+            dest_path="/d",
+            snapshot_name="s",
+            max_wait_time=5,
+        )
+        assert ok is False
+        assert ep._last_transfer_error == "ERROR: could not find subvolume"
+
+    def test_enhanced_monitor_captures_receive_stderr(self):
+        ep = _bare_endpoint()
+        ep._last_transfer_error = None
+        send = self._proc_with_stderr(0)
+        receive = self._proc_with_stderr(1, b"No space left on device")
+        ok = ep._monitor_transfer_progress(
+            {"send": send, "receive": receive, "buffer": None},
+            start_time=time.time(),
+            dest_path="/d",
+            snapshot_name="s",
+            max_wait_time=5,
+        )
+        assert ok is False
+        assert ep._last_transfer_error == "No space left on device"
+
+    def test_log_helpers_return_stderr_text(self):
+        ep = _bare_endpoint()
+        p = self._proc_with_stderr(1, b"  boom  \n")
+        assert ep._log_simple_process_error(p, "receive") == "boom"
+        q = self._proc_with_stderr(1, b"kaboom")
+        assert ep._log_process_error(q, "receive") == "kaboom"
+        # No stderr -> None
+        empty = _proc(1)
+        empty.stderr = io.BytesIO(b"")
+        assert ep._log_simple_process_error(empty, "receive") is None
+
+    def test_direct_pipe_error_carries_captured_reason(self):
+        from btrfs_backup_ng import __util__
+        from btrfs_backup_ng.core import operations as ops
+
+        stub = MagicMock()
+        stub.send_receive.return_value = False
+        stub._last_transfer_error = "ERROR: cannot find parent subvolume"
+        with pytest.raises(__util__.SnapshotTransferError) as ei:
+            ops._do_direct_pipe_transfer(MagicMock(), stub, None, None, None)
+        assert "cannot find parent subvolume" in str(ei.value)
+
+    def test_direct_pipe_error_generic_without_reason_no_double_wrap(self):
+        """When no cause was captured the message is the plain generic string --
+        NOT the old self-wrapped 'failed: SSH direct pipe transfer failed'."""
+        from btrfs_backup_ng import __util__
+        from btrfs_backup_ng.core import operations as ops
+
+        stub = MagicMock()
+        stub.send_receive.return_value = False
+        stub._last_transfer_error = None
+        with pytest.raises(__util__.SnapshotTransferError) as ei:
+            ops._do_direct_pipe_transfer(MagicMock(), stub, None, None, None)
+        assert str(ei.value) == "SSH direct pipe transfer failed"


### PR DESCRIPTION
## Issue #10 — surface remote `btrfs receive` stderr on failure

Closes #10. On investigation, **2 of the issue's 3 fix items were already implemented** since it was filed: both direct-pipe monitors already read + log the receive stderr on failure (`_log_*_process_error(receive_process, "receive")`), and the shell pipeline already uses `set -o pipefail`. This PR closes the **one remaining gap**.

### The gap
The logged cause was **not threaded into the raised `SnapshotTransferError`**, so the message recorded in the **run summary** and **transaction log** (and seen by callers / monitoring tools) stayed the generic `"SSH direct pipe transfer failed"` — even though a separate ERROR log line had the real reason.

### The fix
- `_log_process_error` / `_log_simple_process_error` now **return** the captured stderr (still logging it).
- Both monitors record the failing send/receive stderr in `self._last_transfer_error` (reset at `send_receive` entry; across retries it holds the last attempt).
- `_do_direct_pipe_transfer` surfaces it: `"SSH direct pipe transfer failed: <cause>"` (e.g. `cannot find parent subvolume`, `No space left on device`).
- **Bonus:** fixed a pre-existing double-wrap — the `if not success` raise sat inside the function's own `except`, re-wrapping into `"...failed: ...failed"`; it now raises outside the `try`.

### Not a correctness change
Success/failure is still decided **authoritatively** by the monitor (both processes exit 0 **AND** `btrfs subvolume show` verifies). This is purely diagnostics/UX — the failure *message* now names the real reason. The R1 transfer-success contract is untouched (these tests live alongside the R1 enforcement tests).

### Testing
Mutation-verified: both monitors capture receive **and** send stderr; the log helpers return the text; the raised error carries the cause; the no-cause case stays plain-generic (no double-wrap). Full suite **2938**; ruff + mypy clean.