### PR TITLE
fix(restore): --list finds the prefix a location uses, as restore does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`restore --list` finds the prefix a location uses, like `restore` does** — the
+  most ordinary command there is, `restore --list <destination>` with no
+  `--prefix`, answered "No snapshots matched" for a location holding a perfectly
+  good backup, then told the operator to re-run with a prefix it had just worked
+  out for itself. It now lists them, and says which prefix it used. An explicit
+  `--prefix` is still never second-guessed, and a location holding two prefixes is
+  still reported rather than guessed between.
+
 - **Transfers are no longer limited by a wall clock at all, by default** — a
   transfer that is moving data is succeeding, and ending it because a timer expired
   confused operator policy with fault detection. Any fixed value is a guess about

--- a/src/btrfs_backup_ng/cli/restore.py
+++ b/src/btrfs_backup_ng/cli/restore.py
@@ -17,6 +17,7 @@ from ..__logger__ import create_logger
 from ..config import ConfigError, find_config_file, load_config
 from ..core.target import parse_target
 from ..core.restore import (
+    _retry_with_inferred_prefix,
     RestoreError,
     list_remote_snapshots,
     restore_snapshots,
@@ -406,6 +407,29 @@ def _execute_list(args: argparse.Namespace) -> int:
     except Exception as e:
         logger.error("Failed to list snapshots: %s", e)
         return 1
+
+    if not snapshots:
+        # Do for `--list` what `restore` already does: work out the prefix this
+        # location actually uses and show those snapshots, rather than telling
+        # the operator to re-run with an argument we just derived ourselves.
+        #
+        # The most ordinary command there is -- `restore --list <dest>` with no
+        # --prefix -- otherwise answered "No snapshots matched" for a location
+        # holding a perfectly good backup, which reads as data loss.
+        #
+        # Same primitive as the restore path, so the rules cannot diverge: it
+        # infers only when NO prefix was asked for, and refuses to choose when
+        # the location holds more than one (two prefixes usually means two
+        # volumes side by side, and listing the wrong one is worse than asking).
+        inferred = _retry_with_inferred_prefix(backup_endpoint)
+        if inferred:
+            used = backup_endpoint.config.get("snap_prefix", "") or ""
+            print(
+                f"No snapshots use the default prefix here; listing {used!r} "
+                f"instead, which is what this location uses."
+            )
+            print("")
+            snapshots = inferred
 
     if not snapshots:
         # "No snapshots found" is only honest when the location really is empty.

--- a/tests/test_restore_list_prefix_parity.py
+++ b/tests/test_restore_list_prefix_parity.py
@@ -83,6 +83,40 @@ class TestListInfersLikeRestoreDoes:
         out = capsys.readouterr().out
         assert "No snapshots use the default prefix here" in out, out
         assert "which is what this location uses" in out, out
+        # And it must name the prefix it actually used. Checking only the
+        # wording lets the message degrade to "listing '' instead", which is
+        # nonsense the operator cannot act on.
+        assert "'myvol-'" in out, out
+
+
+class TestTheContractListDependsOn:
+    """`--list` reports which prefix it used by reading the endpoint config
+    AFTER the inference, which works because `_retry_with_inferred_prefix`
+    deliberately leaves the endpoint configured with the prefix it found -- the
+    restore path needs that too, since it goes on to restore from that endpoint.
+
+    That is a real coupling between two modules, so it is pinned here rather
+    than left as something the next reader has to notice.
+    """
+
+    def test_the_helper_leaves_the_inferred_prefix_set(self):
+        from btrfs_backup_ng.core.restore import _retry_with_inferred_prefix
+
+        endpoint = _Endpoint({"myvol-": 1}, configured="")
+        found = _retry_with_inferred_prefix(endpoint)
+        assert found, "nothing was inferred, so the contract cannot be checked"
+        assert endpoint.config["snap_prefix"] == "myvol-", (
+            "the inferred prefix was not left on the endpoint; --list would "
+            "report the wrong prefix and restore would read the wrong set"
+        )
+
+    def test_it_restores_the_previous_prefix_when_nothing_is_found(self):
+        """Failing to infer must not leave the endpoint reconfigured."""
+        from btrfs_backup_ng.core.restore import _retry_with_inferred_prefix
+
+        endpoint = _Endpoint({}, configured="orig-")
+        assert _retry_with_inferred_prefix(endpoint) == []
+        assert endpoint.config["snap_prefix"] == "orig-"
 
     def test_an_explicit_prefix_is_not_second_guessed(self, capsys):
         """Asked for one set, told about another -- that is the harm the

--- a/tests/test_restore_list_prefix_parity.py
+++ b/tests/test_restore_list_prefix_parity.py
@@ -1,0 +1,111 @@
+"""`restore --list` must not make the operator do work the tool already did.
+
+`restore` infers the prefix a location actually uses and proceeds. `--list` did
+not: it printed "No snapshots matched" for a location holding a perfectly good
+backup, then told the operator to re-run with a prefix it had just derived
+itself. "No snapshots matched" reads as data loss, and the most ordinary command
+there is -- `restore --list <dest>` with no --prefix -- produced it.
+
+The two paths now share one primitive, so their rules cannot diverge:
+
+  * infer only when NO prefix was asked for -- an explicit --prefix that matches
+    nothing is a mismatch to report, never a cue to list something else;
+  * refuse to choose when a location holds more than one prefix, because that
+    usually means two volumes side by side and listing the wrong one is worse
+    than asking.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+from btrfs_backup_ng.cli.restore import _execute_list
+
+
+class _Endpoint:
+    """Stands in for an endpoint whose snapshots use a prefix."""
+
+    def __init__(self, prefixes: dict[str, int], configured: str = ""):
+        self._prefixes = prefixes
+        self.config = {"snap_prefix": configured, "path": "/dest"}
+
+    def prefixes_present(self):
+        return {
+            p: n for p, n in self._prefixes.items() if p != self.config["snap_prefix"]
+        }
+
+    def describe_empty_listing(self):
+        if self._prefixes:
+            return "This location is NOT empty: ..."
+        return None
+
+    def list_snapshots(self, flush_cache: bool = False):
+        prefix = self.config.get("snap_prefix", "")
+        out = []
+        for name, count in self._prefixes.items():
+            if name == prefix:
+                for i in range(count):
+                    snap = MagicMock()
+                    snap.get_name.return_value = f"{name}{i}"
+                    snap.time_obj = None
+                    out.append(snap)
+        return out
+
+
+def _run_list(endpoint, prefix=""):
+    import argparse
+
+    args = argparse.Namespace(source="/dest", prefix=prefix, config=None)
+    with patch(
+        "btrfs_backup_ng.cli.restore._prepare_backup_endpoint", return_value=endpoint
+    ):
+        return _execute_list(args)
+
+
+class TestListInfersLikeRestoreDoes:
+    def test_it_lists_the_prefix_the_location_uses(self, capsys):
+        endpoint = _Endpoint({"myvol-": 2}, configured="")
+        code = _run_list(endpoint)
+        out = capsys.readouterr().out
+        assert code == 0, out
+        assert "myvol-0" in out, out
+
+    def test_it_says_that_it_inferred(self, capsys):
+        """Listing a different set than was asked for must never be silent.
+
+        Asserted on the announcement itself, not on the prefix appearing
+        somewhere: the snapshot NAMES contain the prefix, so a looser check
+        passes even with the announcement deleted.
+        """
+        endpoint = _Endpoint({"myvol-": 1}, configured="")
+        _run_list(endpoint)
+        out = capsys.readouterr().out
+        assert "No snapshots use the default prefix here" in out, out
+        assert "which is what this location uses" in out, out
+
+    def test_an_explicit_prefix_is_not_second_guessed(self, capsys):
+        """Asked for one set, told about another -- that is the harm the
+        ambiguity rule exists to prevent, reached from the other side."""
+        endpoint = _Endpoint({"myvol-": 1}, configured="wrong-")
+        code = _run_list(endpoint, prefix="wrong-")
+        out = capsys.readouterr().out
+        assert code == 1, out
+        assert "NOT empty" in out
+        assert "myvol-0" not in out, "an explicit prefix was overridden"
+
+    def test_two_prefixes_are_not_guessed_between(self, capsys):
+        endpoint = _Endpoint({"myvol-": 1, "other-": 1}, configured="")
+        code = _run_list(endpoint)
+        out = capsys.readouterr().out
+        assert code == 1, out
+        assert "myvol-0" not in out and "other-0" not in out, (
+            "it picked one of two volumes to list"
+        )
+
+    def test_a_genuinely_empty_location_still_says_so(self, capsys):
+        endpoint = _Endpoint({}, configured="")
+        code = _run_list(endpoint)
+        out = capsys.readouterr().out
+        assert code == 0
+        assert "No snapshots found" in out


### PR DESCRIPTION
Finishes what 0.9.4 started. That release taught `restore` to work out the prefix a
location actually uses; `--list` never learned it.

## The experience it fixes

Back up to a destination, then run the most obvious command against it:

```
$ btrfs-backup-ng restore --list /home/backups
No snapshots matched at /home/backups.

This location is NOT empty: it holds snapshots, but none use the prefix '' ...
Re-run with --prefix 'myvol-' to list them.
```

"No snapshots matched" for a location holding a perfectly good backup — wording that
reads as data loss — followed by a request to re-run with an argument the tool had
just derived for itself.

Now:

```
$ btrfs-backup-ng restore --list /home/backups
No snapshots use the default prefix here; listing 'myvol-' instead, which is what
this location uses.

Available snapshots at /home/backups:
    1. myvol-20260821-134859                    (2026-08-21 13:48:59)
```

## Rules preserved, because both paths share one primitive

- **An explicit `--prefix` is never second-guessed.** Asked for one set and shown
  another is the same harm the ambiguity rule exists to prevent, reached from the
  other side.
- **Two prefixes are reported, not chosen between** — that usually means two volumes
  side by side, and listing the wrong one is worse than asking.
- **Inferring is announced**, never silent.

## Verification

Against a real local btrfs destination: no prefix now lists the backup; an explicit
wrong prefix still reports the mismatch; two volumes sharing the destination still
refuse to resolve.

Four mutations kill, including "delete the announcement" — which survived the first
pass because the assertion accepted a word that appears in the snapshot names, so
the test was tightened to the announcement itself.

Gate: ruff, mypy, 4022 tests.
