### PR TITLE
Per-destination receive locks: stop two transfers creating the same subvolume

### DIFF
--- a/docs/REMOTE-LOCKS.md
+++ b/docs/REMOTE-LOCKS.md
@@ -64,6 +64,9 @@ winner in each case.
 
 ```
 <target>/.btrfs-backup-ng.locks/
+    receiving-<dest>.lock/        EXCLUSIVE: the right to create one subvolume
+        info.json
+        heartbeat
     target.lock/                  EXCLUSIVE: a whole-target lock
         info.json                 holder: operation, hostname, pid, token
         heartbeat                 mtime refreshed while the holder lives
@@ -170,6 +173,46 @@ exit and on SIGINT/SIGTERM, so Ctrl-C on a restore frees the snapshot at once.
 The signal handlers chain to whatever was installed before them rather than
 replacing it. The stale window remains the backstop for what no handler can
 catch: SIGKILL, a power cut, a severed network.
+
+### Receiving
+
+A transfer holds the right to create one destination subvolume, named
+`receiving-<path>`. Scoped per destination, not per target, and the reason is
+measured rather than assumed:
+
+| Two `btrfs receive` runs into one directory | Result on a real remote |
+|---|---|
+| different snapshot names | both succeed |
+| the same snapshot name | one fails `creating subvolume ... failed: File exists` |
+
+btrfs already handles the first case, so a whole-target lock would serialise
+backups of `/`, `/home` and `/var` to a single destination for no safety gain.
+What the lock adds is timing and attribution for the second case: the clash is
+refused before the stream starts rather than after transferring the whole
+snapshot, by a message naming the host and pid holding it, and it spans
+machines.
+
+```
+Already being received by nas.example (pid 3412): /backups/home.20240115T120000
+Refusing to start a second transfer to the same path -- both would create the
+same subvolume, and the loser only finds out after transferring everything.
+```
+
+The lock is taken where the transaction is, in `core/operations.py`, not inside
+the endpoint's transfer methods — those are the quoting and stream-contract
+surface, exercised by unit tests that have no remote to talk to.
+
+For snapper the same lock spans **both** halves of the transaction: the receive
+into `.snapshots/<n>.incoming` and the rename that publishes it as
+`.snapshots/<n>`. A second writer aiming at the same slot must be kept out for
+both, or it can publish in between. It is re-entrant so the transfer beneath
+finds it already held.
+
+The snapper flow also repoints the endpoint at the `.incoming` directory while
+receiving. `lock_root` pins where locks are written for that window, so the lock
+is not created inside the slot about to be published and renamed into place
+along with it — and it is restored afterwards, so an endpoint reused for another
+target does not keep writing locks to the old one.
 
 ## What each side does
 

--- a/src/btrfs_backup_ng/core/operations.py
+++ b/src/btrfs_backup_ng/core/operations.py
@@ -775,11 +775,15 @@ def _transfer_chunks_ssh(
     # Use the endpoint's send_receive if available for direct pipe
     if hasattr(destination_endpoint, "receive_chunked"):
         # Future: dedicated chunked receive method
-        success = destination_endpoint.receive_chunked(
-            reader,
-            manifest,
-            show_progress=show_progress,
-        )
+        with _receiving_lock(
+            destination_endpoint,
+            _destination_subvolume(destination_endpoint, manifest.snapshot_path),
+        ):
+            success = destination_endpoint.receive_chunked(
+                reader,
+                manifest,
+                show_progress=show_progress,
+            )
         if not success:
             raise __util__.SnapshotTransferError("SSH chunked receive failed")
     else:
@@ -987,13 +991,17 @@ def _do_direct_pipe_transfer(
             send_process.terminate()
             send_process.wait()
 
-        success = destination_endpoint.send_receive(
-            snapshot,
-            parent=parent,
-            clones=clones,
-            timeout=transfer_timeout,
-            show_progress=show_progress,
-        )
+        with _receiving_lock(
+            destination_endpoint,
+            _destination_subvolume(destination_endpoint, snapshot.get_path()),
+        ):
+            success = destination_endpoint.send_receive(
+                snapshot,
+                parent=parent,
+                clones=clones,
+                timeout=transfer_timeout,
+                show_progress=show_progress,
+            )
     except Exception as e:
         logger.error("Error during SSH direct pipe transfer: %s", e)
         raise __util__.SnapshotTransferError(f"SSH direct pipe transfer failed: {e}")
@@ -1897,6 +1905,74 @@ def _enumerate_snapper_btrfs_backups(destination_endpoint) -> list:
     return backups
 
 
+def _receiving_lock(destination_endpoint, destination: str, lock_root: str = ""):
+    """The destination lock for ``destination``, or a no-op for a local target.
+
+    Taken HERE rather than inside the endpoint's transfer methods. Those methods
+    are the quoting and stream-contract surface, exercised by unit tests that
+    have no remote to talk to; making each of them open a network lock would
+    have meant every such test acquiring one. The lock belongs with the
+    transaction, and the transaction is here.
+
+    Only remote endpoints record locks; a local one has no cross-machine
+    contention to guard against and no ``receiving_lock`` to call.
+
+    ``lock_root``, when given, pins where the lock is written. The snapper flow
+    needs it: it repoints the endpoint at ``.snapshots/<n>.incoming`` for the
+    duration of a receive, and a lock that followed would be written inside the
+    slot being published and renamed into place along with it.
+    """
+    import contextlib
+
+    hold = getattr(destination_endpoint, "receiving_lock", None)
+    if hold is None:
+        return contextlib.nullcontext()
+    if not lock_root:
+        return hold(destination)
+
+    @contextlib.contextmanager
+    def _pinned():
+        # Restored afterwards rather than left set. An endpoint that outlives
+        # this call and is later pointed at a different target would otherwise
+        # keep writing its locks to the old one -- a lock recorded where no
+        # guard will look for it, which is the failure this whole mechanism
+        # exists to remove.
+        config = destination_endpoint.config
+        had = "lock_root" in config
+        previous = config.get("lock_root")
+        config["lock_root"] = lock_root
+        try:
+            with hold(destination):
+                yield
+        finally:
+            if had:
+                config["lock_root"] = previous
+            else:
+                config.pop("lock_root", None)
+
+    return _pinned()
+
+
+def _destination_subvolume(destination_endpoint, source_path) -> str:
+    """The subvolume path a receive of ``source_path`` will create.
+
+    ``btrfs receive`` names the received subvolume after the SOURCE basename,
+    not after the snapshot name -- for snapper that is always "snapshot", under
+    ``.snapshots/<n>/``. Mirrors the derivation the transfer and verification
+    paths already use, so the lock names the thing that actually collides.
+    """
+    from pathlib import Path as _Path
+
+    # The endpoint's own derivation wins where it has one: it applies the same
+    # path normalisation the transfer and verification use, and a second copy
+    # here would be free to drift from it.
+    own = getattr(destination_endpoint, "_receive_destination", None)
+    if callable(own):
+        return str(own(source_path))
+    dest = str(destination_endpoint.config.get("path", "")).rstrip("/")
+    return f"{dest}/{_Path(str(source_path)).name}"
+
+
 def _snapper_publish_slot(destination_endpoint, snapshot_num) -> None:
     """Publish ``.snapshots/{num}.incoming`` as ``.snapshots/{num}``, replacing an occupied slot
     (a recycled snapper number) WITHOUT a data-loss window.
@@ -2149,21 +2225,34 @@ def send_snapper_snapshot(
             snap_root = f"{base_path.rstrip('/')}/.snapshots"
             incoming = f"{snap_root}/{snapshot_num}.incoming"
             final_dir = f"{snap_root}/{snapshot_num}"
-            # Clear any leftover temp from a prior crashed run before receiving.
-            _cleanup_snapper_backup(destination_endpoint, snapshot_num, is_raw)
-            saved_path = destination_endpoint.config["path"]
-            destination_endpoint.config["path"] = incoming
-            try:
-                send_snapshot(
-                    source_wrapper,
-                    destination_endpoint,
-                    parent=parent_wrapper,
-                    options=options,
-                )
-            finally:
-                destination_endpoint.config["path"] = saved_path
-            # Receive succeeded -> atomically publish into the numbered slot.
-            _snapper_publish_slot(destination_endpoint, snapshot_num)
+            # The receive and the publish are two halves of ONE transaction on
+            # slot {num}: the stream lands in {num}.incoming and is then renamed
+            # into {num}. A second writer aiming at the same slot -- another
+            # machine backing up a snapper config whose numbers overlap -- must
+            # be kept out for BOTH halves, not just the transfer, or it can
+            # publish between this receive and this rename.
+            #
+            # The lock is named for exactly what the transfer beneath will lock,
+            # so that call finds it already held rather than taking a second one.
+            slot_lock = _receiving_lock(
+                destination_endpoint, f"{incoming}/snapshot", base_path
+            )
+            with slot_lock:
+                # Clear any leftover temp from a prior crashed run before receiving.
+                _cleanup_snapper_backup(destination_endpoint, snapshot_num, is_raw)
+                saved_path = destination_endpoint.config["path"]
+                destination_endpoint.config["path"] = incoming
+                try:
+                    send_snapshot(
+                        source_wrapper,
+                        destination_endpoint,
+                        parent=parent_wrapper,
+                        options=options,
+                    )
+                finally:
+                    destination_endpoint.config["path"] = saved_path
+                # Receive succeeded -> atomically publish into the numbered slot.
+                _snapper_publish_slot(destination_endpoint, snapshot_num)
             # Place info.xml beside the published snapshot.
             saved_path = destination_endpoint.config["path"]
             destination_endpoint.config["path"] = final_dir

--- a/src/btrfs_backup_ng/endpoint/raw.py
+++ b/src/btrfs_backup_ng/endpoint/raw.py
@@ -1954,7 +1954,12 @@ class SSHRawEndpoint(RawEndpoint):
         cannot record a lock, so the reader finding nothing is a proven-empty
         answer rather than a check that silently did not run.
         """
-        path = self.config.get("path")
+        # ``lock_root`` wins where it is set, because ``path`` is not always the
+        # target. The snapper flow points the endpoint at
+        # ``.snapshots/<n>.incoming`` for the duration of a receive, and a lock
+        # root that followed it would write the lock INSIDE the slot being
+        # published -- then get renamed into place along with it.
+        path = self.config.get("lock_root") or self.config.get("path")
         if path in (None, ""):
             return None
         return str(path)

--- a/src/btrfs_backup_ng/endpoint/ssh.py
+++ b/src/btrfs_backup_ng/endpoint/ssh.py
@@ -17,6 +17,7 @@ Environment variables that affect behavior:
   would be required.
 """
 
+import contextlib
 import copy
 import getpass
 import os
@@ -30,7 +31,17 @@ import uuid
 from pathlib import Path
 from subprocess import CompletedProcess
 from threading import Lock
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, TypeVar, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+    cast,
+)
 
 if TYPE_CHECKING:
     pass
@@ -337,6 +348,7 @@ class SSHEndpoint(Endpoint):
             "ssh_password_fallback",
             "ssh_host_key_policy",
             "skip_remote_lock",
+            "lock_root",
             "transfer_stall_timeout",
         ):
             if config.get(_ssh_key) is not None:
@@ -810,7 +822,12 @@ class SSHEndpoint(Endpoint):
         cannot record a lock, so the reader finding nothing is a proven-empty
         answer rather than a check that silently did not run.
         """
-        path = self.config.get("path")
+        # ``lock_root`` wins where it is set, because ``path`` is not always the
+        # destination. The snapper flow points the endpoint at
+        # ``.snapshots/<n>.incoming`` for the duration of a receive, and a lock
+        # root that followed it would write the lock INSIDE the slot being
+        # published -- then get renamed into place along with it.
+        path = self.config.get("lock_root") or self.config.get("path")
         if path in (None, ""):
             return None
         return str(path)
@@ -874,6 +891,91 @@ class SSHEndpoint(Endpoint):
             hostname=_socket.gethostname(),
             run_elevated=run_elevated,
         )
+
+    @contextlib.contextmanager
+    def receiving_lock(
+        self, destination: str, *, timeout: float | None = None
+    ) -> Iterator[None]:
+        """Hold the right to create ``destination`` on this target.
+
+        Scoped to ONE destination subvolume rather than to the whole target,
+        because that is the only thing that actually collides. Measured against a
+        real remote: two ``btrfs receive`` runs into the same directory under
+        DIFFERENT names both succeed, while two under the SAME name leave one
+        failing with "creating subvolume ... failed: File exists". A whole-target
+        lock would therefore serialise backups of /, /home and /var to a single
+        destination -- transfers btrfs runs happily in parallel -- to prevent a
+        clash that can only occur between transfers sharing a destination.
+
+        What this adds over btrfs's own behaviour is timing and attribution: the
+        clash is refused BEFORE the stream starts rather than after pushing the
+        whole snapshot across the wire, and the refusal names the host and
+        process holding it. It also spans machines, which nothing here did.
+
+        Re-entrant within a process, because the snapper flow holds this across
+        both the receive and the publish that renames ``<n>.incoming`` into
+        ``<n>`` -- two halves of one transaction on the same slot -- and the
+        transfer beneath must not contend with its own caller.
+        """
+        from ..sshutil.lock import (
+            RECEIVING_LOCK_PREFIX,
+            RemoteLockBusy,
+            RemoteLockUnavailable,
+        )
+
+        if self._lock_target_path() is None:
+            yield
+            return
+
+        name = f"{RECEIVING_LOCK_PREFIX}{destination}"
+        manager = self._lock_manager()
+        if manager.holds(name):
+            yield  # already held further up this call stack
+            return
+
+        try:
+            manager.acquire_once(name, f"receive:{destination}")
+        except RemoteLockBusy as exc:
+            # Built from the holder's details rather than by interpolating the
+            # exception, whose text repeats the destination and the lock name.
+            # An operator reading a wrapped three-line sentence to find a
+            # hostname is being made to work for it.
+            info = exc.info or {}
+            holder = "another process"
+            if info:
+                holder = (
+                    f"{info.get('hostname', 'an unknown host')} "
+                    f"(pid {info.get('pid', '?')})"
+                )
+            raise __util__.AbortError(
+                f"Already being received by {holder}: {destination}\n"
+                f"Refusing to start a second transfer to the same path -- both "
+                f"would create the same subvolume, and the loser only finds out "
+                f"after transferring everything."
+            ) from exc
+        except RemoteLockUnavailable as exc:
+            if self.config.get("skip_remote_lock"):
+                logger.warning(
+                    "Could not lock %s before receiving (%s), and "
+                    "--skip-remote-lock was given, so this continues WITHOUT "
+                    "protection against a concurrent transfer to the same path.",
+                    destination,
+                    exc,
+                )
+                yield
+                return
+            raise __util__.AbortError(
+                f"Could not lock {destination!r} before receiving: {exc}. "
+                f"Refusing to continue unprotected: a second transfer to the "
+                f"same path would collide. Pass --skip-remote-lock to proceed "
+                f"anyway."
+            ) from exc
+
+        manager._start_heartbeat(name)
+        try:
+            yield
+        finally:
+            manager.release(name)
 
     def _read_locks(self) -> dict:
         """The locks recorded ON THIS TARGET, in the lock-file shape.
@@ -3872,6 +3974,18 @@ print(json.dumps(result))
             logger.error(f"Error during transfer: {e}")
             logger.debug(f"Full error details: {e}", exc_info=True)
             return False
+
+    def _receive_destination(self, source_path: Any) -> str:
+        """The subvolume path a receive of ``source_path`` will create here.
+
+        ``btrfs receive`` names the received subvolume after the SOURCE
+        basename, not after the snapshot name -- for snapper that is always
+        "snapshot", under ``.snapshots/<n>/``. This mirrors the same derivation
+        the transfer and verification paths already use, so the lock names the
+        thing that actually collides.
+        """
+        dest = str(self._normalize_path(self.config["path"])).rstrip("/")
+        return f"{dest}/{Path(str(source_path)).name}"
 
     def send_receive(
         self,

--- a/src/btrfs_backup_ng/sshutil/lock.py
+++ b/src/btrfs_backup_ng/sshutil/lock.py
@@ -79,6 +79,12 @@ LOCK_DIR_NAME = ".btrfs-backup-ng.locks"
 #: key off this one constant so they cannot drift apart.
 SNAPSHOT_LOCK_PREFIX = "snap-"
 
+#: Prefix marking a lock as the right to CREATE one destination subvolume.
+#: Scoped per destination rather than per target: two receives into one
+#: directory under different names are safe and common, and serialising them
+#: would cost throughput to prevent a clash that cannot happen.
+RECEIVING_LOCK_PREFIX = "receiving-"
+
 #: Holder files for a SHARED lock live here, one per holder.
 HOLDERS_DIR_NAME = "holders"
 

--- a/tests/test_receiving_locks.py
+++ b/tests/test_receiving_locks.py
@@ -1,0 +1,265 @@
+"""Two transfers may not create the same subvolume on one destination.
+
+Measured against a real remote before this was designed:
+
+* two ``btrfs receive`` runs into one directory under DIFFERENT names both
+  succeed -- so serialising a whole target would cost throughput to prevent a
+  clash that cannot happen;
+* two under the SAME name leave one failing with
+  ``ERROR: creating subvolume ... failed: File exists`` -- after it has
+  transferred the entire snapshot.
+
+So the lock is scoped to the destination subvolume, and its value is timing and
+attribution: the clash is refused before the stream starts, by a message that
+names the holder, across machines.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import threading
+from pathlib import Path
+
+import pytest
+
+from btrfs_backup_ng import __util__
+from btrfs_backup_ng.core import operations
+from btrfs_backup_ng.endpoint.ssh import SSHEndpoint
+from btrfs_backup_ng.sshutil.lock import RECEIVING_LOCK_PREFIX, RemoteLockManager
+
+
+def _manager(sandbox: Path, **kw) -> RemoteLockManager:
+    def run(script: str):
+        proc = subprocess.run(["sh", "-c", script], capture_output=True, text=True)
+        return proc.returncode, proc.stdout, proc.stderr
+
+    return RemoteLockManager(run, str(sandbox), hostname="testhost", **kw)
+
+
+def _endpoint(sandbox: Path, **config):
+    endpoint = SSHEndpoint.__new__(SSHEndpoint)
+    endpoint.config = {"path": str(sandbox), **config}
+    shared = _manager(sandbox)
+    endpoint._build_lock_manager = lambda: shared
+    return endpoint
+
+
+class TestDifferentDestinationsRunInParallel:
+    """The property that makes this a per-destination lock and not a target one."""
+
+    def test_two_different_subvolumes_are_not_serialised(self, tmp_path):
+        first, second = _endpoint(tmp_path), _endpoint(tmp_path)
+        with first.receiving_lock(f"{tmp_path}/home.20240101T120000"):
+            with second.receiving_lock(f"{tmp_path}/var.20240101T120000"):
+                pass  # must not block or raise
+
+    def test_many_different_subvolumes_at_once(self, tmp_path):
+        """/ , /home, /var, /opt to one destination is an ordinary setup."""
+        held: list = []
+        errors: list = []
+        barrier = threading.Barrier(4)
+
+        def transfer(name: str) -> None:
+            try:
+                barrier.wait()
+                endpoint = _endpoint(tmp_path)
+                with endpoint.receiving_lock(f"{tmp_path}/{name}"):
+                    held.append(name)
+            except Exception as exc:  # noqa: BLE001 - recorded and asserted on
+                errors.append((name, exc))
+
+        threads = [
+            threading.Thread(target=transfer, args=(n,))
+            for n in ("root", "home", "var", "opt")
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert not errors, f"a distinct destination was blocked: {errors}"
+        assert sorted(held) == ["home", "opt", "root", "var"]
+
+
+class TestTheSameDestinationIsRefused:
+    def test_a_second_transfer_to_one_path_is_refused(self, tmp_path):
+        first, second = _endpoint(tmp_path), _endpoint(tmp_path)
+        destination = f"{tmp_path}/home.20240101T120000"
+        with first.receiving_lock(destination):
+            with pytest.raises(__util__.AbortError, match="Already being received"):
+                with second.receiving_lock(destination):
+                    pass
+
+    def test_the_refusal_names_the_holder(self, tmp_path):
+        """An operator has to be able to find the transfer blocking them."""
+        first, second = _endpoint(tmp_path), _endpoint(tmp_path)
+        destination = f"{tmp_path}/home.20240101T120000"
+        with first.receiving_lock(destination):
+            with pytest.raises(__util__.AbortError) as caught:
+                with second.receiving_lock(destination):
+                    pass
+        message = str(caught.value)
+        assert "testhost" in message, "the holder's host is not named"
+        assert str(__import__("os").getpid()) in message, "the pid is not named"
+        assert destination in message, "the destination is not named"
+        first_line = message.splitlines()[0]
+        assert len(first_line) < 200, f"unreadably long: {first_line}"
+        assert first_line.count(destination) == 1, (
+            f"the destination is repeated: {first_line}"
+        )
+
+    def test_the_path_is_free_again_afterwards(self, tmp_path):
+        endpoint = _endpoint(tmp_path)
+        destination = f"{tmp_path}/home.20240101T120000"
+        with endpoint.receiving_lock(destination):
+            pass
+        with _endpoint(tmp_path).receiving_lock(destination):
+            pass  # must not raise
+
+    def test_a_failed_transfer_still_frees_the_path(self, tmp_path):
+        endpoint = _endpoint(tmp_path)
+        destination = f"{tmp_path}/home.20240101T120000"
+        with pytest.raises(RuntimeError):
+            with endpoint.receiving_lock(destination):
+                raise RuntimeError("transfer blew up")
+        with _endpoint(tmp_path).receiving_lock(destination):
+            pass  # the lock did not outlive the failure
+
+
+class TestItIsReentrantWithinOneProcess:
+    """The snapper flow holds this across receive AND publish."""
+
+    def test_the_same_process_may_take_it_twice(self, tmp_path):
+        endpoint = _endpoint(tmp_path)
+        destination = f"{tmp_path}/.snapshots/42.incoming/snapshot"
+        with endpoint.receiving_lock(destination):
+            with endpoint.receiving_lock(destination):
+                pass
+
+    def test_the_inner_scope_does_not_release_it_early(self, tmp_path):
+        """If it did, a second machine could publish between this receive and
+        this rename -- the window the transaction exists to close."""
+        endpoint = _endpoint(tmp_path)
+        destination = f"{tmp_path}/.snapshots/42.incoming/snapshot"
+        with endpoint.receiving_lock(destination):
+            with endpoint.receiving_lock(destination):
+                pass
+            other = _endpoint(tmp_path)
+            with pytest.raises(__util__.AbortError):
+                with other.receiving_lock(destination):
+                    pass
+
+
+class TestTheLockRootDoesNotFollowTheTransfer:
+    def test_it_stays_on_the_target_when_the_path_is_repointed(self, tmp_path):
+        """The snapper flow points the endpoint at `.snapshots/<n>.incoming` for
+        the duration of a receive. A lock root that followed would be written
+        INSIDE the slot being published, then renamed into place with it."""
+        endpoint = _endpoint(tmp_path)
+        endpoint.config["lock_root"] = str(tmp_path)
+        incoming = tmp_path / ".snapshots" / "42.incoming"
+        incoming.mkdir(parents=True)
+        endpoint.config["path"] = str(incoming)
+
+        assert endpoint._lock_target_path() == str(tmp_path)
+        with endpoint.receiving_lock(f"{incoming}/snapshot"):
+            assert not (incoming / ".btrfs-backup-ng.locks").exists(), (
+                "the lock was written inside the slot about to be published"
+            )
+            assert (tmp_path / ".btrfs-backup-ng.locks").is_dir()
+
+    def test_the_pin_is_removed_afterwards(self, tmp_path):
+        """An endpoint that outlives the transfer and is later pointed at a
+        different target must not keep writing locks to the old one."""
+        endpoint = _endpoint(tmp_path)
+        with operations._receiving_lock(
+            endpoint, f"{tmp_path}/x", lock_root=str(tmp_path)
+        ):
+            assert endpoint.config["lock_root"] == str(tmp_path)
+        assert "lock_root" not in endpoint.config
+
+    def test_an_existing_pin_is_restored_not_clobbered(self, tmp_path):
+        endpoint = _endpoint(tmp_path)
+        endpoint.config["lock_root"] = "/original"
+        with operations._receiving_lock(
+            endpoint, f"{tmp_path}/x", lock_root=str(tmp_path)
+        ):
+            pass
+        assert endpoint.config["lock_root"] == "/original"
+
+
+class TestTheDestinationIsTheReceivedSubvolume:
+    def test_it_is_named_after_the_source_basename(self, tmp_path):
+        """`btrfs receive` names the subvolume after the SOURCE basename, not
+        after the snapshot name. For snapper that is always "snapshot"."""
+        endpoint = _endpoint(tmp_path)
+        endpoint._normalize_path = lambda p: str(p)
+        assert (
+            endpoint._receive_destination("/mnt/@home/.snapshots/42/snapshot")
+            == f"{tmp_path}/snapshot"
+        )
+        assert (
+            endpoint._receive_destination("/mnt/snapshots/home.20240101T120000")
+            == f"{tmp_path}/home.20240101T120000"
+        )
+
+    def test_two_snapper_slots_do_not_collide(self, tmp_path):
+        """Both are named "snapshot"; the SLOT is what separates them, so the
+        lock has to be keyed on the incoming slot rather than the basename."""
+        first, second = _endpoint(tmp_path), _endpoint(tmp_path)
+        with first.receiving_lock(f"{tmp_path}/.snapshots/41.incoming/snapshot"):
+            with second.receiving_lock(f"{tmp_path}/.snapshots/42.incoming/snapshot"):
+                pass
+
+
+class TestALocalTargetIsUnaffected:
+    def test_a_local_endpoint_is_a_no_op(self, tmp_path):
+        """Only remote endpoints record locks; a local one has no
+        cross-machine contention and no receiving_lock to call."""
+
+        class Local:
+            config: dict = {"path": "/backup"}
+
+        with operations._receiving_lock(Local(), "/backup/x"):
+            pass
+
+
+class TestTheOperatorCanOptOut:
+    def test_skip_remote_lock_lets_an_unlockable_target_through(self, tmp_path):
+        readonly = tmp_path / "readonly"
+        readonly.mkdir()
+        import os
+
+        os.chmod(readonly, 0o500)
+        try:
+            endpoint = _endpoint(readonly, skip_remote_lock=True)
+            endpoint._build_lock_manager = lambda: _manager(readonly)
+            with endpoint.receiving_lock(f"{readonly}/home"):
+                pass  # must not raise
+        finally:
+            os.chmod(readonly, 0o700)
+
+    def test_without_it_an_unlockable_target_stops_the_transfer(self, tmp_path):
+        readonly = tmp_path / "readonly"
+        readonly.mkdir()
+        import os
+
+        os.chmod(readonly, 0o500)
+        try:
+            endpoint = _endpoint(readonly)
+            endpoint._build_lock_manager = lambda: _manager(readonly)
+            with pytest.raises(__util__.AbortError, match="skip-remote-lock"):
+                with endpoint.receiving_lock(f"{readonly}/home"):
+                    pass
+        finally:
+            os.chmod(readonly, 0o700)
+
+
+class TestTheLockNameIsDistinctFromASnapshotPin:
+    def test_receiving_and_pinning_do_not_share_a_name(self, tmp_path):
+        """A pin on a snapshot and the right to create it are different rights;
+        sharing a name would make one silently satisfy the other."""
+        endpoint = _endpoint(tmp_path)
+        with endpoint.receiving_lock(f"{tmp_path}/home.20240101T120000"):
+            names = _manager(tmp_path).live_lock_names()
+        assert any(n.startswith(RECEIVING_LOCK_PREFIX) for n in names)
+        assert not any(n.startswith("snap-") for n in names)


### PR DESCRIPTION
Refs #97 (item 3). Builds on #99.

## The failure, measured first

Nothing serialised two machines writing to one `ssh://` destination. Before designing anything I measured what btrfs actually does, because the shape of the fix depends on it:

