### PR TITLE
fix(ssh): bound the ControlMaster socket path under the Unix sun_path limit

### DIFF
--- a/src/btrfs_backup_ng/sshutil/master.py
+++ b/src/btrfs_backup_ng/sshutil/master.py
@@ -1,5 +1,6 @@
 import atexit
 import getpass
+import hashlib
 import os
 import pwd
 import shutil
@@ -175,17 +176,40 @@ class SSHMasterManager:
             # only euid owns closes it by design; the socket name already embeds pid+tid, so
             # nothing relied on a stable path. R12c/P2.
             self.control_dir = Path(
-                tempfile.mkdtemp(prefix="btrfs-backup-ng-cm-", dir=_control_dir_base())
+                tempfile.mkdtemp(prefix="bbng-cm-", dir=_control_dir_base())
             )
             self._own_control_dir = True
             # Backstop cleanup if stop_master()/cleanup_socket() is never reached.
             atexit.register(shutil.rmtree, str(self.control_dir), ignore_errors=True)
 
+        # The ControlPath must fit in a Unix domain socket sun_path (108 bytes on
+        # Linux), and OpenSSH appends its own ~17-char ".<random>" suffix while
+        # CREATING the master socket. The old
+        # ``cm_{user}_{host}_{pid}_{tid}.sock`` embedded a 15-digit thread id and a
+        # variable-length hostname, so a real FQDN + the mkdtemp base overflowed the
+        # limit ("unix_listener: path ... too long for Unix domain socket") -- which
+        # aborts the master and makes EVERY ssh operation fail with a misleading
+        # "authentication failed". Use a fixed-length digest of the same identity
+        # components: unique per manager, but bounded regardless of user/host length.
         self._instance_id = f"{os.getpid()}_{threading.get_ident()}"
-        self.control_path = (
-            self.control_dir
-            / f"cm_{self.username}_{self.hostname}_{self._instance_id}.sock"
-        )
+        digest = hashlib.sha1(
+            f"{self.username}_{self.hostname}_{self._instance_id}".encode()
+        ).hexdigest()[:12]
+        self.control_path = self.control_dir / f"cm-{digest}.sock"
+
+        # Belt-and-suspenders: the shortening keeps the real cases well under the
+        # limit, but an operator-supplied ``control_dir`` could still be pathological.
+        # Budget for OpenSSH's socket-creation suffix and warn (multiplexing would
+        # silently fail otherwise). 108 = Linux sun_path; leave margin for the suffix.
+        _effective_len = len(str(self.control_path)) + 20
+        if _effective_len > 108:
+            logger.warning(
+                "ControlMaster socket path is %d bytes (+suffix), near the ~108-byte "
+                "Unix-socket limit; connection multiplexing may fail. Use a shorter "
+                "control_dir. Path: %s",
+                _effective_len,
+                self.control_path,
+            )
         self._lock = threading.Lock()
         self._master_started = False
 

--- a/tests/test_control_socket_path.py
+++ b/tests/test_control_socket_path.py
@@ -1,0 +1,54 @@
+"""ControlMaster socket path must fit the Unix sun_path limit (~108 bytes).
+
+The old ``cm_{user}_{host}_{pid}_{tid}.sock`` embedded a 15-digit thread id and a
+variable-length hostname; with the mkdtemp base + OpenSSH's ~17-char socket-creation
+suffix it overflowed the limit ("unix_listener: path ... too long"), silently
+breaking EVERY ssh operation. The name is now a fixed-length digest.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+from btrfs_backup_ng.sshutil.master import SSHMasterManager
+
+LONG_HOST = "a-really-long-fully-qualified-hostname.example.internal.corp.example.net"
+LONG_USER = "a-very-long-service-account-name-for-backups"
+
+
+class TestControlPathLength:
+    @staticmethod
+    def _mgr(tmp_path, hostname, username="u"):
+        return SSHMasterManager(
+            hostname=hostname,
+            username=username,
+            control_dir=str(tmp_path / "cm"),
+        )
+
+    def test_socket_name_is_short_fixed_length(self, tmp_path):
+        m = self._mgr(tmp_path, "192.168.0.70", "mberry")
+        name = m.control_path.name
+        assert name.startswith("cm-") and name.endswith(".sock")
+        # cm- (3) + 12 hex + .sock (5) = 20, always.
+        assert len(name) == 20, name
+
+    def test_name_does_not_grow_with_host_or_user(self, tmp_path):
+        m = self._mgr(tmp_path, LONG_HOST, LONG_USER)
+        assert len(m.control_path.name) == 20
+        # The raw (bloating) identity must NOT appear in the path.
+        assert LONG_HOST not in str(m.control_path)
+        assert LONG_USER not in str(m.control_path)
+
+    def test_distinct_hosts_get_distinct_sockets(self, tmp_path):
+        a = self._mgr(tmp_path, "host-a")
+        b = self._mgr(tmp_path, "host-b")
+        assert a.control_path.name != b.control_path.name
+
+    def test_full_path_fits_sun_path_limit_on_default_base(self):
+        """With the real mkdtemp base (short: XDG_RUNTIME_DIR or /tmp) and a long
+        FQDN, the path + OpenSSH's ~17-char creation suffix stays under 108."""
+        m = SSHMasterManager(hostname=LONG_HOST, username=LONG_USER)
+        try:
+            assert len(str(m.control_path)) + 20 <= 108, m.control_path
+        finally:
+            shutil.rmtree(m.control_dir, ignore_errors=True)

