### PR TITLE
WIP: use longer timeout on full transfers

### DIFF
--- a/src/btrfs_backup_ng/endpoint/ssh.py
+++ b/src/btrfs_backup_ng/endpoint/ssh.py
@@ -3283,6 +3283,7 @@ print(json.dumps(result))
                 # We'll handle incremental logic in the actual send call
             else:
                 logger.info("Using full transfer")
+                max_wait_time = 10 * max_wait_time
         except Exception as e:
             logger.error(f"Error setting up transfer parameters: {e}")
             return False


### PR DESCRIPTION
Transfers over ssh time out after 1h by default. This can easily prevent initial full transfers, say more than 36GB over a 100Mbit/s connection.

Increase the timeout by a factor of 10 for full transfers.

WIP because there might be better options (such as an option) and other places/transfer modes which need this.