### PR TITLE
feat: do not create "path" directories for local endpoints

### DIFF
--- a/src/btrfs_backup_ng/endpoint/local.py
+++ b/src/btrfs_backup_ng/endpoint/local.py
@@ -82,12 +82,8 @@ class LocalEndpoint(Endpoint):
 
         for d in dirs:
             if not d.is_dir():
-                logger.info("Creating directory: %s", d)
-                try:
-                    d.mkdir(parents=True, exist_ok=True)
-                except OSError as e:
-                    logger.error("Error creating new location %s: %s", d, e)
-                    raise __util__.AbortError(f"Failed to create directory {d}: {e}")
+                logger.error("Error resolving path: %s", d)
+                raise __util__.AbortError(f"Failed to resolve path: {d}")
 
         # Create snapshot directory if it exists in config
         if self.config.get("snapshot_dir") and isinstance(


### PR DESCRIPTION
If a target resides on an external disk, the target "path" may or may not be present. So far, we create "path" unconditionally and use it for the target if it meets other conditions (such as being on a btrfs fs if that's what is to be used). This creates spurious subdirectories and - potentially - "backups" in locations under `/mnt`, `/run/media` etc.

This is similar to what `require_mount` is supposed to solve, but this works (and is necessary) only for the case where "path" is the exact mount point, because that one always exists.

So, stop creating directories for "path" and error out if it is not present. This mirrors would we do with other targets, and it also catches typos in config: we expect an explict "path" to exist.

Note that this does not change behaviour for existing users because target "path"s have been created for them already. Also, we still create necessary subdirs below "path", of course, if "path" exists.

This addresses the main concerns in #100 and has been tested locally. The test suite succeeds unmodified, for better or worse. I have not checked whether there are other code paths (say, for raw local) which need to be touched for an overall behaviour of "expect configured targets to exist, including explicit paths, or abort".