--- a/tests/test_r12c_control_lock_hardening.py
+++ b/tests/test_r12c_control_lock_hardening.py
@@ -39,7 +39,9 @@ def test_control_dir_is_unpredictable_and_0700():
     m = _mgr()
     try:
         assert m._own_control_dir is True
-        assert "btrfs-backup-ng-cm-" in m.control_dir.name
+        # Prefix shortened to keep the ControlPath within the Unix sun_path limit
+        # (see test_control_socket_path.py); still an mkdtemp-random, 0700, euid dir.
+        assert m.control_dir.name.startswith("bbng-cm-")
         st = m.control_dir.stat()
         assert stat.S_IMODE(st.st_mode) == 0o700
         assert st.st_uid == os.geteuid()


### PR DESCRIPTION
## The "paramiko .70 auth failure" was a ControlMaster socket-path-length bug

Investigating the SSHEndpoint auth failure I found during the 0.9.2 hardware testing, the root cause is **not** paramiko or authentication — it's the **ControlMaster socket path exceeding the Unix domain socket `sun_path` limit** (~108 bytes on Linux). *(This merges two backlog items: the "paramiko auth" finding and the "ControlMaster socket-path limit".)*

### Diagnosis
The ControlPath measured **94 bytes** on a plain LAN host:
```
/run/user/1000/btrfs-backup-ng-cm-r1ztak29/cm_mberry_192.168.0.70_2082097_140173833353024.sock
```
OpenSSH appends its own ~17-char `.<random>` suffix while *creating* the master socket → **111 > 108** → `unix_listener: path … too long for Unix domain socket` → the master never opens, so **every ssh operation** (status/list/prune/backup) fails with a misleading **"All SSH authentication methods failed"**. Plain `ssh` works because it doesn't build this path. The bloat is the socket name `cm_{user}_{host}_{pid}_{tid}.sock` — a 15-digit thread id + a variable-length hostname.

### Fix (central)
- The socket name is now a **fixed-length 12-hex digest** of the same identity components: `cm-<12hex>.sock` (20 bytes) — unique per manager, bounded regardless of user/host length.
- mkdtemp prefix `btrfs-backup-ng-cm-` → `bbng-cm-`.
- All **8 ControlPath sites** read `self.control_path`, so they're fixed at once.
- A length-check **warning** fires if a pathological operator-supplied `control_dir` still overflows.

Result on this machine: **94 → ~51 bytes** (+17 suffix = 68), well under the limit, independent of hostname length.

### Verification
- **HARDWARE-PROVEN on a real LAN btrfs host:** the exact repro (`status` over `ssh://`) that failed with "All SSH authentication methods failed" now **authenticates and establishes the master connection** (`SSH key-based authentication succeeded` → `SSH master connection established successfully`).
- Unit tests assert the socket name is short and does **not** grow with host/user length — **mutation-verified** (reverting to the old scheme produces a 238-byte path and trips the tests + the length warning).
- Full suite **2964**; ruff + mypy clean; Tier 2 btrfs integration exercises the real ssh master path.