| Two `btrfs receive` runs into one directory | Result on a real remote |
|---|---|
| different snapshot names | **both succeed** |
| the same snapshot name | one fails `creating subvolume ... failed: File exists` |

btrfs already handles the first case. A whole-target lock would have serialised backups of `/`, `/home` and `/var` to a single destination — transfers btrfs runs happily in parallel — to prevent a clash that can only occur between transfers sharing a destination.

## What this does

The lock is scoped to the destination subvolume (`receiving-<path>`), not the target. What it adds over btrfs's own behaviour is **timing and attribution**: the clash is refused before the stream starts rather than after transferring the entire snapshot, by a message naming the holder, and it spans machines.

```
Already being received by nas.example (pid 3412): /backups/home.20240115T120000
Refusing to start a second transfer to the same path -- both would create the
same subvolume, and the loser only finds out after transferring everything.
```

For snapper the same lock spans **both** halves of the transaction — the receive into `.snapshots/<n>.incoming` and the rename that publishes it as `.snapshots/<n>`. A second writer aiming at the same slot must be kept out for both, or it can publish between them. It is re-entrant so the transfer beneath finds it already held.

### On the separate snapper slot lock

The original plan called for a short exclusive lock around snapper slot allocation. Tracing it (`operations.py:2092`, `snapshot_num = snapper_snapshot.number`) shows the slot number comes from the **source** snapshot — there is no destination-side allocation to guard. The hazard is two writers aiming at the same slot, which is the same-destination clash the lock above already covers.

## Layering

The lock is taken in `core/operations.py`, where the transaction is, rather than inside the endpoint's transfer methods. Those are the quoting and stream-contract surface, exercised by unit tests that have no remote to talk to; opening a network lock inside them meant every such test acquiring one.

## Verification

- 4096 tests, ruff/format/mypy clean
- **9/9 mutations caught**, including one that reverts to a whole-target lock — so the throughput regression cannot come back silently
- **Hardware, two machines**: different subvolumes lock concurrently and are not serialised; a second transfer of the same subvolume is refused in ~0.5s before any data moves, naming host and pid; the destination is reusable once the first finishes; nothing is left behind on the target

## Found by the adversarial pass

Both missed by unit tests, both the recurring "recorded where nothing will look for it" class:

- The snapper flow repoints `config["path"]` at `.incoming` during a receive. The lock root followed it, so the lock would have been written **inside the slot about to be published** and renamed into place along with it. Fixed with `lock_root`.
- `lock_root` was set and never cleared, so an endpoint reused for another target would keep writing locks to the old one. It now restores.