### PR TITLE
Persistent remote locks: protect a restore from a concurrent prune

### DIFF
--- a/README.md
+++ b/README.md
@@ -3189,6 +3189,8 @@ src/btrfs_backup_ng/
 
 - [CLI Reference](docs/CLI-REFERENCE.md) - Complete command and option reference
 - [Migrating from btrbk](docs/MIGRATING-FROM-BTRBK.md) - Guide for btrbk users
+- [Snapper Integration](docs/SNAPPER-INTEGRATION.md) - Backing up and restoring snapper snapshots
+- [Remote Locks](docs/REMOTE-LOCKS.md) - How a restore is protected from a concurrent prune
 - [Changelog](CHANGELOG.md) - Version history and release notes
 
 ### Example Configurations

--- a/docs/REMOTE-LOCKS.md
+++ b/docs/REMOTE-LOCKS.md
@@ -1,0 +1,321 @@
+# Remote Locks
+
+Locks that outlive the process that took them, so a restore reading a snapshot
+on a remote target cannot have that snapshot deleted out from under it by a
+prune running somewhere else.
+
+## The problem
+
+A restore pins the snapshot it is reading. A prune consults those pins and skips
+what is pinned. Both halves worked. They were looking at different things.
+
+The pin lived in the restoring process's memory. A prune is usually a different
+process — a cron job, a second terminal, a scheduler on another machine — and it
+lists the target fresh. Every snapshot it sees therefore has an empty lock set,
+including the one being read at that moment. The guard could not see the other
+process, so it let the delete through, and `btrfs receive` failed partway with a
+stream whose parent had vanished.
+
+`restore --status` reported this state as:
+
+```
+This target does not persist locks.
+```
+
+Accurate, and no use to anyone. A backup tool that reports it cannot protect a
+restore is not protecting the restore.
+
+## Two kinds of lock
+
+The distinction matters more than any other detail here.
+
+**A snapshot pin is shared.** It says "someone is reading this; do not delete
+it". Any number of restores and transfers may pin the same snapshot at once,
+because two reads do not conflict, and it stays pinned until the last of them
+lets go. This mirrors the in-memory contract exactly: `snapshot.locks` is a
+*set* of lock ids, and the local lock file stores it as a list.
+
+**A whole-target lock is exclusive.** It says "this target is being modified;
+wait". A prune takes it. Only one holder at a time.
+
+An early version of this made snapshot pins exclusive too. It looked correct in
+isolation and was wrong: a second restore of the same snapshot failed against
+the first, a concurrency regression the local path never had. If the two kinds
+are ever collapsed again, that is the failure to expect.
+
+## The approach
+
+The lock is recorded on the target, beside the data it protects, so any process
+that can reach the target can see it. There is no persistent connection to hold
+an `flock` on, so the mechanism is built from POSIX operations that are already
+atomic on the remote filesystem:
+
+* **`mkdir` is atomic.** Exactly one of any number of racing creators wins; the
+  rest get `EEXIST`. This is the whole mutual-exclusion primitive.
+* **`mv` is atomic within a filesystem.** This is what makes breaking a dead
+  lock safe: a contender that judges a lock stale renames it and proceeds only
+  if the rename succeeded, so two contenders that both see the same dead lock
+  cannot both go on to acquire it.
+
+Both were verified against a real remote with 20 concurrent contenders: one
+winner in each case.
+
+### Layout
+
+```
+<target>/.btrfs-backup-ng.locks/
+    target.lock/                  EXCLUSIVE: a whole-target lock
+        info.json                 holder: operation, hostname, pid, token
+        heartbeat                 mtime refreshed while the holder lives
+    snap-<name>.lock/             SHARED: a pin on one snapshot
+        holders/
+            restore_abc           one file per holder; its mtime is that
+            transfer_9            holder's own heartbeat
+```
+
+The `snap-` prefix is what separates a pin on a snapshot from a lock on the
+whole target. One constant drives it, so the writer, the delete guards and
+`restore --status` cannot drift apart.
+
+### Names on disk are encoded, identity is not
+
+A lock's directory is named `<sanitised>-<digest>`, where the digest is of the
+exact original name. The sanitised part keeps `ls` readable; the digest makes
+the mapping injective.
+
+That second half is not cosmetic. An earlier version replaced every unsafe
+character with `_` and used the result as the identity, which broke twice:
+
+* `restore:x/y` and `restore:x:y` became the same file, so one holder releasing
+  removed the other's pin and the snapshot it protected became deletable while
+  still in use.
+* The writer stored a rewritten snapshot name while the guard looked its
+  snapshots up by their real ones, so a snapshot whose name needed rewriting was
+  pinned under a name nothing would ever ask for. The pin existed and was
+  invisible.
+
+The lock's real name therefore travels inside its payload, and the directory
+name is treated as nothing more than a filesystem-safe address. Reads key off
+the payload; the guard additionally matches the exact directory name, so a lock
+whose payload cannot be parsed — the one case with no name to offer — still
+blocks.
+
+For the same reason the remote emits only names, never paths. It sent full paths
+at first, split off a space-delimited line, so a target directory containing a
+space produced a truncated path that the sweeper handed to `rm -f`: it deleted
+something unrelated, reported success, and left the real holder in place. Paths
+are rebuilt on this side from the root the manager already knows.
+
+A holder writes and removes only its own file. That is what makes the pin
+reference-counted without any counter: the snapshot is locked while any holder
+file is fresh, one holder releasing cannot drop another's pin, and the empty
+directories are tidied with `rmdir`, which fails harmlessly while anyone else is
+still there. The last one out cleans up.
+
+### Exclusive acquisition is one round trip
+
+Try `mkdir`; if it fails, judge staleness; if stale, break it with `mv` and try
+again. This is deliberately a single script rather than a sequence of calls:
+split across round trips, another contender can slip between the staleness check
+and the break, which is exactly the race the atomic rename exists to close. The
+evaluation cannot be moved to the client for the same reason.
+
+Shared pins need none of this. There is nothing to win, so acquiring one is a
+single write with no contention to resolve.
+
+### One window that had to be closed
+
+Between the `mkdir` that wins an exclusive lock and the `touch` that writes its
+first heartbeat, the heartbeat does not exist. Ageing a missing file from epoch
+zero makes that brand-new lock look infinitely old, so a contender arriving
+inside the window judged it dead, broke it, and took a lock somebody already
+held -- two winners. It surfaced as an intermittent failure of the one-winner
+test and was then reproduced exactly by creating the directory without its
+heartbeat.
+
+The age now falls back to the lock directory's own mtime, which `mkdir` sets
+atomically, so a lock taken microseconds ago cannot read as abandoned. The
+inverse still holds: a genuinely old lock is still broken.
+
+### Staleness is judged from the target's clock
+
+The holder refreshes its file every 30 seconds. Age is `remote_now -
+remote_mtime`, both read **from the target** — its own `date`, its own `stat`.
+No client clock is ever compared to a remote one.
+
+Listing emits those raw facts and does the arithmetic in Python. Conditional
+logic in a script that must behave identically under bash, dash and busybox ash
+is where this project has shipped bugs before, and listing — unlike acquisition
+— has no race to lose, so there is nothing to gain by deciding on the far side.
+A test runs the whole protocol under every POSIX shell present and requires the
+results to match.
+
+This is not hypothetical tidiness. The two machines used to develop this feature
+disagreed by four seconds. With client-side arithmetic, two hosts would reach
+different verdicts about the same lock, and the one with the fast clock would
+break locks that were alive.
+
+A lock whose heartbeat is older than 180 seconds is treated as a leftover from a
+process that died: an exclusive lock is broken by the next contender, and a
+stale holder file stops counting as a pin. A crashed restore therefore costs one
+staleness window, not a permanent outage requiring manual cleanup.
+
+Abandoned holder files are deleted only once they are past *twice* the
+threshold. A live holder refreshes six times inside one threshold, so nothing
+that far behind can still be alive — and deleting somebody's live pin is far
+worse than leaving a small file lying around.
+
+An interrupted run does not wait for any of that. Pins are released on normal
+exit and on SIGINT/SIGTERM, so Ctrl-C on a restore frees the snapshot at once.
+The signal handlers chain to whatever was installed before them rather than
+replacing it. The stale window remains the backstop for what no handler can
+catch: SIGKILL, a power cut, a severed network.
+
+## What each side does
+
+### Taking a lock
+
+`Endpoint.set_lock` records the pin in memory *and* on the target. The in-memory
+set is still maintained because the transfer and prune logic within a single run
+reads it directly, and a remote round trip per query would turn a prune into a
+conversation.
+
+If the lock **cannot** be recorded, the operation stops by default. It does not
+continue with a warning. Continuing would leave the restore running with no
+protection at all while a prune elsewhere sees nothing holding the snapshot —
+the exact failure this exists to prevent, with a log line where the protection
+should be. The error names what to grant:
+
+```
+Could not lock root.20240115T120000 on this destination: ...
+Refusing to continue unprotected: another process pruning this target would not
+see the snapshot as in use and could delete it while it is being read. Make the
+destination writable by the account running this, allow that account to elevate
+for it, or pass --skip-remote-lock to proceed unprotected on purpose.
+```
+
+### `--skip-remote-lock`
+
+One real setup is not served by that default: a destination the operator can
+read but not write. No lock can be recorded there, and none is needed, because
+nothing running as that account will be deleting from it either.
+
+`--skip-remote-lock` is how the operator says so. It relaxes exactly one thing:
+the abort above becomes a warning that states plainly that the run is
+unprotected. It does **not** stop anything from *reading* locks. Every guard
+still consults the target, so nothing begins reporting a target as unlocked
+without having looked — the false all-clear this whole mechanism exists to
+remove.
+
+A target may also carry `skip_remote_lock` in its config, for a destination
+that is permanently read-only. The flag wins when both are present.
+
+Failing to *clear* a lock is not the same risk and is only reported: the
+heartbeat stops, the lock goes stale, and the next contender breaks it.
+
+### Deleting
+
+Every remote delete path asks the target which snapshots are locked before
+deleting anything, and skips those. The answer covers locks taken by any
+process, which is the point.
+
+Three outcomes, kept distinct because they demand different responses:
+
+| Outcome | Meaning | Response |
+|---|---|---|
+| a set of locked names | the target answered | skip those, delete the rest |
+| `RemoteLockBusy` | another process holds it | wait or come back later |
+| `RemoteLockUnavailable` | the question could not be asked | delete nothing, say so |
+
+The third is the one worth dwelling on. Neither available answer would be
+honest. "Nothing is locked" prunes on an unanswered question and can delete the
+snapshot someone is restoring. "Everything is locked" silently skips every
+deletion, which is how retention stops running while the operator is told the
+prune succeeded. So it raises, and each caller turns it into the report it
+already has for a prune that could not run.
+
+### Reporting
+
+`restore --status` and `--unlock` go through `Endpoint._read_locks` and
+`_write_locks`. Remote endpoints implement both against the target, so those
+commands describe a remote target as accurately as a local one:
+
+```
+Active Locks:
+----------------------------------------
+  Restore locks (from restore operations):
+    root.20240115T120000: session abc123
+```
+
+A lock whose `info.json` cannot be parsed is still reported, with the holder
+shown as `unknown`. "Something holds this and we cannot say what" must never be
+rounded down to "nothing holds this".
+
+`--unlock` clears leftover snapshot pins. It addresses holders by the record
+they were found in rather than by lock id, so it can clear the one holder it
+cannot name — the one whose payload is unreadable. Addressed by id, that holder
+survived `--unlock all` forever and the only remedy was deleting files on the
+target by hand.
+
+It deliberately leaves whole-target locks alone: those belong to an operation
+running right now, and the command exists to clear leftovers, not to interrupt
+work in progress.
+
+## Which targets persist locks
+
+| Target | Persists | Where |
+|---|---|---|
+| local | yes | lock file beside the backups |
+| `ssh://` | yes | lock directory on the remote target |
+| `raw+ssh://` | yes | lock directory on the remote target |
+| local `raw://` | no | in memory, for the run only |
+
+`persists_locks` states this per endpoint, and a test asserts the flag cannot
+drift from what `set_lock` actually does.
+
+## Permissions
+
+Locks live beside the data they protect, so the lock directory inherits that
+directory's permissions. Backup destinations are commonly root-owned. The
+unprivileged attempt is made first; if the lock directory cannot be created, the
+same script is retried elevated.
+
+A directory that cannot be created is reported as such and never as contention.
+A bare `mkdir` failure looks exactly like losing a race, and reporting it that
+way sends an operator hunting for a competing process that does not exist.
+
+If neither attempt works, the operation stops with the message shown above
+rather than proceeding unprotected.
+
+## Tuning
+
+| Setting | Default | Meaning |
+|---|---|---|
+| heartbeat interval | 30s | how often a holder refreshes its lock |
+| stale threshold | 180s | age at which a lock is treated as abandoned |
+| sweep threshold | 360s | age at which an abandoned holder file is deleted |
+
+The threshold is six heartbeats. A holder has to miss six consecutive refreshes
+before another process will break its lock, which tolerates transient network
+trouble without leaving a dead lock in place for long.
+
+## Verification
+
+The protocol is exercised against a real filesystem rather than a mock of its
+replies — a mock would pass whatever the protocol did. Unit tests run the real
+scripts against a local sandbox; the properties below were also confirmed
+between two physical machines, with the restore on one host and the prune on
+another:
+
+* two restores pin the same snapshot at once, both recorded, both reported
+* a prune in a separate process cannot delete a snapshot a restore holds
+* the same prune *does* delete an unlocked snapshot, so the refusal is specific
+  rather than a prune that was broken
+* the prune says which snapshots it skipped and why
+* the pin survives one holder leaving and lifts only when the last one goes
+* protection lifts when the restore releases
+* a killed restore leaves a lock that the next contender breaks after the
+  staleness window, rather than locking the target out permanently
+* a third process reads the lock state correctly via `restore --status`
+* SIGINT frees a pin immediately rather than after the staleness window
+* an abandoned pin stops blocking after that window and is then swept

--- a/src/btrfs_backup_ng/cli/common.py
+++ b/src/btrfs_backup_ng/cli/common.py
@@ -170,6 +170,31 @@ def add_ssh_hostkey_arg(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def add_remote_lock_arg(parser: argparse.ArgumentParser) -> None:
+    """Add ``--skip-remote-lock`` to a parser that touches a remote target.
+
+    Locking is the default and a target that cannot record a lock stops the
+    operation, because continuing would run it unprotected while a prune
+    elsewhere is free to delete what is being read.
+
+    That default is wrong for one real setup: a destination the operator can
+    read but not write, where no lock can be recorded and none is needed
+    because nothing here will be deleting either. This flag is how that
+    operator says so explicitly. It is deliberately not a config-file default
+    for a whole site -- the risk is per-run and should be visible in the
+    command that takes it.
+
+    ``default=None`` so an unset flag never overrides a target's own setting.
+    """
+    parser.add_argument(
+        "--skip-remote-lock",
+        action="store_true",
+        default=None,
+        help="Proceed even if a lock cannot be recorded on the remote target. "
+        "Only safe when nothing else can prune this target during the run.",
+    )
+
+
 def get_fs_checks_mode(args: argparse.Namespace) -> str:
     """Get the filesystem checks mode from parsed arguments.
 
@@ -268,6 +293,7 @@ def thread_ssh_target_config(kwargs: dict, target) -> None:
     """
     kwargs["port"] = getattr(target, "ssh_port", 22)
     kwargs["ssh_sudo"] = getattr(target, "ssh_sudo", False)
+    kwargs["skip_remote_lock"] = getattr(target, "skip_remote_lock", False)
     kwargs["ssh_host_key_policy"] = getattr(target, "ssh_host_key_policy", "accept-new")
     kwargs["ssh_password_fallback"] = getattr(target, "ssh_password_auth", True)
     ssh_key = getattr(target, "ssh_key", None)

--- a/src/btrfs_backup_ng/cli/dispatcher.py
+++ b/src/btrfs_backup_ng/cli/dispatcher.py
@@ -13,6 +13,7 @@ from ..__logger__ import logger
 from .common import (
     add_fs_checks_args,
     add_progress_args,
+    add_remote_lock_arg,
     add_ssh_hostkey_arg,
     add_verbosity_args,
 )
@@ -770,6 +771,7 @@ Config-driven restore:
     )
     add_fs_checks_args(restore_parser)
     add_ssh_hostkey_arg(restore_parser)
+    add_remote_lock_arg(restore_parser)
 
     # Config-driven restore options
     config_group = restore_parser.add_argument_group(
@@ -932,6 +934,7 @@ Examples:
     )
     add_fs_checks_args(verify_parser)
     add_ssh_hostkey_arg(verify_parser)
+    add_remote_lock_arg(verify_parser)
     verify_parser.add_argument(
         "--json",
         action="store_true",
@@ -1085,6 +1088,7 @@ Examples:
     )
     add_fs_checks_args(estimate_parser)
     add_ssh_hostkey_arg(estimate_parser)
+    add_remote_lock_arg(estimate_parser)
     estimate_parser.add_argument(
         "--json",
         action="store_true",
@@ -1430,6 +1434,7 @@ Examples:
         help="Explicit ssh-agent socket (overrides auto-discovery; useful under sudo)",
     )
     add_ssh_hostkey_arg(snapper_backup)
+    add_remote_lock_arg(snapper_backup)
     snapper_backup.add_argument(
         "--compress",
         metavar="METHOD",
@@ -1582,6 +1587,7 @@ Examples:
         "does not record one (modern sidecars are authoritative)",
     )
     add_ssh_hostkey_arg(snapper_restore)
+    add_remote_lock_arg(snapper_restore)
     snapper_restore.add_argument(
         "-l",
         "--list",

--- a/src/btrfs_backup_ng/cli/restore.py
+++ b/src/btrfs_backup_ng/cli/restore.py
@@ -513,6 +513,7 @@ def _configured_target_options(args: argparse.Namespace, source: str) -> dict:
                 "ssh_auth_sock",
                 "ssh_host_key_policy",
                 "ssh_password_auth",
+                "skip_remote_lock",
                 "gpg_keyring",
                 "openssl_cipher",
             ):
