### PR TITLE
release: 0.9.3 — ship docs/ in the source tarball (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-08-16
+
 ### Fixed
 
 - **Docs are now included in the source tarball** — `docs/` was omitted from the sdist, so building

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Docs are now included in the source tarball** — `docs/` was omitted from the sdist, so building
+  from the source distribution and running the test suite failed at collection when
+  `test_docs_commands.py` read `docs/SNAPPER-INTEGRATION.md`. The docs now ship, fixing distribution
+  builds. Thanks to Michael J Gruber (@mjg) for the detailed report (#91).
+
 ## [0.9.2] - 2026-08-05
 
 The config, restoration, and SSH-reliability polish release.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,6 +13,7 @@ include README.md
 include LICENSE
 include CHANGELOG.md
 include CONTRIBUTING.md
+recursive-include docs *.md
 
 # Include config example
 include config.example.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ where = ["src"]
 
 [project]
 name = "btrfs-backup-ng"
-version = "0.9.2"
+version = "0.9.3"
 description = "Complete btrfs backup solution with automated snapshots, incremental transfers, restore functionality, snapper integration, and systemd scheduling"
 authors = [{ name = "Michael Berry", email = "trismegustis@gmail.com" }]
 license = { file = "LICENSE" }


### PR DESCRIPTION
Closes #91.

`tests/test_docs_commands.py` extracts example commands from `README.md` and `docs/SNAPPER-INTEGRATION.md` at import time, so the read happens during pytest collection and can't be skipped by test markers. `MANIFEST.in` shipped `tests/` and `README.md` but not `docs/`, so building from the sdist and running the suite failed at collection with `FileNotFoundError` on `docs/SNAPPER-INTEGRATION.md`.

Fix: add `recursive-include docs *.md` so the docs travel with the source distribution — where they belong regardless.

The wheel is unaffected: `tests/` lives at the repo root, outside `src/`, so it's never packaged into the wheel and can't run there. This is purely an sdist gap.

**Verified:** fresh `uv build --sdist`, unpacked into a clean tree — collection now succeeds and `test_docs_commands.py` passes (241). The full tier-1 suite also passes from the unpacked sdist (3002 passed, 1 skipped, 41 tier2 deselected), confirming the sdist ships everything the tests need.

Reported by @mjg (#91).