### PR TITLE
fix(ssh): quote paths/names in residual remote-shell command sites (R9)

### DIFF
--- a/src/btrfs_backup_ng/endpoint/ssh.py
+++ b/src/btrfs_backup_ng/endpoint/ssh.py
@@ -1652,7 +1652,13 @@ print(json.dumps(result))
         ssh_base_cmd = self.ssh_manager.get_ssh_base_cmd(force_tty=needs_tty)  # type: ignore
         logger.debug("SSH base command: %s", ssh_base_cmd)
 
-        ssh_cmd = ssh_base_cmd + ["--"] + remote_cmd
+        # shlex.quote each element: ssh space-joins the command args and the REMOTE
+        # shell re-parses them, so a path/name with a space or metacharacter would be
+        # re-split (or injected) remotely. Quoting mirrors raw.py's _exec_remote_command
+        # and is a no-op for clean tokens. All callers pass literal argv (command +
+        # flags + values), never bare shell operators, so this cannot break intended
+        # remote-shell syntax. (R9)
+        ssh_cmd = ssh_base_cmd + ["--"] + [shlex.quote(str(c)) for c in remote_cmd]
         logger.debug("Complete SSH command: %s", ssh_cmd)
 
         # Always capture stderr if not explicitly provided
@@ -3622,9 +3628,13 @@ print(json.dumps(result))
             "passwordless_sudo_available", False
         )
 
-        # Build the receive command
+        # Build the receive command. shlex.quote the destination: it is
+        # interpolated into a remote `sh -c` string by _build_receive_command
+        # (whose docstring requires a shell-escaped path), and every OTHER caller
+        # already passes shlex.quote(dest_path). Without it a target path with a
+        # space or shell metacharacter breaks the remote receive / injects. (R9)
         receive_cmd = _build_receive_command(
-            dest_path=dest_path,
+            dest_path=shlex.quote(dest_path),
             use_sudo=use_sudo,
             password_on_stdin=use_sudo and not passwordless,
         )