@@ -592,6 +593,12 @@ def _prepare_backup_endpoint(args: argparse.Namespace, source: str):
         )
         if _hkp:
             endpoint_kwargs["ssh_host_key_policy"] = _hkp
+        # --skip-remote-lock is per-run and the flag wins; a target may also
+        # carry it for a destination that can never be written.
+        if getattr(args, "skip_remote_lock", None) or configured.get(
+            "skip_remote_lock"
+        ):
+            endpoint_kwargs["skip_remote_lock"] = True
         # There is no --ssh-password-auth flag, so the args lookup is a constant
         # True unless a caller sets the attribute directly; reading only it meant
         # a configured `ssh_password_auth = false` had no effect on a restore at
@@ -824,16 +831,21 @@ def _execute_status(args: argparse.Namespace) -> int:
     print("=" * 60)
     print()
 
-    # Endpoints whose set_lock is in-memory only never write a lock file, so
-    # there is nothing here to inspect. Reporting "no active locks" would be
-    # technically true and actively misleading: it reads as "we looked, and the
-    # target is clean" when nothing was ever recorded to look at.
+    # Endpoints whose set_lock is in-memory only never record a lock, so there is
+    # nothing here to inspect. Reporting "no active locks" would be technically
+    # true and actively misleading: it reads as "we looked, and the target is
+    # clean" when nothing was ever recorded to look at. Remote endpoints do
+    # record locks now and implement _read_locks against them, so they take the
+    # ordinary path below rather than this one.
     if not backup_endpoint.persists_locks:
         print("This target does not persist locks.")
         print()
-        print("Locks on ssh://, raw:// and raw+ssh:// targets are held in memory for")
-        print("the duration of a single run, so no lock file is written. An")
-        print("interrupted run leaves nothing behind here to inspect or unlock.")
+        print("Locks on a local raw:// target are held in memory for the duration of")
+        print("a single run, so nothing is written here. An interrupted run leaves")
+        print("nothing behind to inspect or unlock.")
+        print()
+        print("ssh:// and raw+ssh:// targets DO persist locks, on the target itself,")
+        print("and report them here.")
         return 0
 
     # Read through the endpoint rather than rebuilding the path here. The
@@ -939,9 +951,8 @@ def _execute_unlock(args: argparse.Namespace, lock_id: str) -> int:
     if not backup_endpoint.persists_locks:
         print("This target does not persist locks, so there is nothing to unlock.")
         print()
-        print("Locks on ssh://, raw:// and raw+ssh:// targets are held in memory for")
-        print("the duration of a single run, so no lock file is written. An")
-        print("interrupted run leaves nothing behind here to inspect or unlock.")
+        print("Locks on a local raw:// target are held in memory for the duration of")
+        print("a single run, so an interrupted run leaves nothing behind to clear.")
         return 0
 
     # Same endpoint API as --status, for the same reason.

--- a/src/btrfs_backup_ng/cli/verify.py
+++ b/src/btrfs_backup_ng/cli/verify.py
@@ -47,6 +47,8 @@ def execute(args: argparse.Namespace) -> int:
     # Host-key policy override (R12b): threaded for any remote; harmless (ignored) for local.
     if getattr(args, "ssh_host_key_policy", None):
         endpoint_kwargs["ssh_host_key_policy"] = args.ssh_host_key_policy
+    if getattr(args, "skip_remote_lock", None):
+        endpoint_kwargs["skip_remote_lock"] = True
 
     # SSH / raw options
     if args.location.startswith("ssh://"):

--- a/src/btrfs_backup_ng/config/schema.py
+++ b/src/btrfs_backup_ng/config/schema.py
@@ -132,6 +132,12 @@ class TargetConfig:
         ssh_auth_sock: Explicit ssh-agent socket path (overrides auto-discovery; useful
             under sudo where SSH_AUTH_SOCK is stripped and the key is passphrase-protected)
         ssh_password_auth: Allow password authentication fallback
+        skip_remote_lock: Proceed even when a lock cannot be recorded on this
+            target. For a destination that can be read but not written, where no
+            lock can be taken and none is needed because nothing running as this
+            account will delete from it either. It relaxes only that failure --
+            locks are still READ, so nothing reports the target as unlocked
+            without having looked.
         compress: Compression algorithm for transfers (none, gzip, zstd, lz4)
         rate_limit: Bandwidth limit for transfers (e.g., "10M", "1G", "500K")
         require_mount: Require path to be an active mount point (safety check for external drives)
@@ -147,6 +153,7 @@ class TargetConfig:
     ssh_key: Optional[str] = None
     ssh_auth_sock: Optional[str] = None
     ssh_password_auth: bool = True
+    skip_remote_lock: bool = False
     # Host-key verification policy: "accept-new" (default; trust-on-first-use, reject a
     # changed key) or "strict" (known_hosts-only, reject an unknown host). R12b.
     ssh_host_key_policy: str = "accept-new"

--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -20,6 +20,7 @@ import os
 import re
 import shlex
 import shutil
+import socket
 import subprocess
 import time
 from collections.abc import Iterator
@@ -1577,7 +1578,8 @@ class RawEndpoint(Endpoint):
         return list(snapshots)
 
     #: Declared beside the override that makes it true, so the two cannot drift.
-    #: SSHRawEndpoint inherits this, which is correct: it does not persist either.
+    #: Local raw keeps its in-memory lock set; SSHRawEndpoint overrides this to
+    #: True because it now writes a real lock on the remote target.
     persists_locks: bool = False
 
     def set_lock(
@@ -1841,14 +1843,186 @@ class SSHRawEndpoint(RawEndpoint):
         )
         return f"raw+ssh://{user_host}{self.config['path']}"
 
+    #: raw+ssh writes its snapshot locks on the remote target, so they survive
+    #: the process and are visible to any other process or machine touching that
+    #: target. Local raw keeps the in-memory set (see RawEndpoint).
+    persists_locks: bool = True
+
+    def _read_locks(self) -> dict:
+        """The locks recorded ON THIS TARGET, in the lock-file shape.
+
+        ``restore --status`` and ``--unlock`` go through this. Overriding it here
+        is what makes those commands tell the truth about a remote target rather
+        than announcing that it does not persist locks.
+        """
+        from ..sshutil.lock import read_persisted_locks
+
+        if self._lock_target_path() is None:
+            return {}
+        return read_persisted_locks(self._lock_manager())
+
+    def _write_locks(self, lock_dict: dict) -> None:
+        """Reconcile this target's locks to ``lock_dict`` (``restore --unlock``)."""
+        from ..sshutil.lock import write_persisted_locks
+
+        if self._lock_target_path() is None:
+            return
+        write_persisted_locks(self._lock_manager(), lock_dict)
+
+    def set_lock(
+        self,
+        snapshot: Any,
+        lock_id: Any,
+        lock_state: bool,
+        parent: bool = False,
+    ) -> None:
+        """Pin or unpin a snapshot ON THE REMOTE, not just in this process.
+
+        A restore reads a snapshot here while a prune, in another process or on
+        another machine, may be deleting from this same target. An in-memory
+        pin is invisible to that prune, so it was free to delete what was being
+        read. The lock is now a directory on the target itself.
+
+        The in-memory set is still maintained, because the transfer and prune
+        logic within this run reads it directly and a remote round trip per
+        query would be gratuitous.
+        """
+        super().set_lock(snapshot, lock_id, lock_state, parent=parent)
+        from ..sshutil.lock import snapshot_lock_name
+
+        name = f"snap-{snapshot_lock_name(snapshot)}"
+        manager = self._lock_manager()
+        try:
+            # SHARED, not exclusive: the in-memory contract is a SET of lock ids,
+            # so any number of restores and transfers may pin one stream at once
+            # and it stays pinned until the last lets go. Each holder writes and
+            # removes only its own file, which is why releasing here cannot drop
+            # somebody else's pin -- and why a parent pin is keyed apart from a
+            # direct one.
+            holder_id = f"p:{lock_id}" if parent else str(lock_id)
+            if lock_state:
+                if not manager.holds_shared(name, holder_id):
+                    manager.acquire_shared_persistent(name, holder_id, str(lock_id))
+            else:
+                manager.release_shared(name, holder_id)
+        except Exception as exc:  # noqa: BLE001 - see below
+            if lock_state and not self.config.get("skip_remote_lock"):
+                # A lock that could not be written must never read as one that
+                # was. Continuing with a warning leaves the operation running
+                # unprotected while a prune on this target sees nothing holding
+                # the stream and is free to delete it mid-read -- the exact
+                # failure this lock exists to prevent, with a log line in place
+                # of the protection. So it stops, and says what to grant.
+                #
+                # --skip-remote-lock is the operator overriding that, for a
+                # destination they can read but not write. It relaxes only THIS:
+                # the pin is still consulted everywhere it is read, so nothing
+                # starts reporting a target as unlocked without having looked.
+                raise __util__.AbortError(
+                    f"Could not lock {snapshot_lock_name(snapshot)} on this "
+                    f"target: {exc}. Refusing to continue unprotected: another "
+                    f"process pruning this target would not see the stream as in "
+                    f"use and could delete it while it is being read. Make the "
+                    f"target writable by the account running this, allow that "
+                    f"account to elevate for it, or pass --skip-remote-lock to "
+                    f"proceed unprotected on purpose."
+                ) from exc
+            # Either the operator opted out with --skip-remote-lock, or this is
+            # a release. A release failing is not the same risk: the heartbeat
+            # stops, the pin goes stale, and it is swept.
+            if lock_state:
+                logger.warning(
+                    "Could not record the lock for %s on this target (%s), and "
+                    "--skip-remote-lock was given, so this continues WITHOUT "
+                    "protection: a prune elsewhere will not see it as in use.",
+                    snapshot_lock_name(snapshot),
+                    exc,
+                )
+            else:
+                logger.warning(
+                    "Could not clear the lock for %s on this target (%s). It will "
+                    "expire on its own once its heartbeat stops.",
+                    snapshot_lock_name(snapshot),
+                    exc,
+                )
+
+    def _lock_target_path(self) -> str | None:
+        """The remote directory locks live in, or None if this target has none.
+
+        The one resolution shared by the writer (``set_lock``) and the reader
+        (the delete guard). They must agree: if this returns None the writer
+        cannot record a lock, so the reader finding nothing is a proven-empty
+        answer rather than a check that silently did not run.
+        """
+        path = self.config.get("path")
+        if path in (None, ""):
+            return None
+        return str(path)
+
+    def _lock_manager(self) -> Any:
+        """The lock manager for this target, one per resolved path.
+
+        See ``sshutil.lock.cached_manager`` for why it is shared rather than
+        rebuilt per call, and why the cache is keyed by path.
+        """
+        from ..sshutil.lock import cached_manager
+
+        return cached_manager(
+            self, self._lock_target_path() or "", self._build_lock_manager
+        )
+
+    def _build_lock_manager(self) -> Any:
+        """A lock manager bound to this target, elevating as this target does.
+
+        Built per call rather than cached: the endpoint's config (path, sudo)
+        can be rewritten between operations, and a manager holding a stale path
+        would lock somewhere other than where the work is happening.
+        """
+        from ..sshutil.lock import RemoteLockManager
+
+        def run(script: str) -> tuple[int, str, str]:
+            # The endpoint quotes each element and applies its own elevation, so
+            # the script must NOT be pre-elevated here -- doing both wraps it in
+            # sudo twice.
+            result = self._exec_remote_command(["sh", "-c", script], check=False)
+            out, err = result.stdout or b"", result.stderr or b""
+            if isinstance(out, bytes):
+                out = out.decode("utf-8", errors="replace")
+            if isinstance(err, bytes):
+                err = err.decode("utf-8", errors="replace")
+            return result.returncode, out, err
+
+        path = self._lock_target_path()
+        if path is None:
+            raise ValueError("raw+ssh target has no path; cannot lock")
+
+        def run_elevated(script: str) -> tuple[int, str, str]:
+            # Only reached when the unprivileged attempt could not create the
+            # lock directory -- a root-owned destination, the common case.
+            return run(self._elevate(f"sh -c {shlex.quote(script)}"))
+
+        return RemoteLockManager(
+            run,
+            path,
+            hostname=socket.gethostname(),
+            run_elevated=run_elevated,
+        )
+
     @contextlib.contextmanager
     def target_lock(self, *, timeout: float | None = None) -> Iterator[None]:
-        """No-op for raw+ssh. A per-target lock over ssh needs a remote lockfile with
-        stale-detection (there is no persistent connection to hold an flock), which is
-        a separate change; concurrent-operation protection is currently local-only. Run
-        maintenance commands against a raw+ssh target when it is otherwise idle. The
-        raw maintenance CLI warns the operator of this at the point of use."""
-        yield
+        """Hold an exclusive lock on this remote target for a MUTATING operation.
+
+        This used to be a no-op, on the grounds that a per-target lock over ssh
+        needs a remote lockfile with stale detection and there is no persistent
+        connection on which to hold an flock. Both halves were true; the
+        conclusion was not. `sshutil.lock` provides exactly that lockfile, so
+        raw+ssh now gets the same mutual exclusion local raw targets have always
+        had -- across processes AND across machines, which the local flock never
+        offered.
+        """
+        manager = self._lock_manager()
+        with manager.hold("target", "mutating operation"):
+            yield
 
     def _build_ssh_command(self) -> list[str]:
         """Build the base SSH command.
@@ -2697,6 +2871,33 @@ class SSHRawEndpoint(RawEndpoint):
         remote deletion for a raw+ssh target. Inheriting the base ``delete_snapshots``
         keeps the (no-op) lock discipline uniform across local and remote. The same
         chain guard as the local primitive applies (never orphan a child stream)."""
+        # Locks recorded ON THE TARGET, not just this process's in-memory set: a
+        # prune in another process lists the target fresh, so every snapshot it
+        # sees looks unlocked -- including one a restore is reading right now.
+        from ..sshutil.lock import (
+            RemoteLockUnavailable,
+            blocked_by_remote_lock,
+            snapshot_lock_name,
+        )
+
+        remote_locked: set[str] = set()
+        if self._lock_target_path() is not None:
+            try:
+                remote_locked = blocked_by_remote_lock(
+                    self._lock_manager(), list(snapshots)
+                )
+            except RemoteLockUnavailable as exc:
+                # Same contract as a refused delete below: retention did not run,
+                # and it says so rather than finishing "successfully" having
+                # removed nothing while the target quietly fills up.
+                raise __util__.AbortError(f"Retention did NOT run: {exc}.") from exc
+        if remote_locked:
+            logger.info(
+                "Skipping %d stream(s) locked by another process on this target: %s",
+                len(remote_locked),
+                ", ".join(sorted(remote_locked)),
+            )
+
         protected = self._chain_referenced_parents(snapshots, delete_session)
         ssh_cmd = self._build_ssh_command()
 
@@ -2708,6 +2909,8 @@ class SSHRawEndpoint(RawEndpoint):
                     "unrestorable. Skipping.",
                     snapshot.get_name(),
                 )
+                continue
+            if snapshot_lock_name(snapshot) in remote_locked:
                 continue
             try:
                 # Build rm command for stream and metadata

--- a/src/btrfs_backup_ng/endpoint/ssh.py
+++ b/src/btrfs_backup_ng/endpoint/ssh.py
@@ -336,6 +336,7 @@ class SSHEndpoint(Endpoint):
             "ssh_auth_sock",
             "ssh_password_fallback",
             "ssh_host_key_policy",
+            "skip_remote_lock",
             "transfer_stall_timeout",
         ):
             if config.get(_ssh_key) is not None:
@@ -639,12 +640,51 @@ class SSHEndpoint(Endpoint):
         return f"(SSH) {username}@{self.hostname}:{self.config['path']}"
 
     def delete_snapshots(self, snapshots: List[Any], **kwargs: Any) -> None:
-        """Delete the given snapshots (subvolumes) on the remote host via SSH."""
+        """Delete the given snapshots (subvolumes) on the remote host via SSH.
+
+        Consults the locks recorded ON THE TARGET as well as the in-memory ones.
+        A prune running in another process (or on another machine) lists this
+        destination fresh, so every snapshot it sees has an empty in-memory lock
+        set -- including one a restore is reading at that moment. The guard
+        existed; it simply could not see the other process.
+        """
+        from ..sshutil.lock import (
+            RemoteLockUnavailable,
+            blocked_by_remote_lock,
+            snapshot_lock_name,
+        )
+
+        remote_locked: set[str] = set()
+        if self._lock_target_path() is not None:
+            try:
+                remote_locked = blocked_by_remote_lock(
+                    self._lock_manager(), list(snapshots)
+                )
+            except RemoteLockUnavailable as exc:
+                # Deleting without knowing risks removing what a restore is
+                # reading, so nothing is deleted -- said plainly, because a
+                # deletion pass that quietly removes nothing reads as success.
+                logger.error(
+                    "Not deleting anything on this destination: %s. Nothing was "
+                    "removed; resolve the error above and run this again.",
+                    exc,
+                )
+                return
+        if remote_locked:
+            logger.info(
+                "Skipping %d snapshot(s) locked by another process on this "
+                "destination: %s",
+                len(remote_locked),
+                ", ".join(sorted(remote_locked)),
+            )
+
         for snapshot in snapshots:
             if hasattr(snapshot, "locks") and (
                 snapshot.locks or getattr(snapshot, "parent_locks", False)
             ):
                 logger.info("Skipping locked snapshot: %s", snapshot)
+                continue
+            if snapshot_lock_name(snapshot) in remote_locked:
                 continue
 
             # Handle remote path normalization properly
@@ -757,8 +797,104 @@ class SSHEndpoint(Endpoint):
             logger.info("Deleting old remote snapshot: %s", str(snap))
             self.delete_snapshots([snap])
 