--- a/src/btrfs_backup_ng/sshutil/diagnose.py
+++ b/src/btrfs_backup_ng/sshutil/diagnose.py
@@ -7,6 +7,7 @@ that may prevent btrfs-backup-ng from successfully transferring backups.
 import argparse
 import logging
 import os
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -153,7 +154,7 @@ def test_write_permissions(
 
     # First check if path exists
     cmd = ssh_command_base(host, port, identity_file)
-    cmd.append(f"test -e '{path}'")
+    cmd.append(f"test -e {shlex.quote(path)}")
 
     returncode, stdout, stderr = run_command(cmd)
 
@@ -163,7 +164,8 @@ def test_write_permissions(
         # Check if parent directory exists and is writable
         parent_path = str(Path(path).parent)
         cmd = ssh_command_base(host, port, identity_file)
-        cmd.append(f"test -d '{parent_path}' && test -w '{parent_path}'")
+        quoted_parent = shlex.quote(parent_path)
+        cmd.append(f"test -d {quoted_parent} && test -w {quoted_parent}")
 
         returncode, stdout, stderr = run_command(cmd)
 
@@ -178,7 +180,7 @@ def test_write_permissions(
 
     # Check if path is writable
     cmd = ssh_command_base(host, port, identity_file)
-    cmd.append(f"test -w '{path}'")
+    cmd.append(f"test -w {shlex.quote(path)}")
 
     returncode, stdout, stderr = run_command(cmd)
 
@@ -190,7 +192,7 @@ def test_write_permissions(
 
         # Check if it's writable with sudo
         cmd = ssh_command_base(host, port, identity_file)
-        cmd.append(f"sudo -n test -w '{path}'")
+        cmd.append(f"sudo -n test -w {shlex.quote(path)}")
 
         returncode, stdout, stderr = run_command(cmd)
 
@@ -212,8 +214,11 @@ def test_btrfs_filesystem(
     logger.debug(f"Testing if {path} is on a btrfs filesystem...")
 
     cmd = ssh_command_base(host, port, identity_file)
+    quoted_path = shlex.quote(path)
+    quoted_parent = shlex.quote(str(Path(path).parent))
     cmd.append(
-        f"stat -f -c '%T' '{path}' 2>/dev/null || stat -f -c '%T' '{str(Path(path).parent)}' 2>/dev/null"
+        f"stat -f -c '%T' {quoted_path} 2>/dev/null || "
+        f"stat -f -c '%T' {quoted_parent} 2>/dev/null"
     )
 
     returncode, stdout, stderr = run_command(cmd)
@@ -265,8 +270,10 @@ def test_btrfs_receive(
         else:
             test_path = f"{path}.test_receive"
 
+        quoted_test_path = shlex.quote(test_path)
         cmd.append(
-            f"sudo -n btrfs subvolume create '{test_path}' && sudo -n btrfs subvolume delete '{test_path}'"
+            f"sudo -n btrfs subvolume create {quoted_test_path} && "
+            f"sudo -n btrfs subvolume delete {quoted_test_path}"
         )
 
         returncode, stdout, stderr = run_command(cmd, timeout=60)

--- a/tests/test_r9_quoting.py
+++ b/tests/test_r9_quoting.py
@@ -1,0 +1,152 @@
+"""R9 defensive shell-quoting sweep: paths/names interpolated into a REMOTE shell
+context must be shlex.quote'd so a space / single-quote / shell metacharacter can
+neither break the command nor inject into the remote shell.
+
+Mutation-verified: reverting any one quote (the chunked-receive dest, the central
+``_exec_remote_command`` element quoting, or a diagnose.py path) makes the matching
+test fail. Clean paths are unchanged (no regression).
+"""
+
+from __future__ import annotations
+
+import shlex
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import btrfs_backup_ng.endpoint.ssh as ssh_mod
+import btrfs_backup_ng.sshutil.diagnose as diag
+from btrfs_backup_ng.endpoint.ssh import SSHEndpoint
+
+NASTY = "/mnt/a b'c$(x)"  # space + single-quote + command-substitution
+CLEAN = "/mnt/backup/home"
+
+
+class TestReceiveChunkedQuotesDest:
+    """HIGH: receive_chunked passes shlex.quote(dest_path) to _build_receive_command
+    (parity with the other three callers)."""
+
+    def _capture_dest(self, configured_path):
+        ep = SSHEndpoint.__new__(SSHEndpoint)
+        ep.config = {"path": configured_path, "ssh_sudo": False}
+        ep._normalize_path = MagicMock(side_effect=lambda p: p)  # type: ignore[method-assign]
+        manifest = SimpleNamespace(
+            snapshot_name="snap", chunk_count=1, snapshot_path="/src/snap"
+        )
+        captured: dict = {}
+
+        def fake_build(dest_path, **kw):
+            captured["dest_path"] = dest_path
+            raise RuntimeError("stop-after-build")
+
+        with patch.object(ssh_mod, "_build_receive_command", side_effect=fake_build):
+            with pytest.raises(RuntimeError, match="stop-after-build"):
+                ep.receive_chunked(chunk_reader=None, manifest=manifest)
+        return captured["dest_path"]
+
+    def test_nasty_path_is_quoted(self):
+        assert self._capture_dest(NASTY) == shlex.quote(NASTY)
+
+    def test_clean_path_unchanged(self):
+        # shlex.quote is a no-op for a clean path -> no regression.
+        assert self._capture_dest(CLEAN) == CLEAN
+
+
+class TestExecRemoteCommandQuotesElements:
+    """Systemic MEDIUM: _exec_remote_command quotes each remote_cmd element (ssh
+    space-joins them and the REMOTE shell re-parses)."""
+
+    def _capture_ssh_cmd(self, built_remote_cmd):
+        ep = SSHEndpoint.__new__(SSHEndpoint)
+        ep.config = {"ssh_sudo": False}
+        ep._normalize_path = MagicMock(side_effect=lambda a: a)  # type: ignore[method-assign]
+        ep._build_remote_command = MagicMock(return_value=built_remote_cmd)  # type: ignore[method-assign]
+        ep.ssh_manager = MagicMock()
+        ep.ssh_manager.get_ssh_base_cmd.return_value = ["ssh", "host"]
+        captured: dict = {}
+
+        def fake_run(cmd, *a, **k):
+            captured["cmd"] = cmd
+            return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+        with patch.object(ssh_mod.subprocess, "run", side_effect=fake_run):
+            ep._exec_remote_command(["btrfs", "subvolume", "show", "/x"])
+        return captured["cmd"]
+
+    def test_path_element_with_space_is_quoted(self):
+        ssh_cmd = self._capture_ssh_cmd(["btrfs", "subvolume", "show", "/mnt/a b"])
+        assert ssh_cmd == [
+            "ssh",
+            "host",
+            "--",
+            "btrfs",
+            "subvolume",
+            "show",
+            "'/mnt/a b'",
+        ]
+
+    def test_metachars_are_neutralized(self):
+        ssh_cmd = self._capture_ssh_cmd(["rm", "-rf", NASTY])
+        assert ssh_cmd[-1] == shlex.quote(NASTY)
+        # the dangerous $()/;/quote is inside single quotes now
+        assert "$(x)" not in " ".join(ssh_cmd).replace(shlex.quote(NASTY), "")
+
+    def test_clean_elements_unchanged(self):
+        ssh_cmd = self._capture_ssh_cmd(["btrfs", "subvolume", "show", CLEAN])
+        assert ssh_cmd == ["ssh", "host", "--", "btrfs", "subvolume", "show", CLEAN]
+
+
+class TestDiagnoseQuotesPaths:
+    """MEDIUM: sshutil/diagnose.py builds remote-shell strings; paths must be
+    shlex.quote'd, not naively wrapped in bare single quotes."""
+
+    def _run_and_capture(self, func, *args):
+        """Call a diagnose.* function with run_command mocked, capturing every
+        appended remote-shell string (cmd[-1] of each call)."""
+        strings: list[str] = []
+
+        def fake_run_command(cmd, timeout=30):
+            strings.append(cmd[-1])
+            return (0, "btrfs", "")  # returncode 0 keeps functions progressing
+
+        with patch.object(diag, "run_command", side_effect=fake_run_command):
+            func(*args)
+        return strings
+
+    def test_write_permissions_quotes_path(self):
+        strings = self._run_and_capture(
+            diag.test_write_permissions, "host", NASTY, None, None
+        )
+        joined = "\n".join(strings)
+        # The raw single-quote-wrapped form must be gone; the shlex form present.
+        assert f"'{NASTY}'" not in joined
+        assert shlex.quote(NASTY) in joined
+
+    def test_btrfs_filesystem_quotes_path(self):
+        strings = self._run_and_capture(
+            diag.test_btrfs_filesystem, "host", NASTY, None, None
+        )
+        joined = "\n".join(strings)
+        assert shlex.quote(NASTY) in joined
+        assert f"'{NASTY}'" not in joined
+
+    def test_btrfs_receive_quotes_sudo_path(self):
+        strings = self._run_and_capture(
+            diag.test_btrfs_receive, "host", NASTY, None, None
+        )
+        joined = "\n".join(strings)
+        # test_path is derived (NASTY + ".test_receive"); assert it's shlex-quoted
+        # in the sudo btrfs subvolume command (injection-as-remote-root vector).
+        assert any(
+            "sudo -n btrfs subvolume create" in s
+            and shlex.quote(NASTY + ".test_receive") in s
+            for s in strings
+        ), joined
+
+    def test_clean_path_not_extra_quoted(self):
+        strings = self._run_and_capture(
+            diag.test_write_permissions, "host", CLEAN, None, None
+        )
+        # A clean path appears bare (shlex.quote is a no-op) -> no regression.
+        assert any(CLEAN in s and f"'{CLEAN}'" not in s for s in strings)


### PR DESCRIPTION
## R9 — defensive shell-quoting sweep

A 4-angle inventory (local `shell=True`, remote SSH strings, raw endpoint, core/helpers) found the local-shell sites and the raw endpoint were **already** `shlex.quote`-hardened (PR4/PR6). All residual risk was **paths/names interpolated into a *remote* shell context**: **1 HIGH + 8 MEDIUM**, fixed in three coherent changes (2 files).

### ① HIGH — `endpoint/ssh.py` `receive_chunked`
The chunked-receive caller passed the **raw** destination path to `_build_receive_command` (which interpolates it into a remote `sh -c` string, and whose docstring says "should be shell-escaped"). The **other 3 callers already pass `shlex.quote(dest_path)`**; this one now matches. A target path with a space/`'`/`$()` previously broke the remote receive or injected.

### ② Systemic MEDIUM — `endpoint/ssh.py::_exec_remote_command`
It builds `ssh … -- <argv>`; ssh space-joins the args and the **remote shell re-parses** them, but the elements weren't quoted — so a path/name with a space/metachar was re-split (or injected) remotely. Covers the `rm -rf`, `btrfs subvolume delete/show`, and `mkdir -p` callers (+ the `expected_path` feeders). Now quotes each element, **mirroring raw.py's already-correct `_exec_remote_command`**.
- **Safety-verified:** grepped all ~20 callers — none passes bare shell operators (`&&`/`>`/`|`), so quoting can't alter intended remote syntax. It also fixes a **latent correctness bug** (any path or `python3 -c` script with spaces was already broken). `shlex.quote` is a no-op for clean tokens → **no regression**.

### ③ MEDIUM — `sshutil/diagnose.py` (6 sites)
Remote-shell strings wrapped paths in bare single quotes (`'{path}'`), which a path containing a `'` escapes. Now `shlex.quote`. **Two run under `sudo -n`** on the remote (`test -w`, `btrfs subvolume create/delete`) — those closed an inject-**as-remote-root** vector.

### Testing
Adversarial paths (space + single-quote + `$()`) driven through each construct, asserting it quotes them **and** that a clean path is unchanged (no regression). All three fixes **mutation-verified**. Full suite **2947**; ruff + mypy clean. Tier 2 btrfs integration exercises the real remote path.