-    #: Declared beside the override that makes it true, so the two cannot drift.
-    persists_locks: bool = False
+    #: ssh:// writes its snapshot locks on the remote destination, so they
+    #: survive the process and are visible to any other process or machine
+    #: touching that destination.
+    persists_locks: bool = True
+
+    def _lock_target_path(self) -> str | None:
+        """The remote directory locks live in, or None if this endpoint has none.
+
+        The one resolution shared by the writer (``set_lock``) and the reader
+        (the delete guard). They must agree: if this returns None the writer
+        cannot record a lock, so the reader finding nothing is a proven-empty
+        answer rather than a check that silently did not run.
+        """
+        path = self.config.get("path")
+        if path in (None, ""):
+            return None
+        return str(path)
+
+    def _lock_manager(self) -> Any:
+        """The lock manager for this destination, one per resolved path.
+
+        See ``sshutil.lock.cached_manager`` for why it is shared rather than
+        rebuilt per call, and why the cache is keyed by path.
+        """
+        from ..sshutil.lock import cached_manager
+
+        return cached_manager(
+            self, self._lock_target_path() or "", self._build_lock_manager
+        )
+
+    def _build_lock_manager(self) -> Any:
+        """A lock manager bound to this destination, elevating as it does."""
+        import socket as _socket
+
+        from ..sshutil.lock import RemoteLockManager
+
+        path = self._lock_target_path()
+        if path is None:
+            raise ValueError("ssh endpoint has no target path; cannot lock")
+
+        def run(script: str) -> tuple[int, str, str]:
+            # PIPE explicitly: unlike the raw endpoint's, this _exec_remote_command
+            # does NOT capture by default. Without this the script's verdict goes
+            # to the terminal, the manager reads empty output, and every
+            # acquisition reports BUSY -- so no lock is ever taken. Only a real
+            # remote showed this; a test runner always hands back captured text.
+            result = self._exec_remote_command(
+                ["sh", "-c", script],
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            if result.stdout is None:
+                raise RuntimeError(
+                    "the remote lock command returned no captured output; its "
+                    "verdict cannot be read, so no lock state can be trusted"
+                )
+            out, err = result.stdout or b"", result.stderr or b""
+            if isinstance(out, bytes):
+                out = out.decode("utf-8", errors="replace")
+            if isinstance(err, bytes):
+                err = err.decode("utf-8", errors="replace")
+            return result.returncode, out, err
+
+        def run_elevated(script: str) -> tuple[int, str, str]:
+            # _build_remote_command deliberately elevates btrfs and nothing else,
+            # so the elevation is applied here rather than by widening that rule.
+            # Only reached when the unprivileged attempt could not create the lock
+            # directory -- a root-owned destination, which is the common case.
+            return run(f"sudo -n sh -c {shlex.quote(script)}")
+
+        return RemoteLockManager(
+            run,
+            path,
+            hostname=_socket.gethostname(),
+            run_elevated=run_elevated,
+        )
+
+    def _read_locks(self) -> dict:
+        """The locks recorded ON THIS TARGET, in the lock-file shape.
+
+        ``restore --status`` and ``--unlock`` go through this. Overriding it here
+        is what makes those commands tell the truth about a remote target rather
+        than announcing that it does not persist locks.
+        """
+        from ..sshutil.lock import read_persisted_locks
+
+        if self._lock_target_path() is None:
+            return {}
+        return read_persisted_locks(self._lock_manager())
+
+    def _write_locks(self, lock_dict: dict) -> None:
+        """Reconcile this target's locks to ``lock_dict`` (``restore --unlock``)."""
+        from ..sshutil.lock import write_persisted_locks
+
+        if self._lock_target_path() is None:
+            return
+        write_persisted_locks(self._lock_manager(), lock_dict)
 
     def set_lock(
         self,
@@ -767,20 +903,87 @@ class SSHEndpoint(Endpoint):
         lock_state: bool,
         parent: bool = False,
     ) -> None:
-        """Update the in-memory retention lock on a remote snapshot.
+        """Pin or unpin a snapshot, in memory AND on the remote destination.
 
-        Overrides the base Endpoint.set_lock, which writes a LOCAL lock file at
-        ``config['path']``. For an ssh endpoint that path is on the REMOTE host, so
-        the base write opens a nonexistent local path and raises -- which aborted a
-        restore FROM an ssh:// source at the lock step. Restore only needs the lock
-        held in memory for the duration of the transfer; persisting ssh locks across
-        runs is a separate change (audit root R3). Mirrors RawEndpoint.set_lock.
+        The base Endpoint.set_lock writes a LOCAL lock file at ``config['path']``.
+        For an ssh endpoint that path is on the REMOTE host, so the base write
+        opens a nonexistent local path and raises -- which aborted a restore FROM
+        an ssh:// source at the lock step. Hence this override, and hence NOT
+        calling super().
+
+        It used to stop there, holding the pin in memory only, with "persisting
+        ssh locks across runs is a separate change (audit root R3)" written where
+        this sentence now is. That is the change. An in-memory pin is invisible
+        to a prune running in another process or on another machine, which was
+        therefore free to delete the very snapshot a restore was reading.
+
+        The in-memory set is still maintained: the transfer and prune logic in
+        this run reads it directly, and a remote round trip per query would be
+        gratuitous.
         """
         target = snapshot.parent_locks if parent else snapshot.locks
         if lock_state:
             target.add(lock_id)
         else:
             target.discard(lock_id)
+
+        from ..sshutil.lock import snapshot_lock_name
+
+        name = f"snap-{snapshot_lock_name(snapshot)}"
+        try:
+            manager = self._lock_manager()
+            # SHARED, not exclusive: the in-memory contract is a SET of lock ids,
+            # so any number of restores and transfers may pin one snapshot at
+            # once and it stays pinned until the last lets go. Each holder writes
+            # and removes only its own file, which is why releasing here cannot
+            # drop somebody else's pin -- and why a parent pin is keyed apart from
+            # a direct one.
+            holder_id = f"p:{lock_id}" if parent else str(lock_id)
+            if lock_state:
+                if not manager.holds_shared(name, holder_id):
+                    manager.acquire_shared_persistent(name, holder_id, str(lock_id))
+            else:
+                manager.release_shared(name, holder_id)
+        except Exception as exc:  # noqa: BLE001 - reported, never silently passed
+            if lock_state and not self.config.get("skip_remote_lock"):
+                # A lock that could not be written must never read as one that
+                # was. Continuing with a warning leaves the operation running
+                # unprotected while a prune on this target sees nothing holding
+                # the snapshot and is free to delete it mid-read -- the exact
+                # failure this lock exists to prevent, with a log line in place
+                # of the protection. So it stops, and says what to grant.
+                #
+                # --skip-remote-lock is the operator overriding that, for a
+                # destination they can read but not write. It relaxes only THIS:
+                # the pin is still consulted everywhere it is read, so nothing
+                # starts reporting a target as unlocked without having looked.
+                raise __util__.AbortError(
+                    f"Could not lock {snapshot_lock_name(snapshot)} on this "
+                    f"destination: {exc}. Refusing to continue unprotected: "
+                    f"another process pruning this target would not see the "
+                    f"snapshot as in use and could delete it while it is being "
+                    f"read. Make the destination writable by the account running "
+                    f"this, allow that account to elevate for it, or pass "
+                    f"--skip-remote-lock to proceed unprotected on purpose."
+                ) from exc
+            # Either the operator opted out with --skip-remote-lock, or this is
+            # a release. A release failing is not the same risk: the heartbeat
+            # stops, the pin goes stale, and it is swept.
+            if lock_state:
+                logger.warning(
+                    "Could not record the lock for %s on this destination (%s), and "
+                    "--skip-remote-lock was given, so this continues WITHOUT "
+                    "protection: a prune elsewhere will not see it as in use.",
+                    snapshot_lock_name(snapshot),
+                    exc,
+                )
+            else:
+                logger.warning(
+                    "Could not clear the lock for %s on this destination (%s). It will "
+                    "expire on its own once its heartbeat stops.",
+                    snapshot_lock_name(snapshot),
+                    exc,
+                )
 
     def send(
         self, snapshot: Any, parent: Any = None, clones: Optional[List[Any]] = None

--- a/src/btrfs_backup_ng/sshutil/lock.py
+++ b/src/btrfs_backup_ng/sshutil/lock.py
@@ -1,0 +1,988 @@
+"""Persistent locks on a remote target, held across processes and machines.
+
+A restore reads a snapshot on a remote target while a prune, in a different
+process or on a different machine, may be deleting from that same target. Before
+this, the lock guarding the snapshot under restore lived in the restoring
+process's memory, so the pruning process could not see it and was free to delete
+what was being read.
+
+Saying "this target does not persist locks", as `restore --status` used to, is
+honest and useless: a backup tool that reports it cannot protect a restore is not
+protecting the restore.
+
+The primitives
+--------------
+Everything is done with POSIX operations on the target, because there is no
+persistent connection on which to hold an ``flock``:
+
+* **``mkdir`` is atomic.** Exactly one of any number of racing creators wins;
+  the rest get EEXIST. Verified against a real remote: 20 concurrent contenders,
+  one winner.
+* **``mv`` is atomic within a filesystem**, which is what makes breaking a stale
+  lock safe. A contender that judges a lock dead renames it and proceeds only if
+  the rename succeeded, so two contenders that both see a dead lock cannot both
+  acquire. Also verified: 20 concurrent breakers, one winner.
+
+Staleness is judged ON THE REMOTE
+---------------------------------
+The holder ``touch``es a heartbeat file; a contender computes
+``remote_now - remote_mtime`` on the target itself. Client clocks are never
+compared. This is not hypothetical tidiness: the two hosts used to develop this
+already differ by several seconds, and two unrelated clients can differ by far
+more. A client with a fast clock would break live locks; one with a slow clock
+would honour dead ones forever.
+
+Cleanup never uses ``rm -rf``
+-----------------------------
+These commands run under sudo on a machine we are only visiting. Files are
+removed by name and the directory is then ``rmdir``ed, which fails harmlessly if
+anything unexpected is inside. A mis-constructed path can therefore delete
+nothing but the lock it created.
+"""
+
+from __future__ import annotations
+
+import atexit
+import hashlib
+import json
+import logging
+import os
+import signal
+import shlex
+import threading
+import uuid
+from contextlib import contextmanager
+from pathlib import PurePosixPath
+from typing import Any, Callable, Iterator, Optional
+
+logger = logging.getLogger(__name__)
+
+#: How often the holder refreshes its heartbeat, in seconds.
+#:
+#: Every refresh is an ssh round trip, so this is a balance rather than a
+#: preference: 15s would be 240 round trips an hour per target for no extra
+#: safety, since the stale threshold is what actually bounds recovery.
+DEFAULT_HEARTBEAT_INTERVAL = 30
+
+#: How long a heartbeat may go unrefreshed before the lock is considered dead.
+#:
+#: Six missed refreshes. Generous on purpose: a lock broken too eagerly is two
+#: writers on one target, which is the exact outcome this exists to prevent,
+#: while a lock broken too late only delays an operation.
+DEFAULT_STALE_AFTER = 180
+
+#: Name of the directory holding all locks for a target.
+LOCK_DIR_NAME = ".btrfs-backup-ng.locks"
+
+#: Prefix marking a lock as a pin on one snapshot, as opposed to a whole-target
+#: or transfer lock. The writer, the delete guards and ``restore --status`` all
+#: key off this one constant so they cannot drift apart.
+SNAPSHOT_LOCK_PREFIX = "snap-"
+
+#: Holder files for a SHARED lock live here, one per holder.
+HOLDERS_DIR_NAME = "holders"
+
+#: A holder file older than this multiple of the stale threshold is not merely
+#: unrefreshed, it is definitively abandoned: a live holder refreshes six times
+#: within one threshold. Only then is it safe to delete someone else's file.
+DEAD_HOLDER_MULTIPLE = 2
+
+
+# --------------------------------------------------------------- cleanup
+#
+# A lock outlives the process that took it -- that is the whole point -- so an
+# interrupted run must not leave its pins sitting on the target until the stale
+# window expires. Ctrl-C on a restore should free the snapshot immediately, not
+# in three minutes.
+#
+# Registered holders are released on normal exit (atexit) and on SIGINT/SIGTERM.
+# The stale window remains the backstop for what neither can catch: SIGKILL,
+# a power cut, a severed network.
+
+_CLEANUP_LOCK = threading.Lock()
+_CLEANUP_REGISTRY: "list[tuple[Any, str]]" = []
+_SIGNALS_INSTALLED = False
+_PREVIOUS_HANDLERS: dict = {}
+
+
+def _register_for_cleanup(manager: Any, key: str) -> None:
+    global _SIGNALS_INSTALLED
+    with _CLEANUP_LOCK:
+        _CLEANUP_REGISTRY.append((manager, key))
+        if not _SIGNALS_INSTALLED:
+            _SIGNALS_INSTALLED = True
+            atexit.register(_release_all_held)
+            _install_signal_handlers()
+
+
+def _unregister_for_cleanup(manager: Any, key: str) -> None:
+    with _CLEANUP_LOCK:
+        for i, (held_manager, held_key) in enumerate(_CLEANUP_REGISTRY):
+            if held_manager is manager and held_key == key:
+                del _CLEANUP_REGISTRY[i]
+                return
+
+
+def _release_all_held() -> None:
+    """Drop every pin this process still holds. Never raises."""
+    with _CLEANUP_LOCK:
+        pending = list(_CLEANUP_REGISTRY)
+        _CLEANUP_REGISTRY.clear()
+    for manager, key in pending:
+        try:
+            name, _, lock_id = key.partition("\x00")
+            if lock_id:
+                manager.release_shared(name, lock_id)
+            else:
+                manager.release(name)
+        except Exception as exc:  # noqa: BLE001 - cleanup must not raise on exit
+            logger.debug("Could not release %r during cleanup: %s", key, exc)
+
+
+def _install_signal_handlers() -> None:
+    """Release on SIGINT/SIGTERM, then do what the previous handler would.
+
+    Chained rather than replaced: this is a library, and swallowing the
+    application's own handler -- or the default that turns Ctrl-C into
+    KeyboardInterrupt -- would be a worse bug than the one being fixed.
+    Installing is skipped off the main thread, where signal() is not allowed.
+    """
+    if threading.current_thread() is not threading.main_thread():
+        return
+    for signum in (signal.SIGINT, signal.SIGTERM):
+        try:
+            previous = signal.getsignal(signum)
+        except (ValueError, OSError):  # pragma: no cover - platform dependent
+            continue
+        _PREVIOUS_HANDLERS[signum] = previous
+
+        def handler(sig: int, frame: Any, _previous: Any = previous) -> None:
+            _release_all_held()
+            if callable(_previous):
+                _previous(sig, frame)
+            elif _previous == signal.SIG_DFL:
+                signal.signal(sig, signal.SIG_DFL)
+                os.kill(os.getpid(), sig)
+
+        try:
+            signal.signal(signum, handler)
+        except (ValueError, OSError):  # pragma: no cover - platform dependent
+            continue
+
+
+class RemoteLockBusy(RuntimeError):
+    """Raised when a live lock is held by someone else.
+
+    Carries the holder's recorded details so the caller can say WHO holds it and
+    since when, rather than only that it failed.
+    """
+
+    def __init__(self, name: str, info: Optional[dict] = None):
+        self.name = name
+        self.info = info or {}
+        holder = ""
+        if self.info:
+            holder = (
+                f" held by {self.info.get('operation', 'an operation')} on "
+                f"{self.info.get('hostname', 'another host')} "
+                f"(pid {self.info.get('pid', '?')})"
+            )
+        super().__init__(f"remote lock {name!r} is busy{holder}")
+
+
+class RemoteLockUnavailable(RuntimeError):
+    """The lock could not be operated at all -- not contention, but breakage.
+
+    Kept distinct from RemoteLockBusy because the two demand different answers:
+    contention means wait or refuse, while an unusable lock directory means the
+    target is not in a state anyone should be writing to.
+    """
+
+
+#: Characters that may appear in a lock's on-disk name unchanged.
+_SAFE_NAME_CHARS = "-_.@"
+
+
+def encode_name(name: str) -> str:
+    """The on-disk name for a lock called ``name``.
+
+    Filesystem-safe AND injective. The safety was there before; the injectivity
+    was not, and its absence was a hole rather than an inconvenience:
+
+    * Every unsafe character mapped to ``_``, so ``restore:x/y`` and
+      ``restore:x:y`` became one file. One holder releasing removed the other's
+      pin, and the snapshot it protected became deletable while still in use.
+    * The guard looked its snapshots up by their REAL names while the writer had
+      stored a rewritten one, so a snapshot whose name needed rewriting was
+      pinned under a name nothing would ever ask for. The pin existed and was
+      invisible -- a prune would delete it mid-restore.
+
+    A digest of the exact original is appended, so two different names cannot
+    share a file no matter what characters they contain. The readable part is
+    kept in front because an operator reading `ls` on a lock directory should
+    still recognise what is locked.
+    """
+    safe = "".join(c if c.isalnum() or c in _SAFE_NAME_CHARS else "_" for c in name)
+    digest = hashlib.sha256(name.encode("utf-8", errors="surrogatepass")).hexdigest()
+    return f"{safe}-{digest[:16]}"
+
+
+def decode_name_for_display(encoded: str) -> str:
+    """Best-effort readable form of an encoded lock name.
+
+    Only used where the lock's payload could not be read, so its real name is
+    genuinely unknown and the encoded directory name is the only handle. The
+    digest is stripped so an operator sees something recognisable rather than a
+    hex suffix. It is a DISPLAY aid: nothing matches on the result, because the
+    encoding is one-way and a name that had unsafe characters cannot be
+    recovered exactly.
+    """
+    head, sep, tail = encoded.rpartition("-")
+    if sep and len(tail) == 16 and all(c in "0123456789abcdef" for c in tail):
+        return head
+    return encoded
+
+
+class Holder:
+    """One live holder of a lock, and where its record lives.
+
+    The file name is carried rather than recomputed because ``--unlock`` has to
+    be able to remove a holder whose payload cannot be parsed -- exactly the
+    holder it cannot name. Reconstructing the path from a name it does not know
+    is impossible; deleting the file it was found in is not.
+    """
+
+    __slots__ = ("dir_name", "file_name", "info")
+
+    def __init__(self, dir_name: str, file_name: str, info: dict) -> None:
+        self.dir_name = dir_name
+        self.file_name = file_name
+        self.info = info
+
+    @property
+    def lock_id(self) -> Optional[str]:
+        value = self.info.get("lock_id")
+        return None if value is None else str(value)
+
+    def __repr__(self) -> str:  # pragma: no cover - diagnostics only
+        return f"Holder({self.dir_name!r}, {self.file_name!r}, {self.info!r})"
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Holder):
+            return NotImplemented
+        return (self.dir_name, self.file_name, self.info) == (
+            other.dir_name,
+            other.file_name,
+            other.info,
+        )
+
+
+def _remote_mtime_expr(path: str) -> str:
+    """Shell yielding ``path``'s mtime, or nothing if it does not exist.
+
+    GNU ``stat -c %Y`` with a BSD ``stat -f %m`` fallback, matching how the rest
+    of the codebase probes remote files -- targets are not all Linux.
+    """
+    q = shlex.quote(path)
+    return f"stat -c %Y {q} 2>/dev/null || stat -f %m {q} 2>/dev/null"
+
+
+def _remote_age_expr(path: str, fallback: Optional[str] = None) -> str:
+    """Shell computing the age in seconds of ``path``, on the remote.
+
+    ``fallback`` is a second path to age from when the first does not exist yet.
+    It closes a real race in acquisition: between the ``mkdir`` that wins a lock
+    and the ``touch`` that writes its first heartbeat there is a window in which
+    the heartbeat is absent. Ageing a missing file from epoch zero makes that
+    brand-new lock look infinitely old, and a contender arriving inside the
+    window breaks it and takes a lock somebody else already holds -- two winners.
+    Observed as an intermittent failure of the one-winner test, then reproduced
+    exactly by creating the directory without its heartbeat.
+
+    The lock directory itself is the fallback: ``mkdir`` creates it atomically,
+    so its mtime is a sound lower bound on the holder's age.
+    """
+    primary = _remote_mtime_expr(path)
+    if fallback is not None:
+        primary = f"{primary} || {_remote_mtime_expr(fallback)}"
+    return f"$(( $(date +%s) - $({primary} || echo 0) ))"
+
+
+class RemoteLockManager:
+    """Acquire, hold and release locks on a remote target.
+
+    ``run_remote`` takes a single shell command string and returns
+    ``(returncode, stdout, stderr)``. It is injected rather than taking an
+    endpoint because the two remote endpoints expose different call signatures,
+    and because it lets the elevation decision stay where it belongs -- with the
+    endpoint that knows whether this target needs sudo.
+    """
+
+    def __init__(
+        self,
+        run_remote: Callable[[str], tuple[int, str, str]],
+        target_path: str,
+        *,
+        heartbeat_interval: int = DEFAULT_HEARTBEAT_INTERVAL,
+        stale_after: int = DEFAULT_STALE_AFTER,
+        hostname: str = "",
+        run_elevated: Optional[Callable[[str], tuple[int, str, str]]] = None,
+    ) -> None:
+        """``run_elevated`` is used only when the unprivileged attempt cannot
+        create the lock directory. Backup destinations are commonly root-owned,
+        and the lock has to live beside the data it protects."""
+        self._run = run_remote
+        self._root = f"{str(target_path).rstrip('/')}/{LOCK_DIR_NAME}"
+        self._heartbeat_interval = heartbeat_interval
+        self._stale_after = stale_after
+        self._hostname = hostname
+        self._run_elevated = run_elevated
+        self._held: dict[str, threading.Event] = {}
+        self._threads: dict[str, threading.Thread] = {}
+
+    # ---------------------------------------------------------------- helpers
+
+    def _lock_dir(self, name: str) -> str:
+        return f"{self._root}/{encode_name(name)}.lock"
+
+    def _acquire_script(self, name: str, payload: str, token: str) -> str:
+        """One round trip: try, judge staleness, break if dead, try again.
+
+        Written as a single script deliberately. Split across calls, another
+        contender can slip between the staleness check and the break, which is
+        precisely the race the atomic rename exists to close.
+        """
+        lock = shlex.quote(self._lock_dir(name))
+        root = shlex.quote(self._root)
+        hb = shlex.quote(f"{self._lock_dir(name)}/heartbeat")
+        info = shlex.quote(f"{self._lock_dir(name)}/info.json")
+        stale_dir = shlex.quote(f"{self._lock_dir(name)}.stale.{token}")
+        age = _remote_age_expr(
+            f"{self._lock_dir(name)}/heartbeat", self._lock_dir(name)
+        )
+        return (
+            # A lock directory that cannot be created is NOT contention. Reported
+            # as BUSY -- which is what a bare mkdir failure looks like -- it sends
+            # an operator hunting for a competing process that does not exist.
+            f"mkdir -p {root} 2>/dev/null; "
+            f"if [ ! -d {root} ] || [ ! -w {root} ]; then echo NOLOCKDIR; exit 0; fi; "
+            f"if mkdir {lock} 2>/dev/null; then "
+            f"  printf '%s' {shlex.quote(payload)} > {info}; touch {hb}; echo ACQUIRED; "
+            f"else "
+            f"  AGE={age}; "
+            f'  if [ "$AGE" -gt {self._stale_after} ]; then '
+            f"    if mv {lock} {stale_dir} 2>/dev/null; then "
+            f"      rm -f {stale_dir}/info.json {stale_dir}/heartbeat 2>/dev/null; "
+            f"      rmdir {stale_dir} 2>/dev/null; "
+            f"      if mkdir {lock} 2>/dev/null; then "
+            f"        printf '%s' {shlex.quote(payload)} > {info}; touch {hb}; "
+            f"        echo ACQUIRED_STALE; "
+            f"      else echo BUSY; fi; "
+            f"    else echo BUSY; fi; "
+            f"  else "
+            # `|| true` because a lock taken microseconds ago may not have its
+            # info.json yet, and cat's failure would otherwise make the script
+            # exit non-zero -- read as "the lock could not be operated" when the
+            # truthful answer is the BUSY it just printed.
+            f"    echo BUSY; cat {info} 2>/dev/null || true; "
+            f"  fi; "
+            f"fi"
+        )
+
+    # ------------------------------------------------------------------- API
+
+    # ------------------------------------------------------- shared (pins)
+    #
+    # A snapshot pin is SHARED, not exclusive. The in-memory contract it mirrors
+    # is ``snapshot.locks``, a SET of lock ids: any number of restores and
+    # transfers may pin the same snapshot at once, and it stays pinned until the
+    # last of them lets go. Two reads of one snapshot do not conflict, so making
+    # the remote pin exclusive would have made a second restore of the same
+    # snapshot fail against the first -- a concurrency regression the local path
+    # never had.
+    #
+    # So each holder writes its OWN file under ``<name>.lock/holders/``. No
+    # exclusion is needed or wanted; the file's mtime is that holder's heartbeat,
+    # and the snapshot counts as locked while ANY holder file is fresh. What the
+    # pin blocks is deletion -- see blocked_by_remote_lock -- not other readers.
+
+    def _holders_dir(self, name: str) -> str:
+        return f"{self._lock_dir(name)}/{HOLDERS_DIR_NAME}"
+
+    def _holder_file(self, name: str, lock_id: str) -> str:
+        return f"{self._holders_dir(name)}/{encode_name(str(lock_id))}"
+
+    def acquire_shared(self, name: str, lock_id: str, operation: str = "") -> str:
+        """Add this holder's pin to ``name``. Never blocks on another holder."""
+        import os
+
+        payload = json.dumps(
+            {
+                # The lock's REAL name, because the directory holding it carries
+                # an encoded one. Identity lives here; the filename is only a
+                # filesystem-safe address for it.
+                "name": name,
+                "lock_id": str(lock_id),
+                "operation": operation or str(lock_id),
+                "hostname": self._hostname or "unknown",
+                "pid": os.getpid(),
+                "shared": True,
+            }
+        )
+        root = shlex.quote(self._root)
+        holders = shlex.quote(self._holders_dir(name))
+        holder = shlex.quote(self._holder_file(name, lock_id))
+        script = (
+            f"mkdir -p {holders} 2>/dev/null; "
+            # Reported distinctly from contention: a bare mkdir failure looks
+            # exactly like losing a race, and sends an operator hunting for a
+            # competing process that does not exist.
+            f"if [ ! -d {root} ] || [ ! -d {holders} ] || [ ! -w {holders} ]; then "
+            f"  echo NOLOCKDIR; exit 0; fi; "
+            f"printf '%s' {shlex.quote(payload)} > {holder} 2>/dev/null "
+            f"&& echo ACQUIRED || echo FAILED"
+        )
+        rc, out, err = self._run(script)
+        if "NOLOCKDIR" in out and self._run_elevated is not None:
+            rc, out, err = self._run_elevated(script)
+        if "NOLOCKDIR" in out:
+            raise RemoteLockUnavailable(
+                f"the lock directory {self._root!r} on the target could not be "
+                f"created or written to. Locks live beside the backups they "
+                f"protect, so this path must be writable by the account running "
+                f"the backup, or that account must be able to elevate for it."
+            )
+        if "ACQUIRED" not in out:
+            raise RemoteLockUnavailable(
+                f"could not record a shared lock on {name!r}: "
+                f"{err.strip() or out.strip() or f'exit {rc}'}"
+            )
+        return "acquired"
+
+    def release_shared(self, name: str, lock_id: str) -> None:
+        """Drop THIS holder's pin. Others keep theirs.
+
+        The empty directories are tidied with rmdir, which fails harmlessly while
+        another holder's file is still there -- so the last one out cleans up and
+        nobody else can remove a pin that is still held.
+        """
+        self._stop_heartbeat(self._held_key(name, lock_id))
+        holder = shlex.quote(self._holder_file(name, lock_id))
+        holders = shlex.quote(self._holders_dir(name))
+        lock = shlex.quote(self._lock_dir(name))
+        rc, _out, err = self._run(
+            f"rm -f {holder} 2>/dev/null; "
+            f"rmdir {holders} 2>/dev/null; rmdir {lock} 2>/dev/null; exit 0"
+        )
+        if rc != 0:
+            logger.warning(
+                "Could not fully release the shared lock %r on the target: %s",
+                name,
+                err.strip(),
+            )
+
+    def acquire_shared_persistent(
+        self, name: str, lock_id: str, operation: str = ""
+    ) -> str:
+        """Pin ``name`` and keep the pin alive until ``release_shared``."""
+        mode = self.acquire_shared(name, lock_id, operation)
+        self._start_heartbeat(
+            self._held_key(name, lock_id), self._holder_file(name, lock_id)
+        )
+        return mode
+
+    @staticmethod
+    def _held_key(name: str, lock_id: str) -> str:
+        return f"{name}\x00{lock_id}"
+
+    def holds_shared(self, name: str, lock_id: str) -> bool:
+        """Whether THIS manager already holds that pin."""
+        return self._held_key(name, lock_id) in self._held
+
+    # ---------------------------------------------------- exclusive (target)
+
+    def acquire_once(self, name: str, operation: str) -> str:
+        """Take the lock, or raise. Returns the acquisition mode."""
+        import os
+
+        token = uuid.uuid4().hex[:12]
+        payload = json.dumps(
+            {
+                "name": name,
+                "lock_id": name,
+                "operation": operation,
+                "hostname": self._hostname or "unknown",
+                "pid": os.getpid(),
+                "token": token,
+            }
+        )
+        script = self._acquire_script(name, payload, token)
+        rc, out, err = self._run(script)
+        if "NOLOCKDIR" in out and self._run_elevated is not None:
+            # Backup destinations are usually root-owned, so the unprivileged
+            # attempt failing is the ordinary case rather than an error.
+            rc, out, err = self._run_elevated(script)
+        if "NOLOCKDIR" in out:
+            raise RemoteLockUnavailable(
+                f"the lock directory {self._root!r} on the target could not be "
+                f"created or written to. Locks live beside the backups they "
+                f"protect, so this path must be writable by the account running "
+                f"the backup, or that account must be able to elevate for it."
+            )
+        if rc != 0 and "ACQUIRED" not in out:
+            raise RemoteLockUnavailable(
+                f"could not operate the lock directory on the target: {err.strip() or rc}"
+            )
+        if "ACQUIRED_STALE" in out:
+            logger.warning(
+                "Broke a stale lock %r on the target: its heartbeat was older than "
+                "%ds, so the process holding it is gone.",
+                name,
+                self._stale_after,
+            )
+            return "stale-broken"
+        if "ACQUIRED" in out:
+            return "acquired"
+
+        info = None
+        for line in out.splitlines():
+            line = line.strip()
+            if line.startswith("{"):
+                try:
+                    info = json.loads(line)
+                except ValueError:
+                    info = None
+        raise RemoteLockBusy(name, info)
+
+    def release(self, name: str) -> None:
+        """Remove the lock. Named files only -- never a recursive delete."""
+        self._stop_heartbeat(name)
+        lock = shlex.quote(self._lock_dir(name))
+        info = shlex.quote(f"{self._lock_dir(name)}/info.json")
+        hb = shlex.quote(f"{self._lock_dir(name)}/heartbeat")
+        # rmdir, not rm -rf: if anything unexpected is inside, this fails and
+        # leaves it alone rather than deleting whatever it happens to find.
+        rc, _out, err = self._run(
+            f"rm -f {info} {hb} 2>/dev/null; rmdir {lock} 2>/dev/null; exit 0"
+        )
+        if rc != 0:
+            logger.warning(
+                "Could not fully release remote lock %r: %s", name, err.strip()
+            )
+
+    def is_locked(self, name: str) -> Optional[dict]:
+        """The holder's details if a LIVE lock exists, else None.
+
+        A lock whose heartbeat has gone stale reports as not held: it is a
+        leftover, and treating it as live would block every future operation on
+        the target until someone cleaned up by hand.
+        """
+        info = shlex.quote(f"{self._lock_dir(name)}/info.json")
+        age = _remote_age_expr(f"{self._lock_dir(name)}/heartbeat")
+        script = (
+            f"if [ -d {shlex.quote(self._lock_dir(name))} ]; then "
+            f'  AGE={age}; if [ "$AGE" -le {self._stale_after} ]; then '
+            f"    cat {info} 2>/dev/null; fi; "
+            f"fi"
+        )
+        _rc, out, _err = self._run(script)
+        for line in out.splitlines():
+            line = line.strip()
+            if line.startswith("{"):
+                try:
+                    return json.loads(line)
+                except ValueError:
+                    return {}
+        return None
+
+    def live_locks(self) -> dict[str, list[Holder]]:
+        """Every lock on this target with a live holder, mapped to its holders.
+
+        One round trip for the whole target: a prune asks about every snapshot it
+        is about to delete, and a query each would turn a prune into a
+        conversation.
+
+        The remote emits RAW FACTS -- its own clock, each holder's mtime, each
+        holder's payload -- and the staleness arithmetic happens here. Two
+        reasons. Conditional logic in a script that has to run identically under
+        bash, dash and busybox ash is where this project has shipped bugs before;
+        and unlike acquisition, listing has no race to lose, so there is nothing
+        to gain by deciding on the far side.
+
+        The clock is still entirely the target's: both `now` and each mtime come
+        from it, and no client time is ever compared against them.
+
+        A holder whose payload cannot be parsed is still reported, with an empty
+        dict. "Something holds this and we cannot say what" must never be rounded
+        down to "nothing holds this".
+        """
+        live, _dead = self._scan_holders()
+        return live
+
+    def live_lock_names(self) -> set[str]:
+        """Names of locks with at least one live holder."""
+        return set(self.live_locks())
+
+    def _scan_holders(self) -> tuple[dict[str, list[Holder]], list[tuple[str, str]]]:
+        """(live locks by real name, (dir, file) of abandoned holder records).
+
+        The remote emits NAMES, never paths. Paths are rebuilt here from the root
+        this manager already knows. A path was emitted at first, and split off a
+        space-delimited line -- so a target directory containing a space produced
+        a truncated path, which the sweeper then passed to ``rm -f``. It deleted
+        something unrelated, reported success, and left the real holder in place.
+        The remote knows nothing this side cannot reconstruct, so it sends the
+        two encoded names, which contain no spaces by construction.
+        """
+        root = shlex.quote(self._root)
+        holders_dir = HOLDERS_DIR_NAME
+        script = (
+            f'printf "NOW %s\\n" "$(date +%s)"; '
+            f"for d in {root}/*.lock; do "
+            f'  [ -d "$d" ] || continue; '
+            f'  n=$(basename "$d" .lock); '
+            f'  if [ -d "$d/{holders_dir}" ]; then '
+            f'    for h in "$d"/{holders_dir}/*; do '
+            f'      [ -f "$h" ] || continue; '
+            f'      m=$(stat -c %Y "$h" 2>/dev/null '
+            f'|| stat -f %m "$h" 2>/dev/null || echo 0); '
+            f'      printf "H %s %s %s " "$n" "$m" "$(basename "$h")"; '
+            f'      cat "$h" 2>/dev/null; printf "\\n"; '
+            f"    done; "
+            f"  else "
+            f'    m=$(stat -c %Y "$d/heartbeat" 2>/dev/null '
+            f'|| stat -f %m "$d/heartbeat" 2>/dev/null '
+            f'|| stat -c %Y "$d" 2>/dev/null '
+            f'|| stat -f %m "$d" 2>/dev/null || echo 0); '
+            f'    printf "X %s %s - "  "$n" "$m"; '
+            f'    cat "$d/info.json" 2>/dev/null; printf "\\n"; '
+            f"  fi; "
+            f"done 2>/dev/null; exit 0"
+        )
+        rc, out, err = self._run(script)
+        if rc != 0:
+            # The script ends in `exit 0`, so a non-zero status means the shell
+            # never ran it -- the host is unreachable, or the lock directory is
+            # not readable. Empty output then means "could not ask", and
+            # returning nothing would report that as "nothing is locked": a
+            # failed check read as a clean result, which is exactly what lets a
+            # prune delete the snapshot a restore is reading.
+            raise RemoteLockUnavailable(
+                f"could not list locks on the target: {err.strip() or f'exit {rc}'}"
+            )
+
+        now: Optional[int] = None
+        live: dict[str, list[Holder]] = {}
+        dead: list[tuple[str, str]] = []
+        for line in out.splitlines():
+            if line.startswith("NOW "):
+                try:
+                    now = int(line[4:].strip())
+                except ValueError:
+                    now = None
+                continue
+            if not line or line[0] not in ("H", "X") or now is None:
+                continue
+            parts = line.split(" ", 4)
+            if len(parts) < 4:
+                continue
+            kind, dir_name, mtime_raw, file_name = parts[:4]
+            raw = parts[4] if len(parts) > 4 else ""
+            try:
+                age = now - int(mtime_raw)
+            except ValueError:
+                continue
+            if age > self._stale_after:
+                if kind == "H" and age > self._stale_after * DEAD_HOLDER_MULTIPLE:
+                    dead.append((dir_name, file_name))
+                continue
+            try:
+                info = json.loads(raw.strip()) if raw.strip() else {}
+            except ValueError:
+                info = {}
+            if not isinstance(info, dict):
+                info = {}
+            # Keyed by the lock's REAL name, which travels in the payload. The
+            # directory name is an encoding of it and cannot be decoded back, so
+            # keying by that would mean the guard -- which asks using real names
+            # -- never matched a snapshot whose name had to be encoded. Where the
+            # payload is unreadable the encoded name is all there is; the guard
+            # checks for both, so such a lock still blocks.
+            key = str(info.get("name") or decode_name_for_display(dir_name))
+            live.setdefault(key, []).append(Holder(dir_name, file_name, info))
+        return live, dead
+
+    def sweep_dead_holders(self) -> int:
+        """Remove holder records far past the point of any doubt.
+
+        A pin whose holder died leaves its record behind. Listing already ignores
+        it, so nothing is blocked, but it would otherwise sit there forever. Only
+        records older than DEAD_HOLDER_MULTIPLE times the stale threshold are
+        touched: a live holder refreshes six times inside one threshold, so this
+        cannot remove a pin that is still held.
+        """
+        _live, dead = self._scan_holders()
+        if not dead:
+            return 0
+        paths = [
+            shlex.quote(f"{self._root}/{dir_name}.lock/{HOLDERS_DIR_NAME}/{file_name}")
+            for dir_name, file_name in dead
+        ]
+        self._run(f"rm -f {' '.join(paths)} 2>/dev/null; exit 0")
+        logger.debug("Swept %d abandoned holder record(s) on the target", len(dead))
+        return len(dead)
+
+    def release_holder(self, holder: Holder) -> None:
+        """Drop a holder by the record it was found in.
+
+        ``--unlock`` must be able to clear a holder whose payload is unreadable,
+        which is precisely the one it cannot name. Addressing the record instead
+        of recomputing a path from a lock id makes that possible.
+        """
+        base = f"{self._root}/{holder.dir_name}.lock"
+        record = shlex.quote(f"{base}/{HOLDERS_DIR_NAME}/{holder.file_name}")
+        holders = shlex.quote(f"{base}/{HOLDERS_DIR_NAME}")
+        lock = shlex.quote(base)
+        if holder.lock_id is not None:
+            name = str(holder.info.get("name") or "")
+            if name:
+                self._stop_heartbeat(self._held_key(name, holder.lock_id))
+        self._run(
+            f"rm -f {record} 2>/dev/null; "
+            f"rmdir {holders} 2>/dev/null; rmdir {lock} 2>/dev/null; exit 0"
+        )
+
+    # ------------------------------------------------------------- heartbeat
+
+    def _start_heartbeat(self, key: str, path: Optional[str] = None) -> None:
+        """Refresh ``path``'s mtime until stopped. ``key`` identifies the holder.
+
+        For an exclusive lock the refreshed file is the lock's ``heartbeat``; for
+        a shared pin it is that holder's own file, so holders of the same
+        snapshot keep their pins alive independently.
+        """
+        stop = threading.Event()
+        target = path if path is not None else f"{self._lock_dir(key)}/heartbeat"
+        hb = shlex.quote(target)
+
+        def beat() -> None:
+            while not stop.wait(self._heartbeat_interval):
+                try:
+                    self._run(f"touch {hb} 2>/dev/null; exit 0")
+                except Exception as exc:  # noqa: BLE001 - a missed beat is not fatal
+                    # One failed refresh must not end a transfer. Several in a
+                    # row let the lock go stale, which is the designed outcome
+                    # for a holder that can no longer reach the target.
+                    logger.debug("Heartbeat for %r failed: %s", key, exc)
+
+        thread = threading.Thread(target=beat, name="lock-hb", daemon=True)
+        self._held[key] = stop
+        self._threads[key] = thread
+        _register_for_cleanup(self, key)
+        thread.start()
+
+    def _stop_heartbeat(self, key: str) -> None:
+        stop = self._held.pop(key, None)
+        thread = self._threads.pop(key, None)
+        _unregister_for_cleanup(self, key)
+        if stop is not None:
+            stop.set()
+        if thread is not None:
+            thread.join(timeout=5)
+
+    def acquire_persistent(self, name: str, operation: str) -> str:
+        """Take a lock and keep it alive until ``release``, without a with-block.
+
+        ``set_lock`` marks a snapshot pinned at the start of an operation and
+        unpins it at the end, which may be hours and several call frames apart --
+        so the scoped ``hold`` does not fit. The heartbeat still runs, because a
+        lock that stops being refreshed is exactly how a crashed holder stops
+        blocking everyone else.
+        """
+        mode = self.acquire_once(name, operation)
+        self._start_heartbeat(name)
+        return mode
+
+    def holds(self, name: str) -> bool:
+        """Whether THIS manager is the one holding ``name``."""
+        return name in self._held
+
+    @contextmanager
+    def hold(self, name: str, operation: str) -> Iterator[str]:
+        """Hold the lock for the duration of the block, refreshing it throughout."""
+        mode = self.acquire_once(name, operation)
+        self._start_heartbeat(name)
+        try:
+            yield mode
+        finally:
+            self.release(name)
+
+
+def read_persisted_locks(manager: Any) -> dict[str, dict]:
+    """The lock-file shape, rebuilt from the locks recorded on the target.
+
+    ``restore --status`` and ``--unlock`` read through ``Endpoint._read_locks``.
+    Giving remote endpoints a real implementation of it is what lets those
+    commands report a remote target truthfully, instead of the standing
+    "this target does not persist locks" they used to print -- which was honest
+    and useless: a backup tool that reports it cannot protect a restore is not
+    protecting the restore.
+
+    Every holder is listed, matching the local file's list of lock ids. A holder
+    whose payload could not be parsed appears as ``unknown``: "something holds
+    this and we cannot say what" must never be rounded down to "nothing".
+    """
+    locks: dict[str, dict] = {}
+    for name, holders in manager.live_locks().items():
+        if not name.startswith(SNAPSHOT_LOCK_PREFIX):
+            continue
+        snapshot = name[len(SNAPSHOT_LOCK_PREFIX) :]
+        entry = locks.setdefault(snapshot, {})
+        for holder in holders:
+            lock_id = holder.lock_id
+            key = "parent_locks" if str(lock_id or "").startswith("p:") else "locks"
+            entry.setdefault(key, []).append(
+                lock_id.removeprefix("p:") if lock_id else "unknown"
+            )
+    return locks
+
+
+def write_persisted_locks(manager: Any, lock_dict: dict[str, Any]) -> None:
+    """Reconcile the target's snapshot pins to ``lock_dict``.
+
+    The caller (``restore --unlock``) computes the state it wants and writes it
+    whole, matching the local lock-file contract. Here that means dropping every
+    holder the new state no longer lists -- per holder, not per snapshot, so
+    clearing one session's lock leaves another session's pin on the same
+    snapshot intact.
+
+    Holders are dropped by the record they were found in, so a holder whose
+    payload cannot be parsed -- reported as ``unknown``, and therefore impossible
+    to name -- can still be cleared. It could not be, when the release was
+    addressed by lock id: ``--unlock all`` left it in place forever and the only
+    remedy was deleting files on the target by hand.
+
+    Locks that are not snapshot pins -- the whole-target lock a prune holds, for
+    instance -- are left alone: they belong to a running operation, and --unlock
+    exists to clear leftovers, not to interrupt work in progress.
+    """
+    for name, holders in manager.live_locks().items():
+        if not name.startswith(SNAPSHOT_LOCK_PREFIX):
+            continue
+        snapshot = name[len(SNAPSHOT_LOCK_PREFIX) :]
+        entry = lock_dict.get(snapshot) or {}
+        keep = {str(x) for x in entry.get("locks", [])}
+        keep |= {f"p:{x}" for x in entry.get("parent_locks", [])}
+        for holder in holders:
+            if holder.lock_id is None or holder.lock_id not in keep:
+                manager.release_holder(holder)
+    manager.sweep_dead_holders()
+
+
+_MANAGER_CACHE_LOCK = threading.Lock()
+
+
+def cached_manager(endpoint: Any, path_key: str, build: Callable[[], Any]) -> Any:
+    """The one manager an endpoint uses for a given target path.
+
+    Shared rather than rebuilt per call for two reasons, both of which were real
+    bugs when it was not:
+
+    * ``holds()`` is per instance. With a fresh manager each time, a second lock
+      on the same snapshot -- pinned directly AND as an incremental parent --
+      did not recognise this process's own lock and reported the target busy
+      against itself.
+    * The heartbeat thread belongs to the manager that started it. A release
+      through a different instance could not stop it, leaking a thread that went
+      on refreshing a lock nobody held.
+
+    Keyed by path rather than cached outright because an endpoint's config can be
+    rewritten between operations, and a manager holding a stale path would lock
+    somewhere other than where the work is happening. Guarded by a lock because
+    transfers run threaded, and two threads racing here would produce exactly the
+    duplicate managers this exists to prevent.
+    """
+    with _MANAGER_CACHE_LOCK:
+        cache = getattr(endpoint, "_lock_manager_cache", None)
+        if cache is None:
+            cache = {}
+            endpoint._lock_manager_cache = cache
+        manager = cache.get(path_key)
+        if manager is None:
+            manager = build()
+            cache[path_key] = manager
+        return manager
+
+
+def snapshot_lock_name(snapshot: Any) -> str:
+    """The identity a snapshot is locked under, on the target.
+
+    The ONE derivation, shared by the writer (each endpoint's ``set_lock``) and
+    the readers (``blocked_by_remote_lock`` and the delete guards). If the two
+    ever disagreed, a lock would be written under one key and looked up under
+    another -- a guard that reports "not locked" for a snapshot that is, which
+    is precisely the failure this module exists to remove.
+
+    Falls back through the shapes ``delete_snapshots`` is actually called with
+    (snapshot objects, path-like objects, plain strings) so that identification
+    itself never fails. Failing to IDENTIFY and failing to ASK are different:
+    the latter is what fails closed.
+    """
+    for attr in ("get_name", "get_path"):
+        getter = getattr(snapshot, attr, None)
+        if callable(getter):
+            try:
+                value = getter()
+            except Exception:  # noqa: BLE001 - fall through to the next shape
+                continue
+            if value:
+                return (
+                    PurePosixPath(str(value)).name if attr == "get_path" else str(value)
+                )
+    name = getattr(snapshot, "name", None)
+    if name:
+        return str(name)
+    return PurePosixPath(str(snapshot)).name
+
+
+def blocked_by_remote_lock(manager: Any, snapshots: list) -> set[str]:
+    """Names of ``snapshots`` a live remote lock says must not be deleted.
+
+    The in-memory lock set cannot answer this. A prune running in another
+    process lists the target fresh, so every snapshot it sees has an empty
+    in-memory lock set -- including the one a restore is reading right now.
+    That is the whole defect: the guard existed, it just could not see the
+    other process.
+
+    A failure to ASK raises ``RemoteLockUnavailable`` rather than answering.
+    Neither available answer would be honest: "nothing is locked" prunes on an
+    unanswered question and can delete the snapshot someone is restoring, and
+    "everything is locked" silently skips every deletion, which is how retention
+    stops running while the operator is told the prune succeeded. The caller
+    decides -- a prune turns it into the abort it already reports for a refused
+    delete; a caller that can proceed without pruning catches it and says so.
+    """
+    names = {snapshot_lock_name(s) for s in snapshots}
+    if not names:
+        return set()
+    try:
+        live = manager.live_locks()
+    except Exception as exc:  # noqa: BLE001 - see docstring: the caller decides
+        raise RemoteLockUnavailable(
+            f"the lock state on this target could not be read ({exc}), so it is "
+            f"not known whether a restore is holding any of these snapshots"
+        ) from exc
+    # Matched on the real name AND on the encoded directory each lock actually
+    # lives in. A lock whose payload cannot be parsed has no real name to offer,
+    # and its listed key is then only a best-effort readable form -- which will
+    # not equal the real name if that name needed encoding. The directory name is
+    # exact in every case, so it is the one that must decide. Without it, an
+    # unreadable pin on an awkwardly-named snapshot was invisible, and invisible
+    # means deletable while a restore is reading it.
+    directories = {holder.dir_name for holders in live.values() for holder in holders}
+    return {
+        n
+        for n in names
+        if f"{SNAPSHOT_LOCK_PREFIX}{n}" in live
+        or encode_name(f"{SNAPSHOT_LOCK_PREFIX}{n}") in directories
+    }

--- a/tests/lockshell.py
+++ b/tests/lockshell.py
@@ -1,0 +1,69 @@
+"""Answer the remote-lock protocol for tests that fake an ssh transport.
+
+``sshutil.lock`` works by running POSIX shell on the target: ``mkdir`` to take a
+lock, ``stat`` to judge a heartbeat, ``mv`` to break a dead one. A test that
+patches ``subprocess.run`` to return a canned object gives those scripts no
+answer, and the manager -- correctly -- refuses to believe it holds a lock it
+could not confirm. Every such test then looks like a locking bug.
+
+The fix is not to fake the protocol's output, which would pass whatever the
+protocol did. It is to run the real scripts, locally, against a sandbox
+directory standing in for the remote target.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from btrfs_backup_ng.sshutil.lock import LOCK_DIR_NAME
+
+#: Captured at import, before any test patches ``subprocess.run``. These tests
+#: patch it globally, so calling the module attribute here would re-enter the
+#: test's own fake -- which recurses until the interpreter stops it, and reports
+#: as a lock failure rather than as the harness bug it is.
+_real_run = subprocess.run
+
+
+class _Result:
+    def __init__(self, returncode: int, stdout: bytes, stderr: bytes) -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def is_lock_script(cmd) -> bool:
+    """Whether this remote command is part of the lock protocol."""
+    return LOCK_DIR_NAME in " ".join(str(c) for c in cmd)
+
+
+def run_lock_script(cmd, sandbox: Path, remote_root: str = "/backup") -> _Result:
+    """Execute the lock script in ``cmd`` against ``sandbox``.
+
+    The script is the last element of an ssh argv. Remote absolute paths are
+    remapped onto the sandbox so the real scripts can run unmodified.
+    """
+    script = str(cmd[-1]).replace(remote_root, str(sandbox))
+    proc = _real_run(["sh", "-c", script], capture_output=True)
+    return _Result(proc.returncode, proc.stdout, proc.stderr)
+
+
+POSIX_SHELLS = ("sh", "dash", "bash")
+
+
+def available_shells() -> list:
+    """Which POSIX shells this machine can actually test against."""
+    import shutil as _shutil
+
+    return [name for name in POSIX_SHELLS if _shutil.which(name)]
+
+
+def lock_aware(fake_run, sandbox: Path, remote_root: str = "/backup"):
+    """Wrap a test's fake ``subprocess.run`` so lock scripts are really run."""
+
+    def dispatch(cmd, *args, **kwargs):
+        if is_lock_script(cmd):
+            return run_lock_script(cmd, sandbox, remote_root)
+        return fake_run(cmd, *args, **kwargs)
+
+    return dispatch

--- a/tests/test_raw_endpoint.py
+++ b/tests/test_raw_endpoint.py
@@ -1085,8 +1085,12 @@ class TestSSHRawEndpointMethods:
         call_args = mock_run.call_args[0][0]
         assert "rm -f" in call_args[-1]
 
-    def test_delete_snapshots_failure(self):
+    def test_delete_snapshots_failure(self, tmp_path):
         """Test handling delete failure on remote."""
+        import subprocess
+
+        from .lockshell import lock_aware
+
         endpoint = SSHRawEndpoint(
             config={
                 "path": "/backup",
@@ -1098,17 +1102,17 @@ class TestSSHRawEndpointMethods:
             stream_path=Path("/backup/test.btrfs"),
         )
 
-        with patch("subprocess.run") as mock_run:
-            import subprocess
+        def refuse(cmd, *a, **k):
+            raise subprocess.CalledProcessError(1, "ssh", stderr=b"Permission denied")
 
-            mock_run.side_effect = subprocess.CalledProcessError(
-                1, "ssh", stderr=b"Permission denied"
-            )
+        with patch("subprocess.run", lock_aware(refuse, tmp_path)):
             # Should not raise, just log error
             endpoint.delete_snapshots([snapshot])
 
-    def test_delete_updates_cache(self):
+    def test_delete_updates_cache(self, tmp_path):
         """Test that remote delete updates cache."""
+        from .lockshell import lock_aware
+
         endpoint = SSHRawEndpoint(
             config={
                 "path": "/backup",
@@ -1121,8 +1125,10 @@ class TestSSHRawEndpointMethods:
         )
         endpoint._cached_snapshots = [snapshot]
 
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
+        def ok(cmd, *a, **k):
+            return MagicMock(returncode=0, stdout=b"", stderr=b"")
+
+        with patch("subprocess.run", lock_aware(ok, tmp_path)):
             endpoint.delete_snapshots([snapshot])
 
         assert len(endpoint._cached_snapshots) == 0

--- a/tests/test_raw_lock.py
+++ b/tests/test_raw_lock.py
@@ -183,12 +183,33 @@ def test_lock_file_is_not_a_snapshot(tmp_path):
     assert ep.streams_without_sidecar() == []
 
 
-def test_ssh_target_lock_is_noop(tmp_path):
-    """raw+ssh locking is deferred: target_lock is a no-op that never blocks."""
+def test_ssh_target_lock_actually_excludes(tmp_path, monkeypatch):
+    """raw+ssh target_lock is a real lock on the target, not a no-op.
+
+    It used to be a no-op -- two concurrent prunes of the same remote target
+    could interleave, and a prune could delete what a restore was reading. The
+    lock now lives on the target itself, so a second holder is refused.
+
+    This drives the real POSIX protocol (mkdir/stat/mv) against a sandbox rather
+    than mocking its replies, so it fails if the protocol stops excluding.
+    """
+    from .lockshell import lock_aware
+
+    def unexpected(cmd, *a, **k):
+        raise AssertionError(f"unexpected remote command: {cmd}")
+
     ep = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
+    monkeypatch.setattr(raw_mod.subprocess, "run", lock_aware(unexpected, tmp_path))
+
+    other = SSHRawEndpoint(config={"path": "/backup", "hostname": "nas"})
     with ep.target_lock():
-        with ep.target_lock(timeout=0.1):  # no conflict, no RuntimeError
-            pass
+        with pytest.raises(RuntimeError, match="busy"):
+            with other.target_lock(timeout=0.1):
+                pass
+
+    # Released cleanly, so the next contender gets it.
+    with other.target_lock(timeout=0.1):
+        pass
 
 
 def _busy_lock(self, **kw):
@@ -283,7 +304,7 @@ def test_prune_takes_lock_once_for_whole_pass(tmp_path, monkeypatch):
     assert len(ep.list_snapshots(flush_cache=True)) == 1
 
 
-def test_ssh_prune_issues_remote_rm(monkeypatch):
+def test_ssh_prune_issues_remote_rm(monkeypatch, tmp_path):
     """delete_old_snapshots must prune a raw+ssh target via a remote rm. The atomic-
     prune refactor routes deletion through _delete_snapshots_locked, so SSHRawEndpoint
     overrides THAT (not delete_snapshots); otherwise remote retention silently deletes
@@ -312,7 +333,9 @@ def test_ssh_prune_issues_remote_rm(monkeypatch):
 
         return _R()
 
-    monkeypatch.setattr(raw_mod.subprocess, "run", fake_run)
+    from .lockshell import lock_aware
+
+    monkeypatch.setattr(raw_mod.subprocess, "run", lock_aware(fake_run, tmp_path))
     ep.delete_old_snapshots(keep=1)  # prune the 2 oldest remotely
     assert len(rm_targets) == 2
     assert all("root.20240103" not in t for t in rm_targets)  # newest kept

--- a/tests/test_raw_snapshot_interface.py
+++ b/tests/test_raw_snapshot_interface.py
@@ -104,24 +104,37 @@ def test_find_parent_picks_most_recent_older():
     assert c.find_parent([]) is None
 
 
-def test_set_lock_is_in_memory_only_and_never_raises(tmp_path):
+def test_set_lock_on_a_local_raw_target_stays_in_memory(tmp_path):
     """Restore locks/unlocks the backup snapshot. The raw override must mutate
     only the in-memory lock set -- no `source` requirement, no local lock-file
     write (which would fail for a remote raw+ssh target and abort the restore).
-    Persisting locks across runs is deferred (R3)."""
-    for ep in (
-        RawEndpoint(config={"path": str(tmp_path)}),
-        SSHRawEndpoint(config={"path": "/remote/backup", "hostname": "nas"}),
-    ):
-        snap = _raw("root.20240115", 15)
+
+    A LOCAL raw target still keeps its locks in memory for the run. raw+ssh no
+    longer does; see tests/test_remote_locks.py."""
+    ep = RawEndpoint(config={"path": str(tmp_path)})
+    snap = _raw("root.20240115", 15)
+    ep.set_lock(snap, "restore:abc", True)
+    assert snap.locks == {"restore:abc"}
+    ep.set_lock(snap, "restore:abc", False)
+    assert snap.locks == set()
+    ep.set_lock(snap, "xfer:1", True, parent=True)
+    assert snap.parent_locks == {"xfer:1"}
+    # No lock file was written next to a local raw target.
+    assert not (tmp_path / ".btrfs-backup-ng.locks").exists()
+
+
+def test_set_lock_on_a_raw_ssh_target_refuses_to_pretend(tmp_path):
+    """A raw+ssh lock that cannot be recorded must stop, not warn.
+
+    It used to mutate the in-memory set and continue. The restore then ran with
+    no protection at all while a prune on that target saw nothing holding the
+    stream -- which is what made a pruned-mid-restore possible in the first
+    place. An unreachable host is the easiest way to reach that state.
+    """
+    ep = SSHRawEndpoint(config={"path": "/remote/backup", "hostname": "nas.invalid"})
+    snap = _raw("root.20240115", 15)
+    with pytest.raises(__util__.AbortError, match="Refusing to continue unprotected"):
         ep.set_lock(snap, "restore:abc", True)
-        assert snap.locks == {"restore:abc"}
-        ep.set_lock(snap, "restore:abc", False)
-        assert snap.locks == set()
-        ep.set_lock(snap, "xfer:1", True, parent=True)
-        assert snap.parent_locks == {"xfer:1"}
-        # No lock file was written next to a local raw target.
-        assert not (tmp_path / ".btrfs-backup-ng.locks").exists()
 
 
 def test_list_snapshots_threads_endpoint_locally(tmp_path):

--- a/tests/test_remote_locks.py
+++ b/tests/test_remote_locks.py
@@ -1,0 +1,823 @@
+"""Locks that survive the process that took them.
+
+A restore reads a snapshot on a remote target while a prune -- in another
+process, possibly on another machine -- deletes from that same target. The lock
+protecting the snapshot under restore used to live in the restoring process's
+memory, where the pruning process could not see it. The guard was there; it was
+looking at the wrong thing.
+
+``restore --status`` reported this as "this target does not persist locks",
+which is honest and useless: a backup tool that reports it cannot protect a
+restore is not protecting the restore.
+
+These tests drive the real POSIX protocol -- mkdir, stat, mv, rmdir -- against a
+local sandbox standing in for the target. Nothing about the protocol is mocked,
+because a mock of its replies would pass whatever the protocol did.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from btrfs_backup_ng.sshutil.lock import (
+    HOLDERS_DIR_NAME,
+    LOCK_DIR_NAME,
+    RemoteLockBusy,
+    RemoteLockManager,
+    RemoteLockUnavailable,
+    blocked_by_remote_lock,
+    encode_name,
+    read_persisted_locks,
+    snapshot_lock_name,
+    write_persisted_locks,
+)
+
+_real_run = subprocess.run
+
+
+def _runner(sandbox: Path):
+    def run(script: str):
+        proc = subprocess.run(["sh", "-c", script], capture_output=True, text=True)
+        return proc.returncode, proc.stdout, proc.stderr
+
+    return run
+
+
+def _manager(sandbox: Path, **kw) -> RemoteLockManager:
+    return RemoteLockManager(_runner(sandbox), str(sandbox), hostname="testhost", **kw)
+
+
+def _snap(name: str):
+    return SimpleNamespace(locks=set(), parent_locks=set(), get_name=lambda: name)
+
+
+class TestExclusion:
+    """The one property everything else rests on."""
+
+    def test_a_second_holder_is_refused(self, tmp_path):
+        first, second = _manager(tmp_path), _manager(tmp_path)
+        assert first.acquire_once("target", "prune") == "acquired"
+        with pytest.raises(RemoteLockBusy):
+            second.acquire_once("target", "restore")
+
+    def test_the_refusal_names_the_holder(self, tmp_path):
+        """An operator has to be able to find the process that is blocking them."""
+        _manager(tmp_path).acquire_once("target", "prune")
+        with pytest.raises(RemoteLockBusy) as caught:
+            _manager(tmp_path).acquire_once("target", "restore")
+        info = caught.value.info or {}
+        assert info.get("operation") == "prune"
+        assert info.get("hostname") == "testhost"
+        assert info.get("pid") == os.getpid()
+
+    def test_release_lets_the_next_contender_in(self, tmp_path):
+        first = _manager(tmp_path)
+        first.acquire_once("target", "prune")
+        first.release("target")
+        assert _manager(tmp_path).acquire_once("target", "restore") == "acquired"
+
+    def test_concurrent_contenders_produce_exactly_one_winner(self, tmp_path):
+        """mkdir is the atomic primitive; this is what it is being trusted for."""
+        wins: list[str] = []
+        barrier = threading.Barrier(12)
+
+        def contend(i: int) -> None:
+            barrier.wait()
+            try:
+                _manager(tmp_path).acquire_once("target", f"op-{i}")
+                wins.append(f"op-{i}")
+            except RemoteLockBusy:
+                pass
+
+        threads = [threading.Thread(target=contend, args=(i,)) for i in range(12)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert len(wins) == 1, f"expected one winner, got {wins}"
+
+
+class TestTheScriptsAreNotBashOnly:
+    """Remote targets are not all Fedora.
+
+    Two shipped bugs in this project came from a remote command string that was
+    written against bash and run under dash. Every lock script is POSIX by
+    construction; this runs them under each shell present rather than trusting
+    that, so a bashism cannot pass review unnoticed.
+    """
+
+    def test_the_protocol_behaves_identically_under_every_posix_shell(self, tmp_path):
+        from .lockshell import available_shells
+
+        shells = available_shells()
+        assert "dash" in shells, (
+            "dash is not installed, so this test would silently prove nothing"
+        )
+
+        results = {}
+        for shell in shells:
+            sandbox = tmp_path / shell
+            sandbox.mkdir()
+
+            def run(script, _sh=shell):
+                proc = subprocess.run(
+                    [_sh, "-c", script], capture_output=True, text=True
+                )
+                return proc.returncode, proc.stdout, proc.stderr
+
+            manager = RemoteLockManager(run, str(sandbox), hostname="h")
+            outcome = {}
+            outcome["exclusive"] = manager.acquire_once("target", "prune")
+            try:
+                RemoteLockManager(run, str(sandbox), hostname="h2").acquire_once(
+                    "target", "other"
+                )
+                outcome["second_exclusive"] = "ACQUIRED (exclusion broken)"
+            except RemoteLockBusy:
+                outcome["second_exclusive"] = "refused"
+            manager.acquire_shared("snap-a", "restore:1")
+            RemoteLockManager(run, str(sandbox), hostname="h2").acquire_shared(
+                "snap-a", "restore:2"
+            )
+            outcome["shared_holders"] = len(manager.live_locks()["snap-a"])
+            outcome["names"] = sorted(manager.live_lock_names())
+            outcome["status"] = read_persisted_locks(manager)
+            manager.release_shared("snap-a", "restore:1")
+            outcome["after_one_release"] = len(manager.live_locks()["snap-a"])
+            results[shell] = outcome
+
+        reference = results[shells[0]]
+        for shell, outcome in results.items():
+            assert outcome == reference, (
+                f"{shell} disagrees with {shells[0]}: {outcome} != {reference}"
+            )
+
+
+class TestSharedPinsDoNotBlockEachOther:
+    """A pin protects a snapshot from DELETION, not from other readers.
+
+    The contract being mirrored is ``snapshot.locks``, a SET of lock ids. Making
+    the remote pin exclusive made a second restore of the same snapshot fail
+    against the first -- a concurrency regression the local path never had.
+    """
+
+    def test_two_restores_can_pin_the_same_snapshot(self, tmp_path):
+        first, second = _manager(tmp_path), _manager(tmp_path)
+        first.acquire_shared("snap-a", "restore:1")
+        second.acquire_shared("snap-a", "restore:2")  # must not raise
+        assert len(_manager(tmp_path).live_locks()["snap-a"]) == 2
+
+    def test_a_backup_can_pin_what_a_restore_is_reading(self, tmp_path):
+        """A transfer pins its incremental parent; a restore may be reading it."""
+        _manager(tmp_path).acquire_shared("snap-a", "restore:1")
+        _manager(tmp_path).acquire_shared("snap-a", "p:transfer:9")
+        assert len(_manager(tmp_path).live_locks()["snap-a"]) == 2
+
+    def test_the_snapshot_stays_pinned_until_the_LAST_holder_leaves(self, tmp_path):
+        first, second = _manager(tmp_path), _manager(tmp_path)
+        first.acquire_shared("snap-a", "restore:1")
+        second.acquire_shared("snap-a", "restore:2")
+
+        first.release_shared("snap-a", "restore:1")
+        assert blocked_by_remote_lock(_manager(tmp_path), [_snap("a")]) == {"a"}, (
+            "one holder let go and the pin vanished while another still held it"
+        )
+
+        second.release_shared("snap-a", "restore:2")
+        assert blocked_by_remote_lock(_manager(tmp_path), [_snap("a")]) == set()
+
+    def test_many_concurrent_holders_all_succeed(self, tmp_path):
+        """The inverse of the exclusive test: here EVERY contender must win."""
+        wins: list = []
+        barrier = threading.Barrier(10)
+
+        def pin(i: int) -> None:
+            barrier.wait()
+            _manager(tmp_path).acquire_shared("snap-a", f"restore:{i}")
+            wins.append(i)
+
+        threads = [threading.Thread(target=pin, args=(i,)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert len(wins) == 10
+        assert len(_manager(tmp_path).live_locks()["snap-a"]) == 10
+
+    def test_a_holder_releases_only_its_own_pin(self, tmp_path):
+        manager = _manager(tmp_path)
+        manager.acquire_shared("snap-a", "restore:1")
+        manager.acquire_shared("snap-a", "restore:2")
+        manager.release_shared("snap-a", "restore:1")
+        holders = _manager(tmp_path).live_locks()["snap-a"]
+        assert [h.lock_id for h in holders] == ["restore:2"]
+
+
+class TestNamesAreNotMangledIntoEachOther:
+    """Four defects found by adversarial review, all one root cause.
+
+    The on-disk name was produced by replacing every unsafe character with an
+    underscore. That map is lossy, and it was being used as an identity.
+    """
+
+    def test_a_snapshot_whose_name_needs_encoding_is_still_seen(self, tmp_path):
+        """The writer stored a rewritten name; the guard asked for the real one,
+        so the pin existed and was invisible and a prune would delete it."""
+        weird = "root:2024/01"
+        _manager(tmp_path).acquire_shared(f"snap-{weird}", "restore:1")
+        assert blocked_by_remote_lock(_manager(tmp_path), [_snap(weird)]) == {weird}
+
+    def test_two_lock_ids_that_used_to_collide_get_separate_records(self, tmp_path):
+        """`restore:x/y` and `restore:x:y` both became `restore_x_y`, so one
+        holder releasing removed the other's pin."""
+        manager = _manager(tmp_path)
+        manager.acquire_shared("snap-a", "restore:x/y")
+        manager.acquire_shared("snap-a", "restore:x:y")
+        assert len(_manager(tmp_path).live_locks()["snap-a"]) == 2
+
+        manager.release_shared("snap-a", "restore:x/y")
+        assert blocked_by_remote_lock(_manager(tmp_path), [_snap("a")]) == {"a"}, (
+            "one holder released and took another holder's pin with it"
+        )
+
+    def test_encoding_is_injective_over_awkward_names(self, tmp_path):
+        candidates = [
+            "restore:x/y",
+            "restore:x:y",
+            "restore_x_y",
+            "root:2024/01",
+            "root_2024_01",
+            "a b",
+            "a-b",
+        ]
+        assert len({encode_name(c) for c in candidates}) == len(candidates)
+
+    def test_status_reports_the_real_name_not_the_encoded_one(self, tmp_path):
+        """The directory name is an encoding and cannot be decoded back, so the
+        lock's real name travels in its payload. Reading identity off the
+        directory instead would show an operator a name that matches no snapshot
+        they have, and --unlock would key off that same wrong name."""
+        weird = "root:2024/01"
+        _manager(tmp_path).acquire_shared(f"snap-{weird}", "restore:1")
+        assert read_persisted_locks(_manager(tmp_path)) == {
+            weird: {"locks": ["restore:1"]}
+        }
+
+    def test_unlock_clears_a_pin_on_an_awkwardly_named_snapshot(self, tmp_path):
+        weird = "root:2024/01"
+        manager = _manager(tmp_path)
+        manager.acquire_shared(f"snap-{weird}", "restore:1")
+        manager.acquire_shared(f"snap-{weird}", "restore:2")
+
+        write_persisted_locks(_manager(tmp_path), {weird: {"locks": ["restore:2"]}})
+        assert read_persisted_locks(_manager(tmp_path)) == {
+            weird: {"locks": ["restore:2"]}
+        }
+
+    def test_a_target_path_with_a_space_does_not_misdirect_the_sweeper(self, tmp_path):
+        """The remote used to emit full paths on a space-delimited line. A target
+        directory containing a space produced a truncated path, which the sweeper
+        handed to `rm -f` -- deleting something unrelated, reporting success, and
+        leaving the real holder in place."""
+        spaced = tmp_path / "my backups"
+        spaced.mkdir()
+        decoy = tmp_path / "my"
+        decoy.write_text("not a lock file")
+
+        manager = _manager(spaced, stale_after=1)
+        manager.acquire_shared("snap-a", "restore:1")
+        holder = next((spaced / LOCK_DIR_NAME).glob("*/holders/*"))
+        old = time.time() - 10_000
+        os.utime(holder, (old, old))
+
+        assert manager.sweep_dead_holders() == 1
+        assert not holder.exists(), "the real holder survived the sweep"
+        assert decoy.exists(), "the sweeper deleted an unrelated path"
+
+    def test_an_unnameable_holder_can_still_be_unlocked(self, tmp_path):
+        """--unlock addressed holders by lock id, which is exactly what a holder
+        with an unreadable payload does not have. It could never be cleared."""
+        holders = (
+            tmp_path
+            / LOCK_DIR_NAME
+            / f"{encode_name('snap-a')}.lock"
+            / HOLDERS_DIR_NAME
+        )
+        holders.mkdir(parents=True)
+        (holders / "mystery").write_text("{{{")
+
+        assert blocked_by_remote_lock(_manager(tmp_path), [_snap("a")]) == {"a"}, (
+            "a pin nobody can name must still block a delete"
+        )
+        write_persisted_locks(_manager(tmp_path), {})
+        assert _manager(tmp_path).live_lock_names() == set()
+
+    def test_an_unnameable_holder_on_an_encoded_name_still_blocks(self, tmp_path):
+        """Both failures at once: the payload is unreadable AND the snapshot name
+        needed encoding, so neither the listed key nor the real name matches.
+        The directory name is exact in every case, so it is what decides."""
+        weird = "root:2024/01"
+        holders = (
+            tmp_path
+            / LOCK_DIR_NAME
+            / f"{encode_name(f'snap-{weird}')}.lock"
+            / HOLDERS_DIR_NAME
+        )
+        holders.mkdir(parents=True)
+        (holders / "mystery").write_text("{{{")
+        assert blocked_by_remote_lock(_manager(tmp_path), [_snap(weird)]) == {weird}
+
+    def test_an_unnameable_holder_reads_back_recognisably(self, tmp_path):
+        holders = (
+            tmp_path
+            / LOCK_DIR_NAME
+            / f"{encode_name('snap-a')}.lock"
+            / HOLDERS_DIR_NAME
+        )
+        holders.mkdir(parents=True)
+        (holders / "mystery").write_text("{{{")
+        assert read_persisted_locks(_manager(tmp_path)) == {"a": {"locks": ["unknown"]}}
+
+
+class TestTheAcquisitionWindow:
+    """Between the mkdir that wins a lock and the touch that heartbeats it."""
+
+    def test_a_lock_taken_microseconds_ago_is_not_treated_as_dead(self, tmp_path):
+        """Ageing a missing heartbeat from epoch zero made a brand-new lock look
+        infinitely old, so a contender arriving inside that window broke it and
+        took a lock somebody already held. Two winners, intermittently."""
+        manager = _manager(tmp_path)
+        (tmp_path / LOCK_DIR_NAME / f"{encode_name('target')}.lock").mkdir(parents=True)
+        with pytest.raises(RemoteLockBusy):
+            manager.acquire_once("target", "thief")
+
+    def test_a_genuinely_dead_lock_is_still_breakable(self, tmp_path):
+        """The other half: closing the window must not make dead locks eternal."""
+        manager = _manager(tmp_path, stale_after=1)
+        lock = tmp_path / LOCK_DIR_NAME / f"{encode_name('target')}.lock"
+        lock.mkdir(parents=True)
+        old = time.time() - 10_000
+        os.utime(lock, (old, old))
+        assert manager.acquire_once("target", "later") == "stale-broken"
+
+
+class TestTheOperatorCanOptOut:
+    """--skip-remote-lock, for a destination that can be read but not written."""
+
+    def _endpoint(self, tmp_path, **extra):
+        from btrfs_backup_ng.endpoint.ssh import SSHEndpoint
+
+        endpoint = SSHEndpoint.__new__(SSHEndpoint)
+        endpoint.config = {"path": str(tmp_path), **extra}
+        return endpoint
+
+    def test_without_the_flag_an_unrecordable_lock_stops_the_run(self, tmp_path):
+        from btrfs_backup_ng import __util__
+
+        readonly = tmp_path / "readonly"
+        readonly.mkdir()
+        os.chmod(readonly, 0o500)  # the read-only destination this is all about
+        try:
+            endpoint = self._endpoint(readonly)
+            endpoint._build_lock_manager = lambda: _manager(readonly)
+            with pytest.raises(__util__.AbortError, match="skip-remote-lock"):
+                endpoint.set_lock(_snap("a"), "restore:1", True)
+        finally:
+            os.chmod(readonly, 0o700)
+
+    def test_the_flag_lets_it_continue(self, tmp_path, caplog):
+        endpoint = self._endpoint(tmp_path, skip_remote_lock=True)
+
+        def unusable():
+            raise RemoteLockUnavailable("read-only target")
+
+        endpoint._build_lock_manager = unusable
+        snapshot = _snap("a")
+        endpoint.set_lock(snapshot, "restore:1", True)  # must not raise
+        assert "restore:1" in snapshot.locks, "the in-memory pin is still kept"
+
+    def test_the_flag_does_not_silence_the_readers(self, tmp_path):
+        """It relaxes the abort ONLY. Nothing may start reporting a target as
+        unlocked without having looked -- that is the false all-clear this
+        whole mechanism exists to remove."""
+        endpoint = self._endpoint(tmp_path, skip_remote_lock=True)
+        assert endpoint._lock_target_path() == str(tmp_path)
+        _manager(tmp_path).acquire_shared("snap-a", "restore:elsewhere")
+        assert blocked_by_remote_lock(_manager(tmp_path), [_snap("a")]) == {"a"}
+
+
+class TestTheConfigOptionIsReal:
+    def test_a_target_can_carry_skip_remote_lock(self):
+        """The flag has a config counterpart, or a site that needs it has to
+        remember to type it on every run."""
+        from btrfs_backup_ng.config.schema import TargetConfig
+
+        assert TargetConfig(path="/backup").skip_remote_lock is False
+        assert TargetConfig(path="/backup", skip_remote_lock=True).skip_remote_lock
+
+    def test_it_reaches_the_endpoint_config(self):
+        from btrfs_backup_ng.cli.common import thread_ssh_target_config
+        from btrfs_backup_ng.config.schema import TargetConfig
+
+        kwargs: dict = {}
+        thread_ssh_target_config(
+            kwargs, TargetConfig(path="/backup", skip_remote_lock=True)
+        )
+        assert kwargs["skip_remote_lock"] is True
+
+
+class TestAbandonedHoldersAreSwept:
+    def test_a_long_dead_holder_file_is_removed(self, tmp_path):
+        manager = _manager(tmp_path, stale_after=1)
+        manager.acquire_shared("snap-a", "restore:1")
+        holder = (
+            tmp_path
+            / LOCK_DIR_NAME
+            / f"{encode_name('snap-a')}.lock"
+            / HOLDERS_DIR_NAME
+            / encode_name("restore:1")
+        )
+        old = time.time() - 10_000
+        os.utime(holder, (old, old))
+        assert manager.sweep_dead_holders() == 1
+        assert not holder.exists()
+
+    def test_a_merely_unrefreshed_holder_is_left_alone(self, tmp_path):
+        """Past the stale threshold but not past all doubt: ignored for locking
+        purposes, but not deleted, because deleting someone else's live pin is
+        far worse than leaving a small file behind."""
+        manager = _manager(tmp_path, stale_after=100)
+        manager.acquire_shared("snap-a", "restore:1")
+        holder = (
+            tmp_path
+            / LOCK_DIR_NAME
+            / f"{encode_name('snap-a')}.lock"
+            / HOLDERS_DIR_NAME
+            / encode_name("restore:1")
+        )
+        old = time.time() - 150  # stale, but under 2x the threshold
+        os.utime(holder, (old, old))
+        assert manager.live_lock_names() == set()
+        assert manager.sweep_dead_holders() == 0
+        assert holder.exists()
+
+
+class TestCleanupOnExit:
+    def test_an_interrupted_run_releases_its_pins(self, tmp_path):
+        """Ctrl-C on a restore should free the snapshot now, not in three
+        minutes when the stale window expires."""
+        from btrfs_backup_ng.sshutil import lock as lock_mod
+
+        manager = _manager(tmp_path)
+        manager.acquire_shared_persistent("snap-a", "restore:1")
+        assert manager.live_lock_names() == {"snap-a"}
+
+        lock_mod._release_all_held()  # what atexit and the signal handler call
+        assert manager.live_lock_names() == set()
+
+    def test_cleanup_never_raises_on_a_broken_transport(self, tmp_path):
+        """Exit-time cleanup that raises would mask the real failure."""
+        from btrfs_backup_ng.sshutil import lock as lock_mod
+
+        def broken(_script):
+            raise OSError("no route to host")
+
+        manager = RemoteLockManager(broken, str(tmp_path), hostname="h")
+        lock_mod._register_for_cleanup(manager, "snap-a\x00restore:1")
+        lock_mod._release_all_held()  # must not raise
+
+
+class TestStaleness:
+    """A crashed holder must not lock the target out forever."""
+
+    def test_a_dead_holder_is_broken_after_the_threshold(self, tmp_path):
+        holder = _manager(tmp_path, stale_after=1)
+        holder.acquire_once("target", "prune")
+        holder._stop_heartbeat("target")  # simulate the process dying
+        time.sleep(2)
+        assert _manager(tmp_path, stale_after=1).acquire_once("t2", "x") == "acquired"
+        assert (
+            _manager(tmp_path, stale_after=1).acquire_once("target", "restore")
+            == "stale-broken"
+        )
+
+    def test_a_live_holder_is_not_broken(self, tmp_path):
+        """The inverse: a heartbeat that is being refreshed must hold the lock."""
+        holder = _manager(tmp_path, stale_after=60)
+        holder.acquire_once("target", "prune")
+        with pytest.raises(RemoteLockBusy):
+            _manager(tmp_path, stale_after=60).acquire_once("target", "restore")
+
+    def test_staleness_is_judged_on_the_target_not_the_client(self, tmp_path):
+        """No client clock is ever compared, so client skew cannot break a lock.
+
+        The age expression must be computed from the target's own `date` and the
+        target's own `stat`; if either came from this side, two hosts four
+        seconds apart (which is what the development pair measured) would each
+        reach a different verdict about the same lock.
+        """
+        script = _manager(tmp_path)._acquire_script("target", "{}", "tok")
+        assert "date +%s" in script, "the target must supply the current time"
+        assert "stat -c %Y" in script or "stat -f %m" in script
+
+
+class TestListing:
+    def test_live_locks_are_listed_and_stale_ones_are_not(self, tmp_path):
+        manager = _manager(tmp_path, stale_after=1)
+        manager.acquire_shared("snap-a", "restore:1")
+        manager.acquire_shared("snap-b", "restore:2")
+        assert manager.live_lock_names() == {"snap-a", "snap-b"}
+        time.sleep(2)
+        beat = (
+            f"{tmp_path}/{LOCK_DIR_NAME}/{encode_name('snap-b')}.lock"
+            f"/{HOLDERS_DIR_NAME}/{encode_name('restore:2')}"
+        )
+        manager._run(f"touch {beat}")  # b's holder keeps beating; a's does not
+        assert manager.live_lock_names() == {"snap-b"}
+
+    def test_a_lock_with_unreadable_details_is_still_a_lock(self, tmp_path):
+        """ "Something holds this and we cannot say what" must never round down
+        to "nothing holds this" -- that is the whole failure being fixed."""
+        manager = _manager(tmp_path)
+        manager.acquire_shared("snap-a", "restore:1")
+        broken = (
+            tmp_path
+            / LOCK_DIR_NAME
+            / f"{encode_name('snap-broken')}.lock"
+            / HOLDERS_DIR_NAME
+        )
+        broken.mkdir(parents=True)
+        (broken / "someholder").write_text("not json {{")
+
+        live = manager.live_locks()
+        assert "snap-broken" in live, "a lock vanished because its details did"
+        assert live["snap-broken"][0].info == {}
+        assert live["snap-a"][0].info["operation"] == "restore:1"
+
+
+class TestTheGuardAProcessConsults:
+    def test_a_snapshot_locked_by_another_process_is_blocked(self, tmp_path):
+        """The headline case, stated exactly.
+
+        The restoring process takes the lock. The pruning process is a DIFFERENT
+        manager with its own empty in-memory state -- as a separate process
+        genuinely is -- and must still see the lock.
+        """
+        restoring = _manager(tmp_path)
+        restoring.acquire_shared_persistent("snap-root.20240101T120000", "restore:abc")
+
+        pruning = _manager(tmp_path)
+        blocked = blocked_by_remote_lock(
+            pruning, [_snap("root.20240101T120000"), _snap("root.20240102T120000")]
+        )
+        assert blocked == {"root.20240101T120000"}
+
+    def test_an_unreadable_lock_state_is_not_answered(self, tmp_path):
+        """Neither available answer is honest, so it must raise rather than pick.
+
+        Answering "nothing is locked" prunes on an unanswered question and can
+        delete what a restore is reading. Answering "everything is locked" skips
+        every deletion, which is how retention stops running while the operator
+        is told it succeeded.
+        """
+
+        def broken(_script):
+            raise OSError("no route to host")
+
+        manager = RemoteLockManager(broken, str(tmp_path), hostname="h")
+        with pytest.raises(RemoteLockUnavailable):
+            blocked_by_remote_lock(manager, [_snap("root.20240101T120000")])
+
+    def test_a_query_that_could_not_run_is_not_a_clean_answer(self, tmp_path):
+        """The scripts end in `exit 0`, so a non-zero status means the shell
+        never ran -- unreachable host, unreadable lock directory. Empty output
+        then means "could not ask", and must not be read as "nothing is locked".
+
+        This is the shape the hardware run exposed: the query failed at the
+        transport, produced no output, and the prune deleted on the strength of
+        it.
+        """
+
+        def failed(_script):
+            return 255, "", "ssh: connect to host nas port 22: No route to host"
+
+        manager = RemoteLockManager(failed, str(tmp_path), hostname="h")
+        with pytest.raises(RemoteLockUnavailable):
+            manager.live_lock_names()
+        with pytest.raises(RemoteLockUnavailable):
+            manager.live_locks()
+        with pytest.raises(RemoteLockUnavailable):
+            blocked_by_remote_lock(manager, [_snap("root.20240101T120000")])
+
+    def test_nothing_locked_blocks_nothing(self, tmp_path):
+        """The guard must not be a blanket refusal, or pruning never runs."""
+        assert (
+            blocked_by_remote_lock(_manager(tmp_path), [_snap("a"), _snap("b")])
+            == set()
+        )
+
+
+class TestWriterAndReaderAgree:
+    """A lock written under one key and read under another is a silent hole."""
+
+    @pytest.mark.parametrize(
+        "snapshot,expected",
+        [
+            (
+                SimpleNamespace(get_name=lambda: "root.20240101T120000"),
+                "root.20240101T120000",
+            ),
+            (
+                SimpleNamespace(get_path=lambda: "/backup/root.20240101T120000"),
+                "root.20240101T120000",
+            ),
+            (SimpleNamespace(name="root.20240101T120000"), "root.20240101T120000"),
+            ("/backup/root.20240101T120000", "root.20240101T120000"),
+        ],
+    )
+    def test_every_shape_delete_is_called_with_yields_the_same_name(
+        self, snapshot, expected
+    ):
+        assert snapshot_lock_name(snapshot) == expected
+
+    def test_the_name_the_guard_looks_up_is_the_name_set_lock_wrote(self, tmp_path):
+        from btrfs_backup_ng.endpoint.ssh import SSHEndpoint
+
+        endpoint = SSHEndpoint.__new__(SSHEndpoint)
+        endpoint.config = {"path": str(tmp_path)}
+        endpoint._lock_manager = lambda: _manager(tmp_path)
+
+        snapshot = _snap("root.20240101T120000")
+        endpoint.set_lock(snapshot, "restore:abc", True)
+
+        assert blocked_by_remote_lock(_manager(tmp_path), [snapshot]) == {
+            "root.20240101T120000"
+        }
+
+
+class TestReleaseIsNotPremature:
+    def test_a_parent_lock_still_held_keeps_the_remote_lock(self, tmp_path):
+        """A snapshot can be pinned directly AND as an incremental parent.
+
+        Clearing the first of the two must not drop the protection while the
+        second still holds it.
+        """
+        from btrfs_backup_ng.endpoint.ssh import SSHEndpoint
+
+        endpoint = SSHEndpoint.__new__(SSHEndpoint)
+        endpoint.config = {"path": str(tmp_path)}
+        # ONE manager, as a single process has: the endpoint caches it per path
+        # so that holds() recognises this process's own lock and so that a
+        # release can stop the heartbeat the acquire started.
+        shared = _manager(tmp_path)
+        endpoint._lock_manager = lambda: shared
+
+        snapshot = _snap("root.20240101T120000")
+        endpoint.set_lock(snapshot, "restore:abc", True)
+        endpoint.set_lock(snapshot, "transfer:xyz", True, parent=True)
+
+        endpoint.set_lock(snapshot, "restore:abc", False)
+        assert _manager(tmp_path).live_lock_names() == {"snap-root.20240101T120000"}, (
+            "the remote lock was released while a parent lock still held it"
+        )
+
+        endpoint.set_lock(snapshot, "transfer:xyz", False, parent=True)
+        assert _manager(tmp_path).live_lock_names() == set()
+
+
+class TestOneProcessOneManager:
+    """The endpoint must reuse its manager, or it locks against itself."""
+
+    def test_the_same_path_gets_the_same_manager(self, tmp_path):
+        from btrfs_backup_ng.endpoint.ssh import SSHEndpoint
+
+        endpoint = SSHEndpoint.__new__(SSHEndpoint)
+        endpoint.config = {"path": str(tmp_path)}
+        endpoint._build_lock_manager = lambda: _manager(tmp_path)
+        assert endpoint._lock_manager() is endpoint._lock_manager()
+
+    def test_a_changed_path_gets_a_new_manager(self, tmp_path):
+        """The config can be rewritten between operations; a manager holding the
+        old path would lock somewhere other than where the work is happening."""
+        from btrfs_backup_ng.endpoint.ssh import SSHEndpoint
+
+        endpoint = SSHEndpoint.__new__(SSHEndpoint)
+        endpoint.config = {"path": str(tmp_path)}
+        endpoint._build_lock_manager = lambda: _manager(Path(endpoint.config["path"]))
+        first = endpoint._lock_manager()
+        endpoint.config["path"] = str(tmp_path / "elsewhere")
+        assert endpoint._lock_manager() is not first
+
+    def test_locking_a_snapshot_twice_in_one_process_is_not_contention(self, tmp_path):
+        """Pinned directly AND as an incremental parent is normal, not a clash."""
+        from btrfs_backup_ng.endpoint.ssh import SSHEndpoint
+
+        endpoint = SSHEndpoint.__new__(SSHEndpoint)
+        endpoint.config = {"path": str(tmp_path)}
+        # A partially-built endpoint has no ssh transport, so the shell runner is
+        # pointed at this machine. The caching under test is the endpoint's.
+        endpoint._build_lock_manager = lambda: _manager(tmp_path)
+
+        snapshot = _snap("root.20240101T120000")
+        endpoint.set_lock(snapshot, "restore:abc", True)
+        endpoint.set_lock(snapshot, "transfer:xyz", True, parent=True)  # must not raise
+        assert endpoint._lock_manager().live_lock_names() == {
+            "snap-root.20240101T120000"
+        }
+
+    def test_threads_racing_for_the_manager_get_the_same_one(self, tmp_path):
+        """Transfers run threaded. Two threads building a manager each would
+        recreate the duplicate-instance bug the cache exists to prevent."""
+        from btrfs_backup_ng.endpoint.ssh import SSHEndpoint
+
+        endpoint = SSHEndpoint.__new__(SSHEndpoint)
+        endpoint.config = {"path": str(tmp_path)}
+        endpoint._build_lock_manager = lambda: _manager(tmp_path)
+
+        seen: list = []
+        barrier = threading.Barrier(8)
+
+        def grab():
+            barrier.wait()
+            seen.append(endpoint._lock_manager())
+
+        threads = [threading.Thread(target=grab) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert len({id(m) for m in seen}) == 1, "threads got different managers"
+
+
+class TestStatusAndUnlockTellTheTruth:
+    """What `restore --status` used to be unable to say about a remote target."""
+
+    def test_status_reports_a_lock_taken_by_another_process(self, tmp_path):
+        _manager(tmp_path).acquire_shared_persistent(
+            "snap-root.20240101T120000", "restore:abc"
+        )
+        locks = read_persisted_locks(_manager(tmp_path))
+        assert locks == {"root.20240101T120000": {"locks": ["restore:abc"]}}
+
+    def test_a_lock_with_unreadable_details_is_reported_not_omitted(self, tmp_path):
+        root = tmp_path / LOCK_DIR_NAME
+        root.mkdir(parents=True, exist_ok=True)
+        broken = root / "snap-x.lock"
+        broken.mkdir()
+        (broken / "heartbeat").touch()
+        (broken / "info.json").write_text("{{{")
+        assert read_persisted_locks(_manager(tmp_path)) == {"x": {"locks": ["unknown"]}}
+
+    def test_unlock_releases_what_the_new_state_drops(self, tmp_path):
+        manager = _manager(tmp_path)
+        manager.acquire_shared("snap-a", "restore:1")
+        manager.acquire_shared("snap-b", "restore:2")
+
+        write_persisted_locks(_manager(tmp_path), {"b": {"locks": ["restore:2"]}})
+        assert _manager(tmp_path).live_lock_names() == {"snap-b"}
+
+    def test_unlock_drops_one_holder_and_leaves_the_other(self, tmp_path):
+        """Clearing one session must not unpin a snapshot another still holds."""
+        manager = _manager(tmp_path)
+        manager.acquire_shared("snap-a", "restore:1")
+        manager.acquire_shared("snap-a", "restore:2")
+
+        write_persisted_locks(_manager(tmp_path), {"a": {"locks": ["restore:2"]}})
+        remaining = read_persisted_locks(_manager(tmp_path))
+        assert remaining == {"a": {"locks": ["restore:2"]}}
+
+    def test_unlock_does_not_disturb_a_running_operations_target_lock(self, tmp_path):
+        """--unlock clears leftover snapshot pins; it must not yank the lock a
+        prune is holding right now, which is not a snapshot pin at all."""
+        manager = _manager(tmp_path)
+        manager.acquire_persistent("target", "prune")  # exclusive, not a pin
+        manager.acquire_shared("snap-a", "restore:1")
+
+        write_persisted_locks(_manager(tmp_path), {})
+        assert _manager(tmp_path).live_lock_names() == {"target"}
+
+
+class TestReleaseIsNotRecursive:
+    def test_an_unexpected_file_is_left_alone_rather_than_deleted(self, tmp_path):
+        """release() is rmdir, never rm -rf: if something unexpected is inside
+        the lock directory, it must fail and leave it rather than delete whatever
+        it happens to find."""
+        manager = _manager(tmp_path)
+        manager.acquire_once("target", "prune")
+        stray = (
+            tmp_path
+            / LOCK_DIR_NAME
+            / f"{encode_name('target')}.lock"
+            / "somebodys-data"
+        )
+        stray.write_text("do not delete me")
+
+        manager.release("target")
+        assert stray.exists(), "release deleted a file it did not create"

--- a/tests/test_restore_lock_reporting.py
+++ b/tests/test_restore_lock_reporting.py
@@ -8,10 +8,17 @@ Three separate ways this command claimed a target was unlocked without knowing:
    logged as a warning, and followed with "No active locks found." -- measured
    against a real host holding real backups.
 
-2. ssh://, raw:// and raw+ssh:// endpoints override set_lock to mutate only the
-   in-memory lock set; no lock file is ever written for them. "No active locks
-   found" is then true and useless, because it reads as "we looked and it is
+2. ssh://, raw:// and raw+ssh:// endpoints overrode set_lock to mutate only the
+   in-memory lock set; no lock was ever recorded for them. "No active locks
+   found" was then true and useless, because it reads as "we looked and it is
    clean" when there was never anything to look at.
+
+   ssh:// and raw+ssh:// now record locks ON THE TARGET (sshutil.lock), so for
+   them the answer is real: --status reports what actually holds the target and
+   --unlock clears it. Local raw:// still keeps its locks in memory only, and
+   still says so. The invariant these tests defend is unchanged -- persists_locks
+   must never claim more than set_lock actually does -- only the set of endpoints
+   on each side of it has moved.
 
 3. Endpoint._read_locks answered {} for any path that was not a regular file, so
    a directory or a symlink where the lock file belongs also reported zero locks.
@@ -38,6 +45,25 @@ from btrfs_backup_ng.endpoint.ssh import SSHEndpoint
 LOCK_NAME = ".btrfs-backup-ng.locks"
 
 
+def _local_manager(target):
+    """A RemoteLockManager whose "remote" is this machine.
+
+    The manager only ever runs POSIX shell against the target, so pointing its
+    runner at a local `sh` exercises the real acquire/release protocol -- the
+    scripts, the atomic mkdir, the heartbeat -- instead of a mock of its output.
+    A mock here would pass whatever the protocol did.
+    """
+    import subprocess
+
+    from btrfs_backup_ng.sshutil.lock import RemoteLockManager
+
+    def run(script):
+        proc = subprocess.run(["sh", "-c", script], capture_output=True, text=True)
+        return proc.returncode, proc.stdout, proc.stderr
+
+    return RemoteLockManager(run, str(target), hostname="test")
+
+
 def _endpoint(cls, path):
     ep = cls.__new__(cls)
     ep.config = {"path": path, "lock_file_name": LOCK_NAME}
@@ -62,7 +88,16 @@ class TestTheCapabilityMatchesTheBehaviour:
             SSHRawEndpoint,
         ],
     )
-    def test_the_flag_predicts_whether_a_lock_file_appears(self, cls, tmp_path):
+    def test_the_flag_predicts_whether_a_lock_is_recorded(self, cls, tmp_path):
+        """The flag must predict a DURABLE record, wherever that record lives.
+
+        Local endpoints write a lock file next to the backups; ssh:// and
+        raw+ssh:// write a lock directory on the remote target. Both are
+        persistence, and the flag has to mean the same thing for both -- so the
+        remote endpoints are driven through a lock manager backed by a real
+        directory here, and the assertion is "something durable appeared",
+        not "a local file appeared".
+        """
         target = tmp_path / cls.__name__
         target.mkdir()
         ep = _endpoint(cls, target)
@@ -70,28 +105,46 @@ class TestTheCapabilityMatchesTheBehaviour:
             locks=set(), parent_locks=set(), get_name=lambda: "snap-1"
         )
 
+        if cls in (SSHEndpoint, SSHRawEndpoint):
+            ep._lock_manager = lambda: _local_manager(target)  # type: ignore[method-assign]
+            ep._lock_target_path = lambda: str(target)  # type: ignore[method-assign]
+
         ep.set_lock(snapshot, "restore:s1", True)
 
-        wrote_a_file = (target / LOCK_NAME).is_file()
-        assert wrote_a_file == cls.persists_locks, (
+        recorded = (target / LOCK_NAME).is_file() or bool(
+            list((target / LOCK_NAME).glob("*.lock"))
+            if (target / LOCK_NAME).is_dir()
+            else []
+        )
+        assert recorded == cls.persists_locks, (
             f"{cls.__name__}.persists_locks={cls.persists_locks} but set_lock "
-            f"{'wrote' if wrote_a_file else 'did not write'} a lock file"
+            f"{'recorded' if recorded else 'did not record'} a durable lock"
         )
 
     def test_the_lock_is_held_in_memory_either_way(self, tmp_path):
-        """Non-persisting endpoints still have to track locks for the run."""
-        for cls in (SSHEndpoint, RawEndpoint):
+        """Persisting or not, the run's own logic reads the in-memory set.
+
+        Transfer and prune within a single run consult it directly rather than
+        making a remote round trip per query, so it has to be maintained even
+        where a durable record is also written.
+        """
+        for cls in (SSHEndpoint, RawEndpoint):  # one persists, one does not
             target = tmp_path / cls.__name__
             target.mkdir()
             snapshot = SimpleNamespace(
                 locks=set(), parent_locks=set(), get_name=lambda: "snap-1"
             )
-            _endpoint(cls, target).set_lock(snapshot, "restore:s1", True)
+            endpoint = _endpoint(cls, target)
+            if cls is SSHEndpoint:
+                endpoint._lock_manager = lambda t=target: _local_manager(t)
+            endpoint.set_lock(snapshot, "restore:s1", True)
             assert "restore:s1" in snapshot.locks
 
 
 class TestATargetThatNeverPersistsLocks:
-    @pytest.mark.parametrize("cls", [SSHEndpoint, RawEndpoint, SSHRawEndpoint])
+    """Only local raw:// is still in this category; ssh:// and raw+ssh:// left it."""
+
+    @pytest.mark.parametrize("cls", [RawEndpoint])
     def test_status_says_so_instead_of_reporting_zero_locks(
         self, cls, tmp_path, capsys
     ):
@@ -106,7 +159,7 @@ class TestATargetThatNeverPersistsLocks:
         assert "does not persist locks" in out
         assert "No active locks found" not in out, "a false all-clear"
 
-    @pytest.mark.parametrize("cls", [SSHEndpoint, RawEndpoint, SSHRawEndpoint])
+    @pytest.mark.parametrize("cls", [RawEndpoint])
     def test_unlock_says_so_instead_of_nothing_to_unlock(self, cls, tmp_path, capsys):
         with patch.object(
             restore_cli,
@@ -119,16 +172,17 @@ class TestATargetThatNeverPersistsLocks:
         assert "does not persist locks" in out
         assert "No lock file found" not in out
 
-    def test_a_remote_str_path_does_not_raise_a_typeerror(self, capsys):
+    def test_a_remote_str_path_does_not_raise_a_typeerror(self, tmp_path, capsys):
         """The production shape: an SSH endpoint's config['path'] is a str, which
         is what the CLI's own `path / name` could not handle."""
-        ep = _endpoint(SSHEndpoint, "/backups/home")  # str, as SSH endpoints keep it
+        ep = _endpoint(SSHEndpoint, str(tmp_path))  # str, as SSH endpoints keep it
+        ep._lock_manager = lambda: _local_manager(tmp_path)
         with patch.object(restore_cli, "_prepare_backup_endpoint", lambda a, s: ep):
-            rc = restore_cli._execute_status(_args("ssh://nas:/backups/home"))
+            with patch.object(restore_cli, "list_remote_snapshots", lambda e: []):
+                rc = restore_cli._execute_status(_args("ssh://nas:/backups/home"))
         out = capsys.readouterr().out
         assert rc == 0
         assert "unsupported operand" not in out
-        assert "No active locks found" not in out
 
 
 class TestATargetThatDoesPersistLocks:

--- a/tests/test_ssh_remote_restore.py
+++ b/tests/test_ssh_remote_restore.py
@@ -17,7 +17,10 @@ from __future__ import annotations
 import subprocess
 from unittest.mock import MagicMock
 
+import pytest
+
 import btrfs_backup_ng.endpoint.ssh as ssh_mod
+from btrfs_backup_ng import __util__
 from btrfs_backup_ng.endpoint.ssh import SSHEndpoint
 
 
@@ -95,19 +98,45 @@ def test_send_quotes_remote_path(monkeypatch):
     assert "'/backup/weird name;rm -rf'" in remote
 
 
-def test_set_lock_is_in_memory_only_and_never_writes(tmp_path):
-    """SSHEndpoint.set_lock must only mutate the in-memory lock set -- no local lock file
-    (its path is on the remote). Mutation guard: falling back to the base set_lock would
-    try to write a lock file and (for a remote path) raise."""
+def test_set_lock_writes_no_local_lock_file(tmp_path):
+    """SSHEndpoint.set_lock must never write a LOCAL lock file: its path is on the
+    remote. Falling back to the base set_lock would try to write one and (for a
+    remote path) raise, which aborted a restore FROM an ssh:// source.
+
+    The lock is recorded on the remote target instead -- driven here through a
+    manager whose shell runs on this machine, since there is no remote host in a
+    unit test. tests/test_remote_locks.py covers the protocol itself.
+    """
+    from tests.test_remote_locks import _manager
+
     ep = SSHEndpoint(hostname="backup-host", config={"path": str(tmp_path)})
+    ep._build_lock_manager = lambda: _manager(tmp_path)
     snap = MagicMock()
     snap.locks = set()
     snap.parent_locks = set()
+    snap.get_name.return_value = "root.20240115T120000"
+
     ep.set_lock(snap, "restore:abc", True)
     assert snap.locks == {"restore:abc"}
     ep.set_lock(snap, "xfer:1", True, parent=True)
     assert snap.parent_locks == {"xfer:1"}
     ep.set_lock(snap, "restore:abc", False)
     assert snap.locks == set()
-    # No lock file was written next to the (here local-stand-in) path.
-    assert not (tmp_path / ".btrfs-backup-ng.locks").exists()
+
+    # Recorded on the target, never as a local lock FILE at the endpoint path.
+    assert not (tmp_path / ".btrfs-backup-ng.locks").is_file()
+
+
+def test_set_lock_refuses_to_continue_when_it_cannot_record(tmp_path):
+    """Mutation guard for the whole point of the change.
+
+    If set_lock goes back to mutating memory and warning, this passes silently
+    and a prune elsewhere is free to delete the snapshot being restored.
+    """
+    ep = SSHEndpoint(hostname="nas.invalid", config={"path": "/backup"})
+    snap = MagicMock()
+    snap.locks = set()
+    snap.parent_locks = set()
+    snap.get_name.return_value = "root.20240115T120000"
+    with pytest.raises(__util__.AbortError, match="Refusing to continue unprotected"):
+        ep.set_lock(snap, "restore:abc", True)


### PR DESCRIPTION
Closes the case where a prune in one process deletes the snapshot a restore is reading in another. Refs #97 (item 1).

## What was wrong

A restore pins the snapshot it reads; a prune skips what is pinned. Both halves worked, on different data. The pin lived in the restoring process's memory, and a prune lists the target fresh, so every snapshot it saw had an empty lock set — including the one being read. `restore --status` described this as "This target does not persist locks", which is accurate and useless.

## What this does

Locks are recorded on the target, beside the data they protect. Two kinds, and the distinction is the important part:

- **Snapshot pin — shared.** Any number of restores and transfers may pin the same snapshot; it stays pinned until the last lets go. This is what the in-memory contract already meant (`snapshot.locks` is a *set*). Each holder writes and removes only its own record under `holders/`.
- **Whole-target lock — exclusive.** Taken by mutating operations.

Built on `mkdir` (atomic — one winner of N racers) and `mv` (atomic rename, which is what makes breaking an abandoned lock safe). Exclusive acquisition stays a single remote script: splitting it would put a round trip between the staleness check and the break, which is the race the rename closes. Staleness is computed entirely from the target's clock — the two machines this was developed against disagree by four seconds.

`restore --status` and `--unlock` describe a remote target as accurately as a local one. `--skip-remote-lock` (and the matching target option) is the explicit opt-out for a destination that can be read but not written; it relaxes the abort and nothing else, so nothing begins reporting a target as unlocked without having looked.

`docs/REMOTE-LOCKS.md` records the design and the reasoning behind each choice.

## Verification

- 4079 tests, ruff/format/mypy clean
- **20/20 mutations caught**, including one that re-introduces exclusive pins
- Every lock script run under `dash` as well as `bash`, with results required to match
- **Hardware, two machines**, restore on one host and prune on the other: two restores pin one snapshot concurrently and both are reported; the prune is refused and says why; the same prune *does* delete an unpinned snapshot, so the refusal is specific rather than a broken prune; the pin survives one holder leaving; SIGINT frees it at once; an abandoned pin stops blocking after the staleness window and is then swept.

## Defects found and fixed during review

Nine, of which these could each have deleted a snapshot mid-restore:

- Output was not captured on this endpoint's remote exec, so the lock script's verdict went to the terminal and **every** acquisition reported BUSY. Only a real remote showed this.
- A non-zero exit status was ignored, so a query that could not run read as "nothing is locked".
- Between the `mkdir` that wins a lock and the `touch` that heartbeats it, a missing heartbeat aged from epoch zero — so a lock taken microseconds ago looked abandoned and a contender broke it. Two winners, intermittently.
- Sanitising a name for the filesystem was used as an identity. Two lock ids could collapse onto one record; a snapshot whose name needed sanitising was pinned under a name the guard never asked for.
- The remote emitted full paths on a space-delimited line, so a target directory containing a space gave a truncated path that the sweeper handed to `rm -f`.